### PR TITLE
Add plugin config loader and schema-based secrets workflow

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ __pycache__/
 .env
 reports/
 staging/
+plugins/**/plugin.secrets.local.env

--- a/README.md
+++ b/README.md
@@ -208,6 +208,19 @@ python app.py
 python app.py --status
 ```
 
+### 🔐 Plugin configuration
+
+Each integration plugin now declares the environment variables it needs in
+`plugins/<name>/config.schema.json`. To configure credentials locally:
+
+1. Copy the checked-in `plugin.secrets.example.env` file to
+   `plugin.secrets.local.env` within the same plugin directory.
+2. Provide values only for the keys listed in the corresponding
+   `config.schema.json` file.
+
+The local secrets files are gitignored so that credentials stay on your
+machine, while the schema keeps the whitelist of supported variables obvious.
+
 ### Notion setup
 
 Create a **Sources** database in Notion to catalog linked systems alongside the inventory tracker. Configure these lean properties:

--- a/core/config.py
+++ b/core/config.py
@@ -1,0 +1,46 @@
+"""Configuration loading helpers for the controller core and plugins."""
+
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Dict, Any
+
+
+def load_core_config() -> Dict[str, Any]:
+    """Return configuration values required by the core system."""
+    return {}
+
+
+def load_plugin_config(plugin: str) -> Dict[str, str]:
+    """Load configuration for a plugin based on its schema and environment.
+
+    Parameters
+    ----------
+    plugin:
+        The plugin folder name under the ``plugins`` directory.
+
+    Returns
+    -------
+    dict
+        A mapping of environment variable names to their resolved values. Only
+        variables declared in the plugin's ``config.schema.json`` file are
+        considered. Missing environment variables are omitted from the result.
+    """
+
+    schema_path = Path("plugins") / plugin / "config.schema.json"
+
+    base: Dict[str, Any] = {}
+    if schema_path.exists():
+        base = json.loads(schema_path.read_text())
+
+    env_vars = base.get("env", []) if isinstance(base, dict) else []
+
+    resolved: Dict[str, str] = {}
+    for key in env_vars:
+        value = os.getenv(key)
+        if value is not None:
+            resolved[key] = value
+
+    return resolved

--- a/plugins/google-plugin/config.schema.json
+++ b/plugins/google-plugin/config.schema.json
@@ -1,0 +1,7 @@
+{
+  "env": [
+    "GOOGLE_APPLICATION_CREDENTIALS",
+    "DRIVE_ROOT_FOLDER_ID",
+    "SHEET_INVENTORY_ID"
+  ]
+}

--- a/plugins/google-plugin/plugin.secrets.example.env
+++ b/plugins/google-plugin/plugin.secrets.example.env
@@ -1,0 +1,4 @@
+# Copy this file to plugin.secrets.local.env and populate the required values.
+GOOGLE_APPLICATION_CREDENTIALS=
+DRIVE_ROOT_FOLDER_ID=
+SHEET_INVENTORY_ID=

--- a/plugins/notion-plugin/config.schema.json
+++ b/plugins/notion-plugin/config.schema.json
@@ -1,0 +1,6 @@
+{
+  "env": [
+    "NOTION_TOKEN",
+    "NOTION_DB_INVENTORY_ID"
+  ]
+}

--- a/plugins/notion-plugin/plugin.secrets.example.env
+++ b/plugins/notion-plugin/plugin.secrets.example.env
@@ -1,0 +1,3 @@
+# Copy this file to plugin.secrets.local.env and populate the required values.
+NOTION_TOKEN=
+NOTION_DB_INVENTORY_ID=


### PR DESCRIPTION
## Summary
- add a core configuration module that exposes helpers for plugin env loading
- define config schemas and example secret files for the Notion and Google plugins
- document how to manage plugin secrets locally while ignoring sensitive files

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec508af3b08322b090576153ded8b4