### PR TITLE
Add Google Sheets read helpers and integrate Sheets debug tools

### DIFF
--- a/app.py
+++ b/app.py
@@ -67,6 +67,11 @@ def main() -> None:
         type=int,
         help="Stop traversal after this depth",
     )
+    parser.add_argument(
+        "--max-rows",
+        type=int,
+        help="Stop Sheets reads after this many rows",
+    )
     parser.add_argument("--debug", action="store_true", help="Enable debug logging")
     parser.add_argument("--quiet", action="store_true", help="Suppress informational logging")
     args = parser.parse_args()
@@ -103,9 +108,11 @@ def main() -> None:
         return numeric if numeric > 0 else None
 
     limit_kwargs: Dict[str, float | int] = {}
+    runtime_limits: Dict[str, float | int] = {}
     seconds_value = _positive(args.max_seconds)
     if seconds_value is not None:
         limit_kwargs["max_seconds"] = seconds_value
+        runtime_limits["max_seconds"] = seconds_value
     pages_value = _positive(args.max_pages)
     if pages_value is not None:
         limit_kwargs["max_pages"] = int(pages_value)
@@ -115,6 +122,10 @@ def main() -> None:
     depth_value = _positive(args.max_depth)
     if depth_value is not None:
         limit_kwargs["max_depth"] = int(depth_value)
+    rows_value = _positive(args.max_rows)
+    if rows_value is not None:
+        runtime_limits["max_rows"] = int(rows_value)
+    controller.runtime_limits = runtime_limits
     traversal_limits = TraversalLimits(**limit_kwargs) if limit_kwargs else None
 
     if args.update:

--- a/tgc/adapters/google_sheets.py
+++ b/tgc/adapters/google_sheets.py
@@ -1,37 +1,57 @@
-"""Google Sheets adapter placeholder."""
+"""Google Sheets adapter providing lightweight read access utilities."""
 
 from __future__ import annotations
 
-from typing import Dict, List, Optional
+from typing import Any, Dict, List, Mapping, Optional
 
 from .base import AdapterCapability, BaseAdapter
+from . import sheets_adapter
 from ..config import GoogleSheetsConfig
-from ..integration_support import format_sheets_missing_env_message
+from ..integration_support import format_sheets_missing_env_message, sheets_share_hint
+from ..modules.google_drive import DriveModuleConfig
 
 
 class GoogleSheetsAdapter(BaseAdapter):
     name = "sheets"
+    implementation_state = "implemented"
 
     def __init__(
-        self, config: GoogleSheetsConfig, *, service_account_email: Optional[str] = None
+        self,
+        config: GoogleSheetsConfig,
+        drive_config: Optional[DriveModuleConfig] = None,
+        *,
+        service_account_email: Optional[str] = None,
     ) -> None:
         super().__init__(config)
+        self._drive_config = drive_config or DriveModuleConfig()
         self._service_account_email = service_account_email
+        self._cached_metadata: Optional[Dict[str, Any]] = None
 
     def is_configured(self) -> bool:
-        return self.config.is_configured()
+        return bool(self.config.is_configured() and self._drive_config.has_credentials())
 
     def capabilities(self) -> List[AdapterCapability]:
+        configured = self.is_configured()
         return [
+            AdapterCapability(
+                name="Inventory preview",
+                description="Read configured spreadsheet metadata and sample rows",
+                configured=configured,
+            ),
             AdapterCapability(
                 name="Metrics sync",
                 description="Push summarized metrics to dashboard sheet",
-                configured=self.is_configured(),
+                configured=configured,
             )
         ]
 
     def metadata(self) -> Dict[str, Optional[str]]:
-        return {"inventory_sheet_id": self.config.inventory_sheet_id}
+        sheet_id = self.config.inventory_sheet_id
+        return {
+            "inventory_sheet_id": sheet_id,
+            "timeout_seconds": str(self._drive_config.timeout_seconds),
+            "has_credentials": str(self._drive_config.has_credentials()).lower(),
+        }
 
     def sync_metrics(self, metrics: Dict[str, str]) -> List[str]:
         if not self.is_configured():
