### PR TITLE
Add chunk size constant for sheets index markdown

### DIFF
--- a/tests/test_sheets_index.py
+++ b/tests/test_sheets_index.py
@@ -233,6 +233,42 @@ def test_write_sheets_index_markdown_writes_sorted_table(tmp_path):
     assert data_rows[1].startswith("| Budget | Summary | 20 | 5 | 2024-02-02T00:00:00Z | S2 | 22 | /Finance |")
 
 
+def test_write_sheets_index_markdown_counts_unique_spreadsheets(tmp_path):
+    rows = [
+        {
+            "spreadsheetId": "S1",
+            "spreadsheetTitle": "Analytics",
+            "sheetId": 11,
+            "sheetTitle": "Data",
+            "sheetIndex": 0,
+            "rows": 100,
+            "cols": 10,
+            "modifiedTime": "2024-02-01T00:00:00Z",
+            "parentPath": "/Ops",
+        },
+        {
+            "spreadsheetId": "S1",
+            "spreadsheetTitle": "Analytics",
+            "sheetId": 12,
+            "sheetTitle": "Pivot",
+            "sheetIndex": 1,
+            "rows": 50,
+            "cols": 6,
+            "modifiedTime": "2024-02-03T00:00:00Z",
+            "parentPath": "/Ops",
+        },
+    ]
+
+    (tmp_path / "nested").mkdir()
+    output_paths = write_sheets_index_markdown(tmp_path / "nested", rows)
+
+    assert output_paths == [tmp_path / "nested" / "sheets_index.md"]
+    content = output_paths[0].read_text(encoding="utf-8").splitlines()
+
+    assert content[0] == "# Master Index — Google Sheets"
+    assert content[2] == "Total spreadsheets: 1 • Total tabs: 2"
+
+
 def test_write_sheets_index_markdown_splits_large_dataset(tmp_path):
     rows = [
         {

--- a/tgc/actions/sheets_index.py
+++ b/tgc/actions/sheets_index.py
@@ -351,6 +351,9 @@ def build_sheets_index(
     return rows
 
 
+MAX_ROWS_PER_INDEX_CHUNK = 5_000
+
+
 def write_sheets_index_markdown(
     output_dir: Path,
     rows: Sequence[Mapping[str, Any]],
@@ -400,7 +403,7 @@ def write_sheets_index_markdown(
     total_spreadsheets = len(unique_spreadsheets)
     total_tabs = len(sorted_rows)
 
-    chunk_size = 5_000
+    chunk_size = MAX_ROWS_PER_INDEX_CHUNK
     output_dir.mkdir(parents=True, exist_ok=True)
 
     def _render_chunk(chunk_rows: Sequence[Mapping[str, Any]]) -> str:


### PR DESCRIPTION
## Summary
- expose the sheets index markdown chunk size as a named constant for clarity
- add coverage that asserts the header totals are calculated from the unique spreadsheets collected

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec38beceb483229554ecf2f8a90e97