### PR TITLE
Add CLI system health check command and banner

### DIFF
--- a/app.py
+++ b/app.py
@@ -10,6 +10,7 @@ from typing import Dict, Optional
 
 from tgc.actions.master_index import MasterIndexAction
 from tgc.bootstrap import bootstrap_controller
+from tgc.health import format_health_banner, format_health_table, system_health
 from tgc.menu import run_cli
 from tgc.organization import configure_profile_interactive
 from tgc.master_index_controller import MasterIndexController, TraversalLimits
@@ -25,6 +26,11 @@ def main() -> None:
         "--status",
         action="store_true",
         help="Print a connector functionality report and exit",
+    )
+    parser.add_argument(
+        "--check",
+        action="store_true",
+        help="Run integration system checks and print a compact summary",
     )
     parser.add_argument(
         "--init-org",
@@ -76,6 +82,15 @@ def main() -> None:
         configure_profile_interactive()
         return
 
+    checks, _ = system_health()
+    banner = format_health_banner(checks)
+    if banner:
+        print(banner)
+
+    if args.check:
+        print("> " + format_health_table(checks))
+        return
+
     controller = bootstrap_controller()
 
     def _positive(value: Optional[float]) -> Optional[float]:
@@ -103,7 +118,7 @@ def main() -> None:
     traversal_limits = TraversalLimits(**limit_kwargs) if limit_kwargs else None
 
     if args.update:
-        action_id = "0"
+        action_id = "U"
         plan_text = controller.build_plan(action_id)
         print("=== PLAN ===")
         print(plan_text)

--- a/tgc/actions/update.py
+++ b/tgc/actions/update.py
@@ -17,7 +17,7 @@ from .base import SimpleAction
 class UpdateAction(SimpleAction):
     """Pull the latest changes from the tracked Git remote."""
 
-    id: str = "0"
+    id: str = "U"
     name: str = "Update from repository"
     description: str = "Fetch and merge the latest code without leaving the session"
 

--- a/tgc/menu.py
+++ b/tgc/menu.py
@@ -6,6 +6,7 @@ from typing import Callable, Dict, Optional
 
 from .controller import Controller
 from .master_index_controller import MasterIndexController
+from .health import format_health_table, system_health
 from .util.serialization import safe_serialize
 
 
@@ -22,6 +23,11 @@ def run_cli(controller: Controller) -> None:
     print("Type the menu number to continue, or 'q' to quit.\n")
 
     advanced_options: Dict[str, tuple[str, str, Callable[[Controller], None]]] = {
+        "0": (
+            "System Check",
+            "Validate credentials and show READY/MISSING status",
+            _run_system_check,
+        ),
         "13": (
             "Print Master Index (debug)",
             "Build the Master Index snapshot and dump it as JSON",
@@ -30,10 +36,10 @@ def run_cli(controller: Controller) -> None:
     }
 
     while True:
-        for action in controller.available_actions():
-            print(f"{action.id}) {action.name} — {action.description}")
         for key, (name, description, _) in advanced_options.items():
             print(f"{key}) {name} — {description}")
+        for action in controller.available_actions():
+            print(f"{action.id}) {action.name} — {action.description}")
         choice = input("Select an option (or q to quit): ").strip()
         if choice.lower() in {"q", "quit", "exit"}:
             print("Goodbye!")
@@ -77,3 +83,8 @@ def _print_master_index_snapshot(controller: Controller) -> None:
     master = MasterIndexController(controller)
     snapshot = master.build_index_snapshot()
     print(safe_serialize(snapshot))
+
+
+def _run_system_check(_: Controller) -> None:
+    checks, _ = system_health()
+    print(format_health_table(checks))


### PR DESCRIPTION
## Summary
- add helpers to format system health results for banners and compact CLI output
- print a startup status banner, provide a `--check` flag, and expose the compact summary via the menu
- move the update action to ID `U` so "0) System Check" can sit at the top of the interactive menu

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ebf1adec4c83229053942c48dd43fc