@@ -43,5 +63,101 @@ class GoogleSheetsAdapter(BaseAdapter):
 
     def implementation_notes(self) -> str:
         return (
-            "Placeholder Google Sheets adapter; write operations are simulated pending API wiring."
+            "Adapter provides read-only helpers for Google Sheets while retaining a simulated "
+            "metrics sync placeholder."
         )
+
+    def service_account_email(self) -> Optional[str]:
+        return self._service_account_email
+
+    # ------------------------------------------------------------------
+    # Read helpers used by menu + health checks
+
+    def inventory_metadata(self, *, force_refresh: bool = False) -> Dict[str, Any]:
+        if not self.is_configured():
+            raise RuntimeError(self.missing_configuration_message())
+        if not force_refresh and self._cached_metadata is not None:
+            return dict(self._cached_metadata)
+        sheet_id = self.config.inventory_sheet_id
+        if not sheet_id:
+            raise RuntimeError("SHEET_INVENTORY_ID is not configured.")
+        metadata = sheets_adapter.get_spreadsheet_metadata(
+            sheet_id,
+            credentials=self._credentials_info(),
+            timeout=self._drive_config.timeout_seconds,
+        )
+        self._cached_metadata = dict(metadata)
+        return metadata
+
+    def read_inventory_range(
+        self,
+        range_a1: str,
+        limits: Optional[Mapping[str, object]] = None,
+    ) -> Dict[str, Any]:
+        if not self.is_configured():
+            raise RuntimeError(self.missing_configuration_message())
+        sheet_id = self.config.inventory_sheet_id
+        if not sheet_id:
+            raise RuntimeError("SHEET_INVENTORY_ID is not configured.")
+        return sheets_adapter.read_range(
+            sheet_id,
+            range_a1,
+            limits,
+            credentials=self._credentials_info(),
+            timeout=self._drive_config.timeout_seconds,
+        )
+
+    def read_inventory_preview(
+        self,
+        *,
+        max_rows: int = 10,
+        limits: Optional[Mapping[str, object]] = None,
+    ) -> Dict[str, Any]:
+        if max_rows <= 0:
+            max_rows = 10
+        range_a1 = f"A1:Z{max_rows}"
+        effective_limits: Dict[str, object] = {"max_rows": max_rows}
+        if limits:
+            effective_limits.update({key: value for key, value in limits.items() if value is not None})
+        return self.read_inventory_range(range_a1, effective_limits)
+
+    def status_report(self) -> Dict[str, object]:
+        report = super().status_report()
+        if not self.config.inventory_sheet_id:
+            return report
+        if not self.is_configured():
+            report["inventory_access"] = {
+                "status": "missing",
+                "detail": self.missing_configuration_message(),
+            }
+            return report
+        try:
+            metadata = self.inventory_metadata()
+        except Exception as exc:  # pragma: no cover - network dependent
+            hint = sheets_share_hint(self._service_account_email)
+            report["inventory_access"] = {
+                "status": "error",
+                "detail": f"{exc}. {hint}",
+            }
+            return report
+        sheets = metadata.get("sheets") or []
+        sheet_names = [
+            entry.get("title")
+            for entry in sheets
+            if isinstance(entry, Mapping) and entry.get("title")
+        ]
+        report["inventory_access"] = {
+            "status": "ready",
+            "detail": f"Spreadsheet {metadata.get('title') or '(untitled)'} ({metadata.get('spreadsheetId')})",
+            "sheets": sheet_names,
+        }
+        return report
+
+    # ------------------------------------------------------------------
+    # Internal helpers
+
+    def _credentials_info(self) -> Mapping[str, Any]:
+        credentials = self._drive_config.credentials
+        if not credentials:
+            raise RuntimeError("Drive module credentials are missing; re-run Drive configuration.")
+        return credentials

