### PR TITLE
Add traversal limits to Master Index command

### DIFF
--- a/tgc/controller.py
+++ b/tgc/controller.py
@@ -63,7 +63,9 @@ class Controller:
         action = self.get_action(action_id)
         return action.build_plan(self)
 
-    def run_action(self, action_id: str, apply: bool) -> ActionResult:
+    def run_action(
+        self, action_id: str, apply: bool, *, options: Optional[Dict[str, object]] = None
+    ) -> ActionResult:
         action = self.get_action(action_id)
         plan_text = action.build_plan(self)
         context = RunContext(
@@ -71,6 +73,7 @@ class Controller:
             apply=apply,
             reports_root=self.reports_root,
             metadata={"action_name": action.name, "apply": str(apply)},
+            options=dict(options or {}),
         )
         context.log_plan(plan_text)
         result = action.run(self, context)

--- a/tgc/reporting.py
+++ b/tgc/reporting.py
@@ -16,6 +16,7 @@ class RunContext:
     apply: bool
     reports_root: Path
     metadata: Dict[str, str]
+    options: Dict[str, object] = field(default_factory=dict)
 
     run_id: str = field(init=False)
     run_dir: Path = field(init=False)


### PR DESCRIPTION
## Summary
- add optional limit flags to the Build Master Index CLI path and pass them through the action context
- update Notion and Drive traversals to honour time, request, page, and depth limits and report partial results
- extend unit tests for the new traversal result object and limit enforcement scenarios

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eb3cdd6bbc83228dbe70132fdb4843