### PR TITLE
Add quiet flag and gate debug logging

### DIFF
--- a/app.py
+++ b/app.py
@@ -62,10 +62,15 @@ def main() -> None:
         help="Stop traversal after this depth",
     )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
+    parser.add_argument("--quiet", action="store_true", help="Suppress informational logging")
     args = parser.parse_args()
 
+    level = logging.INFO
     if args.debug:
-        logging.getLogger().setLevel(logging.DEBUG)
+        level = logging.DEBUG
+    if args.quiet:
+        level = logging.WARNING
+    logging.getLogger().setLevel(level)
 
     if args.init_org:
         configure_profile_interactive()

--- a/tgc/master_index_controller.py
+++ b/tgc/master_index_controller.py
@@ -476,7 +476,8 @@ def collect_notion_pages(
 
     root_id_list = list(root_ids)
     timer_start = time.perf_counter()
-    logging.debug("notion.list_pages.start", extra={"root_ids": root_id_list})
+    if logging.getLogger().isEnabledFor(logging.DEBUG):
+        logging.debug("notion.list_pages.start", extra={"root_ids": root_id_list})
     try:
         if not isinstance(notion_module, NotionAccessModule):
             return [], ["Notion module unavailable"]
@@ -721,10 +722,11 @@ def collect_notion_pages(
         partial = bool(stop_reason)
         return TraversalResult(records=records[:limit], errors=errors, partial=partial, reason=stop_reason)
     finally:
-        logging.debug(
-            "notion.list_pages.done",
-            extra={"ms": int((time.perf_counter() - timer_start) * 1000)},
-        )
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            logging.debug(
+                "notion.list_pages.done",
+                extra={"ms": int((time.perf_counter() - timer_start) * 1000)},
+            )
 
 
 def _handle_database_root(
@@ -879,7 +881,8 @@ def collect_drive_files(
 
     root_id_list = list(root_ids)
     timer_start = time.perf_counter()
-    logging.debug("drive.list_files.start", extra={"root_ids": root_id_list})
+    if logging.getLogger().isEnabledFor(logging.DEBUG):
+        logging.debug("drive.list_files.start", extra={"root_ids": root_id_list})
     try:
         if not isinstance(drive_module, GoogleDriveModule):
             return TraversalResult(records=[], errors=["Google Drive module unavailable"])
@@ -1093,10 +1096,11 @@ def collect_drive_files(
         partial = bool(stop_reason)
         return TraversalResult(records=records[:limit], errors=errors, partial=partial, reason=stop_reason)
     finally:
-        logging.debug(
-            "drive.list_files.done",
-            extra={"ms": int((time.perf_counter() - timer_start) * 1000)},
-        )
+        if logging.getLogger().isEnabledFor(logging.DEBUG):
+            logging.debug(
+                "drive.list_files.done",
+                extra={"ms": int((time.perf_counter() - timer_start) * 1000)},
+            )
 
 def _resolve_shortcut(
     service: object,


### PR DESCRIPTION
## Summary
- add a --quiet flag to suppress info-level log noise by default
- ensure the CLI sets the root logger level based on --debug and --quiet flags
- guard per-request debug logging so it only emits in debug mode

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb41df783c83229e1953e80d96a730