--- a/tgc/adapters/sheets_adapter.py
+++ b/tgc/adapters/sheets_adapter.py
@@ -1,0 +1,284 @@
+"""Thin Google Sheets REST client helpers used across the project."""
+
+from __future__ import annotations
+
+import logging
+import sys
+import time
+from dataclasses import dataclass
+from typing import Any, Dict, List, Mapping, MutableMapping, Optional, Sequence, Tuple, Union
+from urllib.parse import quote
+
+from requests import Response, Session
+
+from ..util.http import default_client
+
+try:  # Optional dependency kept consistent with other Google integrations
+    from google.auth.transport.requests import Request as GoogleAuthRequest
+    from google.oauth2.service_account import Credentials as ServiceAccountCredentials
+except Exception:  # pragma: no cover - fallback when google-auth is unavailable
+    GoogleAuthRequest = None  # type: ignore
+    ServiceAccountCredentials = None  # type: ignore
+
+
+logger = logging.getLogger(__name__)
+
+SHEETS_SCOPE = "https://www.googleapis.com/auth/spreadsheets.readonly"
+SHEETS_ENDPOINT = "https://sheets.googleapis.com/v4/spreadsheets"
+
+LimitsLike = Union[Mapping[str, Any], object, None]
+
+
+class SheetsAPIError(RuntimeError):
+    """Raised when the Google Sheets API returns an error payload."""
+
+
+@dataclass
+class SheetsRequestContext:
+    """Configuration for issuing authorised Sheets API requests."""
+
+    credentials_info: Mapping[str, Any]
+    timeout: int = 30
+    client: Session = default_client
+
+
+def _limit_value(limits: LimitsLike, key: str) -> Optional[float]:
+    if limits is None:
+        return None
+    if isinstance(limits, Mapping):
+        value = limits.get(key)
+    else:
+        value = getattr(limits, key, None)
+    if value is None:
+        return None
+    try:
+        numeric = float(value)
+    except (TypeError, ValueError):
+        return None
+    return numeric
+
+
+def _ensure_credentials(context: SheetsRequestContext) -> ServiceAccountCredentials:
+    if ServiceAccountCredentials is None or GoogleAuthRequest is None:  # pragma: no cover - dependency guard
+        raise SheetsAPIError(
+            "google-auth is required to access Sheets. Run `pip install -r requirements.txt`."
+        )
+    try:
+        credentials = ServiceAccountCredentials.from_service_account_info(
+            dict(context.credentials_info), scopes=[SHEETS_SCOPE]
+        )
+    except Exception as exc:  # pragma: no cover - defensive guard for malformed JSON
+        raise SheetsAPIError(f"Unable to load service account credentials: {exc}") from exc
+
+    if not credentials.valid or credentials.expired or not credentials.token:
+        request = GoogleAuthRequest(session=context.client)
+        try:
+            credentials.refresh(request)
+        except Exception as exc:  # pragma: no cover - network dependent
+            raise SheetsAPIError(f"Unable to refresh Sheets access token: {exc}") from exc
+    return credentials
+
+
+def _authorised_headers(context: SheetsRequestContext) -> Dict[str, str]:
+    credentials = _ensure_credentials(context)
+    token = credentials.token
+    if not token:
+        raise SheetsAPIError("Sheets credentials did not provide an access token.")
+    return {"Authorization": f"Bearer {token}"}
+
+
+def _perform_get(
+    url: str,
+    *,
+    params: Optional[MutableMapping[str, Any]] = None,
+    context: SheetsRequestContext,
+) -> Dict[str, Any]:
+    headers = _authorised_headers(context)
+    try:
+        response: Response = context.client.get(
+            url,
+            headers=headers,
+            params=params,
+            timeout=context.timeout,
+        )
+    except Exception as exc:  # pragma: no cover - network dependent
+        raise SheetsAPIError(f"Sheets request failed: {exc}") from exc
+    if response.status_code >= 400:
+        detail = response.text.strip() or response.reason
+        raise SheetsAPIError(f"Sheets API error {response.status_code}: {detail}")
+    if not response.content:
+        return {}
+    try:
+        return response.json()
+    except ValueError as exc:  # pragma: no cover - defensive guard
+        raise SheetsAPIError(f"Invalid JSON from Sheets API: {exc}") from exc
+
+
+def _ticker(enabled: bool) -> Tuple[callable[[], None], callable[[int, bool], None], callable[[], None]]:
+    state = {"last": 0.0}
+
+    def start() -> None:
+        if not enabled:
+            return
+        state["last"] = time.perf_counter()
+        sys.stdout.write("\rSheets rows read (0)")
+        sys.stdout.flush()
+
+    def tick(rows: int, force: bool = False) -> None:
+        if not enabled:
+            return
+        now = time.perf_counter()
+        if not force and (now - state.get("last", 0.0)) < 0.5:
+            return
+        state["last"] = now
+        sys.stdout.write(f"\rSheets rows read ({rows})")
+        sys.stdout.flush()
+
+    def stop() -> None:
+        if not enabled:
+            return
+        sys.stdout.write("\n")
+        sys.stdout.flush()
+
+    return start, tick, stop
+
+
+def _normalise_sheet_entry(entry: Mapping[str, Any]) -> Dict[str, Any]:
+    properties = entry.get("properties") if isinstance(entry.get("properties"), Mapping) else {}
+    grid = properties.get("gridProperties") if isinstance(properties, Mapping) else {}
+    if not isinstance(grid, Mapping):
+        grid = {}
+    return {
+        "sheetId": properties.get("sheetId"),
+        "title": properties.get("title"),
+        "index": properties.get("index"),
+        "rowCount": grid.get("rowCount"),
+        "columnCount": grid.get("columnCount"),
+    }
+
+
+def get_spreadsheet_metadata(
+    spreadsheet_id: str,
+    *,
+    credentials: Mapping[str, Any],
+    timeout: int = 30,
+    client: Optional[Session] = None,
+) -> Dict[str, Any]:
+    """Return the spreadsheet title and sheet list for ``spreadsheet_id``."""
+
+    if not spreadsheet_id:
+        raise ValueError("Spreadsheet ID is required")
+    context = SheetsRequestContext(
+        credentials_info=credentials,
+        timeout=timeout,
+        client=client or default_client,
+    )
+    params = {
+        "includeGridData": "false",
+        "fields": "spreadsheetId,properties.title,sheets(properties(sheetId,title,index,gridProperties))",
+    }
+    payload = _perform_get(f"{SHEETS_ENDPOINT}/{spreadsheet_id}", params=params, context=context)
+    spreadsheet_id = payload.get("spreadsheetId", spreadsheet_id)
+    properties = payload.get("properties") if isinstance(payload.get("properties"), Mapping) else {}
+    title = properties.get("title") if isinstance(properties, Mapping) else None
+    sheets_payload = payload.get("sheets")
+    sheets: List[Dict[str, Any]] = []
+    if isinstance(sheets_payload, Sequence):
+        for entry in sheets_payload:
+            if isinstance(entry, Mapping):
+                sheets.append(_normalise_sheet_entry(entry))
+    return {
+        "spreadsheetId": spreadsheet_id,
+        "title": title,
+        "sheets": sheets,
+    }
+
+
+def read_range(
+    spreadsheet_id: str,
+    range_a1: str,
+    limits: LimitsLike = None,
+    *,
+    credentials: Mapping[str, Any],
+    timeout: int = 30,
+    client: Optional[Session] = None,
+) -> Dict[str, Any]:
+    """Read ``range_a1`` rows from ``spreadsheet_id`` using the Values API."""
+
+    if not spreadsheet_id:
+        raise ValueError("Spreadsheet ID is required")
+    if not range_a1:
+        raise ValueError("Range (A1 notation) is required")
+
+    context = SheetsRequestContext(
+        credentials_info=credentials,
+        timeout=timeout,
+        client=client or default_client,
+    )
+
+    max_seconds = _limit_value(limits, "max_seconds")
+    max_rows = _limit_value(limits, "max_rows")
+    if max_rows is not None:
+        max_rows = max(int(max_rows), 0)
+
+    start_time = time.monotonic()
+
+    ticker_start, ticker_tick, ticker_stop = _ticker(logger.isEnabledFor(logging.INFO))
+    ticker_start()
+    try:
+        params: Dict[str, Any] = {
+            "majorDimension": "ROWS",
+            "valueRenderOption": "FORMATTED_VALUE",
+        }
+        encoded_range = quote(range_a1, safe="!:'(),$&=*-_.~")
+        payload = _perform_get(
+            f"{SHEETS_ENDPOINT}/{spreadsheet_id}/values/{encoded_range}",
+            params=params,
+            context=context,
+        )
+    except Exception:
+        ticker_stop()
+        raise
+
+    values_raw = payload.get("values")
+    values: List[List[str]] = []
+    if isinstance(values_raw, Sequence):
+        for row in values_raw:
+            if isinstance(row, Sequence):
+                str_row = ["" if cell is None else str(cell) for cell in row]
+            else:  # pragma: no cover - defensive guard
+                str_row = [str(row)]
+            values.append(str_row)
+
+    total_rows = len(values)
+    truncated = False
+    if max_rows is not None and total_rows > max_rows:
+        values = values[: max_rows]
+        truncated = True
+
+    elapsed = time.monotonic() - start_time
+    ticker_tick(len(values), force=True)
+    ticker_stop()
+
+    if max_seconds is not None and elapsed > max_seconds:
+        truncated = True
+        reason = "max_seconds"
+    elif truncated:
+        reason = "max_rows"
+    else:
+        reason = None
+
+    result = {
+        "range": payload.get("range", range_a1),
+        "majorDimension": payload.get("majorDimension", "ROWS"),
+        "values": values,
+        "rows_returned": len(values),
+        "total_rows": total_rows,
+        "elapsed_seconds": elapsed,
+    }
+    if truncated:
+        result["truncated"] = True
+        if reason:
+            result["reason"] = reason
+    return result
+

