### PR TITLE
Validate Drive module settings and expose audit feedback

### DIFF
--- a/tests/test_master_index.py
+++ b/tests/test_master_index.py
@@ -173,8 +173,8 @@ class FakeDriveService:
 
 class FakeDriveModule(GoogleDriveModule):
     def __init__(self, service):
-        super().__init__(DriveModuleConfig(enabled=True))
         self._service = service
+        super().__init__(DriveModuleConfig(enabled=True))
 
     def ensure_service(self, *, require_write=False):  # type: ignore[override]
         return self._service, None

--- a/tgc/actions/discover.py
+++ b/tgc/actions/discover.py
@@ -49,6 +49,21 @@ class DiscoverAuditAction(SimpleAction):
                 preview = access.get("preview_sample")
                 if isinstance(preview, list):
                     lines.append(f"    preview rows available: {len(preview)}")
+            if key == "drive":
+                from ..modules import GoogleDriveModule
+
+                module_obj = controller.get_module("drive")
+                if isinstance(module_obj, GoogleDriveModule):
+                    validation_lines = module_obj.validation_summary()
+                    if validation_lines:
+                        lines.append("  - Drive module validation:")
+                        lines.extend(f"    {line}" for line in validation_lines)
+                    details = module_obj.validation_details()
+                    for message in details.get("errors", []):
+                        notes.append(f"drive validation error: {message}")
+                    notes.extend(
+                        f"drive validation note: {message}" for message in details.get("notes", [])
+                    )
         context.log_notes("audit", lines)
         plan_text = controller.build_plan(self.id)
         return ActionResult(

--- a/tgc/bootstrap.py
+++ b/tgc/bootstrap.py
@@ -58,7 +58,11 @@ def _build_adapters(config: AppConfig) -> Dict[str, object]:
 
 def _build_modules(config: AppConfig, env_file: str) -> Dict[str, object]:
     return {
-        "drive": GoogleDriveModule.load(config.drive.module_config_path),
+        "drive": GoogleDriveModule.load(
+            config.drive.module_config_path,
+            fallback_root_id=config.drive.fallback_root_id,
+            shared_drive_id=config.drive.shared_drive_id,
+        ),
         "notion_access": NotionAccessModule(config.notion, env_file),
     }
 

--- a/tgc/config.py
+++ b/tgc/config.py
@@ -36,6 +36,7 @@ class NotionConfig:
 class GoogleDriveConfig:
     module_config_path: Path = Path("config/google_drive_module.json")
     fallback_root_id: Optional[str] = None
+    shared_drive_id: Optional[str] = None
 
     def is_configured(self) -> bool:
         path = self.module_config_path.expanduser()
@@ -114,6 +115,7 @@ class AppConfig:
                 _clean_env("DRIVE_MODULE_CONFIG") or "config/google_drive_module.json"
             ),
             fallback_root_id=_clean_env("DRIVE_ROOT_FOLDER_ID"),
+            shared_drive_id=_clean_env("DRIVE_SHARED_DRIVE_ID"),
         )
 
         sheets = GoogleSheetsConfig(inventory_sheet_id=_clean_env("SHEET_INVENTORY_ID"))
@@ -157,6 +159,7 @@ class AppConfig:
             "SHEET_INVENTORY_ID": mask_secret(self.sheets.inventory_sheet_id),
             "DRIVE_MODULE_CONFIG": str(self.drive.module_config_path),
             "DRIVE_ROOT_FOLDER_ID": mask_secret(self.drive.fallback_root_id),
+            "DRIVE_SHARED_DRIVE_ID": mask_secret(self.drive.shared_drive_id),
             "GMAIL_QUERY": self.gmail.query,
             "WAVE_GRAPHQL_TOKEN": mask_secret(self.wave.graphql_token),
             "WAVE_BUSINESS_ID": mask_secret(self.wave.business_id),


### PR DESCRIPTION
## Summary
- add DRIVE_SHARED_DRIVE_ID handling to configuration and bootstrap wiring
- extend the Drive module to validate fallback roots, corpora mode, and shared drive alignment with helpful messaging
- surface Drive validation details in the Discover & Audit action and update tests for the stricter module init

## Testing
- pytest


------
https://chatgpt.com/codex/tasks/task_e_68ebbf473ba0832298690ebacb6ebf96