### PR TITLE
Add audit logging and plugin consent management CLI

### DIFF
--- a/core/audit.py
+++ b/core/audit.py
@@ -1,0 +1,37 @@
+"""Audit logging utilities for capability executions."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Iterable, Sequence
+
+_AUDIT_PATH = Path("reports") / "audit.log"
+
+
+def _normalise_scopes(scopes: Iterable[str] | Sequence[str]) -> list[str]:
+    return [str(scope) for scope in scopes]
+
+
+def write_audit(
+    run_id: str,
+    plugin: str,
+    capability: str,
+    scopes: Iterable[str] | Sequence[str],
+    outcome: str,
+    ms: float,
+) -> None:
+    """Append an audit entry as a JSON line."""
+
+    entry = {
+        "run_id": run_id,
+        "plugin": plugin,
+        "capability": capability,
+        "scopes": _normalise_scopes(scopes),
+        "outcome": outcome,
+        "ms": float(ms),
+    }
+    _AUDIT_PATH.parent.mkdir(parents=True, exist_ok=True)
+    with _AUDIT_PATH.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(entry, separators=(",", ":")))
+        handle.write("\n")

--- a/core/consent_cli.py
+++ b/core/consent_cli.py
@@ -1,0 +1,69 @@
+"""Interactive helpers for managing plugin consent scopes."""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+from core.capabilities import REGISTRY
+from core.permissions import grant as grant_scopes
+import core.permissions as _permissions
+
+_CONSENT_PATH = Path("consents.json")
+
+
+def _load_consents() -> Dict[str, bool]:
+    if not _CONSENT_PATH.exists():
+        return {}
+    try:
+        return json.loads(_CONSENT_PATH.read_text())
+    except json.JSONDecodeError:
+        return {}
+
+
+def _write_consents(consents: Dict[str, bool]) -> None:
+    _CONSENT_PATH.write_text(json.dumps(consents, indent=2))
+
+
+def current_consents() -> Dict[str, List[str]]:
+    consents = _load_consents()
+    granted: Dict[str, List[str]] = {}
+    for key, approved in consents.items():
+        if not approved:
+            continue
+        if ":" not in key:
+            continue
+        plugin, scope = key.split(":", 1)
+        granted.setdefault(plugin, []).append(scope)
+    for plugin, scopes in granted.items():
+        scopes.sort()
+    return granted
+
+
+def list_scopes() -> Dict[str, List[str]]:
+    plugins: Dict[str, set[str]] = {}
+    for metadata in REGISTRY.values():
+        plugin = metadata.get("plugin")
+        scopes = metadata.get("scopes") or []
+        if not plugin:
+            continue
+        bucket = plugins.setdefault(str(plugin), set())
+        for scope in scopes:
+            bucket.add(str(scope))
+    return {plugin: sorted(scope_set) for plugin, scope_set in plugins.items()}
+
+
+def revoke_scopes(plugin: str, scopes: Iterable[str]) -> None:
+    existing = _load_consents()
+    changed = False
+    for scope in scopes:
+        key = f"{plugin}:{scope}"
+        if key in existing:
+            existing.pop(key, None)
+            changed = True
+        _permissions._CONSENTS.pop(key, None)
+    if changed:
+        _write_consents(existing)
+    elif not _CONSENT_PATH.exists():
+        _write_consents(existing)

--- a/core/runtime.py
+++ b/core/runtime.py
@@ -1,6 +1,6 @@
 import time
 import uuid
-from typing import Any, Dict
+from typing import Any, Dict, Optional
 
 from core.capabilities import meta, resolve
 from core.config import load_core_config
@@ -24,12 +24,12 @@ def generate_run_id() -> str:
     return time.strftime("%Y%m%dT%H%M%SZ") + "-" + str(uuid.uuid4())[:8]
 
 
-def run_capability(cap_name: str, **params):
+def run_capability(cap_name: str, run_id: Optional[str] = None, **params):
     fn = resolve(cap_name)
     m = meta(cap_name)
     require(m["plugin"], m["scopes"])
     ctx = Context(
-        run_id=generate_run_id(),
+        run_id=run_id or generate_run_id(),
         config=load_core_config(),
         limits=get_runtime_limits(),
         logger=logger,


### PR DESCRIPTION
## Summary
- add an audit utility for JSONL reports and hook run_cap timing into it
- allow run_capability to accept provided run IDs so audits align with capability runs
- add consent CLI helpers and an interactive menu option to manage plugin scopes

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec58aa6f7883229ad3fb8bef7bdb90