### PR TITLE
Fix master index controller syntax and error handling

### DIFF
--- a/tgc/actions/master_index.py
+++ b/tgc/actions/master_index.py
@@ -58,13 +58,8 @@ class MasterIndexAction(SimpleAction):
         drive_errors = [str(value) for value in summary.get("drive_errors", [])]
 
         if summary.get("status") == "unavailable":
-            detail = message or (
-                "Master Index unavailable: run 'Discover & Audit' and verify Notion + Drive readiness."
-            )
+            detail = message or "Master Index unavailable: run 'Discover & Audit' and verify Notion + Drive readiness."
             errors = [detail]
-            errors = [
-                "Master Index unavailable: run 'Discover & Audit' and verify Notion + Drive readiness."
-            ]
             return ActionResult(
                 plan_text=plan_text,
                 changes=[],
@@ -76,7 +71,6 @@ class MasterIndexAction(SimpleAction):
         if summary.get("status") == "error":
             if not errors:
                 errors = [message or "Unable to initialise Master Index modules."]
-                errors = ["Unable to initialise Master Index modules."]
             return ActionResult(
                 plan_text=plan_text,
                 changes=[],

--- a/tgc/master_index_controller.py
+++ b/tgc/master_index_controller.py
@@ -79,12 +79,6 @@ class MasterIndexController:
             summary = MasterIndexSummary(status="unavailable", dry_run=dry_run, message=detail)
             self._append_log(summary)
             return summary.to_dict()
-        ready, _details = self._adapters_ready()
-        if not ready:
-            print(
-                "Master Index unavailable: run 'Discover & Audit' and verify Notion + Drive are ready."
-            )
-            return MasterIndexSummary(status="unavailable", dry_run=dry_run).to_dict()
 
         notion_module = self._notion_module()
         drive_module = self._drive_module()
@@ -101,7 +95,6 @@ class MasterIndexController:
             )
             print(message)
             self._append_log(summary)
-            )
             return summary.to_dict()
 
         notion_roots = self._notion_root_ids(notion_module)
@@ -156,18 +149,10 @@ class MasterIndexController:
                 except OSError as exc:
                     drive_errors.append(f"Failed to write Drive index: {exc}")
 
-        status = "ok"
-        if notion_errors or drive_errors:
-            status = "error"
+        status = "error" if notion_errors or drive_errors else "ok"
 
         summary = MasterIndexSummary(
             status=status,
-            output_dir.mkdir(parents=True, exist_ok=True)
-            notion_path.write_text(notion_markdown, encoding="utf-8")
-            drive_path.write_text(drive_markdown, encoding="utf-8")
-
-        summary = MasterIndexSummary(
-            status="ok",
             dry_run=dry_run,
             notion_count=len(notion_records),
             drive_count=len(drive_records),
@@ -190,7 +175,6 @@ class MasterIndexController:
         if notion_ready and drive_ready:
             return True, None
         message = "Required adapters not ready: Notion ({}) · Drive ({})".format(
-        message = """Required adapters not ready: Notion ({}) Drive ({})""".format(
             "ready" if notion_ready else "not ready",
             "ready" if drive_ready else "not ready",
         )
@@ -249,11 +233,6 @@ class MasterIndexController:
             line += f" output={summary.output_dir}"
         if summary.message:
             line += f" message={summary.message}"
-            f"{timestamp} module=master_index dry_run={summary.dry_run} "
-            f"notion={summary.notion_count} drive={summary.drive_count}"
-        )
-        if summary.output_dir:
-            line += f" output={summary.output_dir}"
         with log_path.open("a", encoding="utf-8") as handle:
             handle.write(line + "\n")
 


### PR DESCRIPTION
## Summary
- clean up the master index controller to fix the syntax regression and simplify readiness and module checks
- ensure master index reports are only written after successful dry-run checks and log entries are recorded consistently
- streamline the master index action error handling so unavailable/error states return a single consolidated message

## Testing
- python -m compileall buisness_project/tgc/master_index_controller.py buisness_project/tgc/actions/master_index.py
- python app.py > /tmp/app.log  # interrupted after CLI prompt

------
https://chatgpt.com/codex/tasks/task_e_68eb181fd6b08322b727062b7f98677c