### PR TITLE
Limit Notion request logging to debug level

### DIFF
--- a/tgc/notion/api.py
+++ b/tgc/notion/api.py
@@ -121,14 +121,14 @@ class NotionAPIClient:
             request_kwargs["json"] = body
         self._throttle()
         start = time.perf_counter()
-        logger.info("→ Notion %s %s", method, path)
+        logger.debug("→ Notion %s %s", method, path)
         try:
             response = http.request(method, url, timeout=self.timeout, **request_kwargs)
             response.raise_for_status()
         except HTTPError as exc:  # pragma: no cover - network dependent
             elapsed_ms = (time.perf_counter() - start) * 1000
             error = self._convert_http_error(exc.response)
-            logger.info(
+            logger.debug(
                 "← Notion %s %s failed [%s] in %.0f ms: %s",
                 method,
                 path,
@@ -140,7 +140,7 @@ class NotionAPIClient:
             raise error
         except RequestException as exc:  # pragma: no cover - network dependent
             elapsed_ms = (time.perf_counter() - start) * 1000
-            logger.info(
+            logger.debug(
                 "← Notion %s %s failed [network] in %.0f ms: %s",
                 method,
                 path,
@@ -151,7 +151,7 @@ class NotionAPIClient:
             raise NotionAPIError(status=0, code="network_error", message=str(exc)) from None
         else:
             elapsed_ms = (time.perf_counter() - start) * 1000
-            logger.info(
+            logger.debug(
                 "← Notion %s %s succeeded [%s] in %.0f ms",
                 method,
                 path,


### PR DESCRIPTION
## Summary
- change the Notion API client's per-request logging to use DEBUG so normal runs only show stage banners and tickers

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ebf7de62748322b0ca2890597e0aa9