--- a/tgc/bootstrap.py
+++ b/tgc/bootstrap.py
@@ -54,7 +54,11 @@ def _build_adapters(config: AppConfig, drive_module_config: DriveModuleConfig) -
     return {
         "notion": NotionAdapter(config.notion),
         "drive": GoogleDriveAdapter(config.drive),
-        "sheets": GoogleSheetsAdapter(config.sheets, service_account_email=sheets_email),
+        "sheets": GoogleSheetsAdapter(
+            config.sheets,
+            drive_module_config,
+            service_account_email=sheets_email,
+        ),
         "gmail": GmailAdapter(config.gmail),
         "wave": WaveAdapter(config.wave),
     }

--- a/tgc/controller.py
+++ b/tgc/controller.py
@@ -36,6 +36,7 @@ class Controller:
     reports_root: Path = Path("reports")
     actions: Dict[str, ControllerAction] = field(default_factory=dict)
     modules: Dict[str, object] = field(default_factory=dict)
+    runtime_limits: Dict[str, object] = field(default_factory=dict)
 
     def register_action(self, action: ControllerAction) -> None:
         if action.id in self.actions:

--- a/tgc/integration_support.py
+++ b/tgc/integration_support.py
@@ -46,6 +46,15 @@ def format_sheets_missing_env_message(email: Optional[str]) -> str:
     )
 
 
