### PR TITLE
Handle database roots when building Notion master index

### DIFF
--- a/tgc/notion/api.py
+++ b/tgc/notion/api.py
@@ -52,10 +52,18 @@ class NotionAPIClient:
     def databases_retrieve(self, database_id: str) -> Dict[str, Any]:
         return self._request("GET", f"/databases/{database_id}")
 
-    def databases_query(self, database_id: str, *, page_size: Optional[int] = None) -> Dict[str, Any]:
+    def databases_query(
+        self,
+        database_id: str,
+        *,
+        page_size: Optional[int] = None,
+        start_cursor: Optional[str] = None,
+    ) -> Dict[str, Any]:
         payload: Dict[str, Any] = {}
         if page_size is not None:
             payload["page_size"] = page_size
+        if start_cursor is not None:
+            payload["start_cursor"] = start_cursor
         return self._request("POST", f"/databases/{database_id}/query", body=payload)
 
     def pages_retrieve(self, page_id: str) -> Dict[str, Any]:


### PR DESCRIPTION
## Summary
- add database traversal support to the master index Notion collector so database roots enqueue their pages
- extend the Notion API helper to accept a start cursor for database pagination
- add unit tests covering page, database, and error scenarios for the master index collector

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb211f50548322b6b58164795ee220