### PR TITLE
Add chunked Drive Markdown writer for master index

### DIFF
--- a/tgc/actions/master_index.py
+++ b/tgc/actions/master_index.py
@@ -95,9 +95,17 @@ class MasterIndexAction(SimpleAction):
         if context.apply:
             notion_path = summary.get("notion_output")
             drive_path = summary.get("drive_output")
+            drive_chunks = [
+                str(value)
+                for value in summary.get("drive_outputs", [])
+                if isinstance(value, str) and value
+            ]
             if notion_path:
                 changes.append(f"Wrote Notion index to {notion_path}")
-            if drive_path:
+            if drive_chunks:
+                for path in drive_chunks:
+                    changes.append(f"Wrote Drive index to {path}")
+            elif drive_path:
                 changes.append(f"Wrote Drive index to {drive_path}")
         else:
             notes.extend(self._dry_run_message())


### PR DESCRIPTION
## Summary
- add a reusable `write_drive_files_markdown` helper that sorts Drive rows and writes chunked Markdown tables
- capture shortcut and parent metadata in the Drive traversal and call the new writer when applying the master index action
- surface multiple Drive output files in the action summary and cover the helper with new tests

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ebbc99cbe88322aa8a99d41509cb5b