+def sheets_share_hint(email: Optional[str]) -> str:
+    """Return guidance for sharing the spreadsheet with the service account."""
+
+    share_target = email or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
+    return (
+        f"Share the sheet with {share_target} as Viewer. Set SHEET_INVENTORY_ID in .env."
+    )
+
+
 def format_drive_share_message(root_id: str, email: Optional[str]) -> str:
     """Return a consistent instruction to share a Drive root with the service account."""
 

--- a/tgc/menu.py
+++ b/tgc/menu.py
@@ -2,11 +2,12 @@
 
 from __future__ import annotations
 
-from typing import Callable, Dict, Optional
+from typing import Callable, Dict, Iterable, List, Optional
 
 from .controller import Controller
 from .master_index_controller import MasterIndexController
 from .health import format_health_table, system_health
+from .integration_support import service_account_email, sheets_share_hint
 from .util.serialization import safe_serialize
 
 
@@ -32,7 +33,12 @@ def run_cli(controller: Controller) -> None:
             "Print Master Index (debug)",
             "Build the Master Index snapshot and dump it as JSON",
             _print_master_index_snapshot,
-        )
+        ),
+        "14": (
+            "Inspect Sheets (debug)",
+            "List sheet tabs and read a limited preview",
+            _inspect_sheets_debug,
+        ),
     }
 
     while True:
@@ -45,8 +51,8 @@ def run_cli(controller: Controller) -> None:
             print("Goodbye!")
             return
         if choice in advanced_options:
