### PR TITLE
Add stage timing utility

### DIFF
--- a/tgc/util/stage.py
+++ b/tgc/util/stage.py
@@ -1,0 +1,19 @@
+"""Utilities for timing labeled stages of execution."""
+import sys
+import time
+from typing import Optional
+
+
+def stage(title: str) -> float:
+    """Begin a stage with the given *title* and return the start timestamp."""
+    sys.stdout.write(f"\n=== {title} ===\n")
+    sys.stdout.flush()
+    return time.perf_counter()
+
+
+def stage_done(start: float, note: Optional[str] = "") -> None:
+    """Log completion of a stage that started at *start* with an optional *note*."""
+    elapsed = int((time.perf_counter() - start) * 1000)
+    sys.stdout.write(f"\n--- done in {elapsed} ms {note}\n")
+    sys.stdout.flush()
+


### PR DESCRIPTION
## Summary
- add a reusable timing helper for logging stage start/finish output

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eb42f45ae88322a7ec932d9a7018fc