### PR TITLE
Make controller documentation brand-agnostic

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
-# True Good Craft Controller
+# Universal Business Controller
 
-This repository implements the controller architecture described in the True Good Craft master project brief. It provides a single startup command that loads configuration, assembles modular adapters, and exposes a menu-driven workflow for the core business operations.
+This repository implements the controller architecture described in the True Good Craft master project brief and makes it available for any organization to adopt. It provides a single startup command that loads configuration, assembles modular adapters, and exposes a menu-driven workflow for core business operations. (Created by True Good Craft, generalized for wider use.)
 
 ## Features
 
@@ -9,7 +9,7 @@ This repository implements the controller architecture described in the True Goo
 - **ID-first, traceable runs** that create timestamped folders in `reports/` containing `plan.md`, `changes.md`, and `errors.md`.
 - **Beginner-safe defaults** with configuration masking, preview-friendly dry runs, and clear notes on missing credentials.
 - **ChatGPT-first interface** via the included startup prompt file, with a CLI fallback for local execution.
-- **Organization reference tracking** so business name, short codes, and contact details are captured once and reused across the workflow.
+- **Organization reference tracking** so business name, short codes, and contact details are captured once and reused across the workflow. Placeholder values ship with the project so new operators can quickly rebrand it.
 - **Connector status report** available via `python app.py --status` to quickly audit which adapters are implemented and configured.
 - **In-session auto-update** command so you can pull new repository changes without restarting the conversation.
 
@@ -56,7 +56,7 @@ Adapters are designed to run safely without credentials. The Notion adapter now 
    python app.py --init-org
    ```
 
-   The command asks for the business name, contact information, and preferred short code (for example, `TGC` to produce IDs like `TGC-001`). Your answers populate `organization_profile.json` and refresh `docs/organization_reference.md` for quick reference during audits.
+   The command asks for the business name, contact information, and preferred short code (for example, `ABC` to produce IDs like `ABC-001`). Your answers populate `organization_profile.json` and refresh `docs/organization_reference.md` for quick reference during audits.
 
 3. Install dependencies and launch the controller:
 
@@ -104,4 +104,4 @@ The file [`docs/chatgpt_startup_prompt.md`](docs/chatgpt_startup_prompt.md) cont
 
 ---
 
-© 2024 True Good Craft — Contact: [truegoodcragt@gmail.com](mailto:truegoodcragt@gmail.com)
+Crafted by True Good Craft — released for community use.

--- a/docs/chatgpt_startup_prompt.md
+++ b/docs/chatgpt_startup_prompt.md
@@ -1,17 +1,17 @@
-# True Good Craft Controller — ChatGPT Startup Prompt
+# Universal Business Controller — ChatGPT Startup Prompt
 
-Copy and paste the content of this file into a new ChatGPT conversation. The prompt instructs ChatGPT to act as the primary interface for the True Good Craft controller while keeping you in control of dry-runs and apply operations.
+Copy and paste the content of this file into a new ChatGPT conversation. The prompt instructs ChatGPT to act as the primary interface for the controller while keeping you in control of dry-runs and apply operations. The workflow ships with placeholder branding so it can be adopted by any organization. (Originally created by True Good Craft.)
 
 ---
 
 **SYSTEM ROLE FOR CHATGPT**
 
-You are the operator interface for the "True Good Craft" controller. When the user types natural-language instructions, translate them into controller actions using the provided command palette.
+You are the operator interface for this business controller. When the user types natural-language instructions, translate them into controller actions using the provided command palette.
 
 **ENVIRONMENT BOOTSTRAP**
 
 1. Load the `.env` file for credentials and IDs. Do not display secrets—mask them when summarizing.
-2. If the organization profile has not been customized yet (the business name shows as "Your Business Name" or the short code is `XXX`), start by running `python app.py --init-org`. Ask the operator for the business name, preferred short code (e.g., `TGC` to produce `TGC-001` SKUs), contact email, phone, website, and address. Confirm the summary written to `docs/organization_reference.md`.
+2. If the organization profile still shows placeholder values (business name is "Your Business Name" or the short code is `XXX`), start by running `python app.py --init-org`. Ask the operator for the business name, preferred short code (e.g., `ABC` to produce `ABC-001` SKUs), contact email, phone, website, and address. Confirm the summary written to `docs/organization_reference.md`.
 3. Initialize the controller by running `python app.py --menu-only` if available, otherwise call the controller bootstrap directly.
 4. Present the main menu exactly as shown below and wait for the user's instruction before triggering any action.
 


### PR DESCRIPTION
## Summary
- rebrand the ChatGPT startup prompt so it starts with generic business placeholders and only references True Good Craft for attribution
- refresh the README to describe the controller as a reusable, brand-agnostic toolkit while keeping credit to True Good Craft

## Testing
- not run (documentation-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68eac2f1a58c83228b8685cd744072ed