-            handler = advanced_options[choice][2]
-            print("\n=== MASTER INDEX SNAPSHOT ===")
+            name, _, handler = advanced_options[choice]
+            print(f"\n=== {name.upper()} ===")
             handler(controller)
             print()
             continue
@@ -88,3 +94,94 @@ def _print_master_index_snapshot(controller: Controller) -> None:
 def _run_system_check(_: Controller) -> None:
     checks, _ = system_health()
     print(format_health_table(checks))
+
+
+def _inspect_sheets_debug(controller: Controller) -> None:
+    adapter = controller.adapters.get("sheets")
+    if adapter is None:
+        print("Sheets adapter is not available.")
+        return
+    is_configured = getattr(adapter, "is_configured", lambda: False)
+    if not is_configured():
+        message = getattr(adapter, "missing_configuration_message", lambda: None)()
+        if message:
+            print(message)
+        else:
+            print("Sheets adapter is not configured.")
+        return
+    try:
+        metadata = getattr(adapter, "inventory_metadata")()
+    except Exception as exc:
+        print(f"Failed to load spreadsheet metadata: {exc}")
+        hint = _sheets_share_message(controller, adapter)
+        if hint:
+            print(hint)
+        return
+    title = metadata.get("title") or "(untitled)"
+    spreadsheet_id = metadata.get("spreadsheetId")
+    print(f"Spreadsheet: {title} ({spreadsheet_id})")
+    sheets = metadata.get("sheets")
+    if isinstance(sheets, Iterable):
+        rows: List[str] = []
+        for entry in sheets:
+            if not isinstance(entry, dict):
+                continue
+            sheet_name = entry.get("title") or "(untitled)"
+            dims: List[str] = []
+            if isinstance(entry.get("rowCount"), int):
+                dims.append(f"rows={entry['rowCount']}")
+            if isinstance(entry.get("columnCount"), int):
+                dims.append(f"cols={entry['columnCount']}")
+            suffix = f" ({', '.join(dims)})" if dims else ""
+            rows.append(f"- {sheet_name}{suffix}")
+        if rows:
+            print("Tabs:")
+            for line in rows:
+                print(line)
+        else:
+            print("Tabs: none visible")
+    else:
+        print("Tabs: unavailable")
+
+    limits = dict(getattr(controller, "runtime_limits", {}) or {})
+    max_rows = limits.get("max_rows")
+    if not isinstance(max_rows, int) or max_rows <= 0:
+        max_rows = 10
+        limits["max_rows"] = max_rows
+    try:
+        preview = getattr(adapter, "read_inventory_preview")(max_rows=max_rows, limits=limits)
+    except Exception as exc:
+        print(f"Failed to read preview: {exc}")
+        hint = _sheets_share_message(controller, adapter)
+        if hint:
+            print(hint)
+        return
+    values = preview.get("values")
+    if not isinstance(values, list):
+        print("No preview values returned.")
+    else:
+        print(f"Preview ({len(values)} row(s)):")
+        for row in values:
+            cells = [str(cell) for cell in row] if isinstance(row, list) else [str(row)]
+            print(" | ".join(cells))
+    if preview.get("truncated"):
+        reason = preview.get("reason") or "limit"
+        print(f"… truncated due to {reason}.")
+
+
+def _sheets_share_message(controller: Controller, adapter: object) -> Optional[str]:
+    email: Optional[str] = None
+    if hasattr(adapter, "service_account_email"):
+        try:
+            email = adapter.service_account_email()  # type: ignore[attr-defined]
+        except Exception:  # pragma: no cover - defensive
+            email = None
+    if not email:
+        drive_module = controller.get_module("drive")
+        drive_config = getattr(drive_module, "config", None)
+        if drive_config is not None:
+            try:
+                email = service_account_email(drive_config)  # type: ignore[arg-type]
+            except Exception:  # pragma: no cover - defensive
+                email = None
+    return sheets_share_hint(email)


### PR DESCRIPTION
## Summary
- add a Sheets REST helper with metadata and range reads using the existing HTTP client
- wire the Sheets adapter, health check, and menu debug option to surface spreadsheet previews and share hints
- add --max-rows runtime limits so interactive previews respect CLI bounds

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ebfe93c07c8322a009458f0f0fa15f