### PR TITLE
Set Notion traversal child page size to 100

### DIFF
--- a/tgc/master_index_controller.py
+++ b/tgc/master_index_controller.py
@@ -648,7 +648,7 @@ def collect_notion_pages(
                     try:
                         children = client.blocks_children_list(
                             page_id,
-                            page_size=min(page_size, 100),
+                            page_size=100,
                             start_cursor=next_cursor,
                         )
                     except NotionAPIError as exc:


### PR DESCRIPTION
## Summary
- set the Notion block traversal to request 100 children per page while retaining existing pagination handling

## Testing
- pytest tests/test_master_index.py

------
https://chatgpt.com/codex/tasks/task_e_68eb4112abe483228497073a5a76fa4e