### PR TITLE
Enable unified logging across workflow entry points

### DIFF
--- a/app.py
+++ b/app.py
@@ -39,8 +39,10 @@ from core import retention
 from core.runtime import get_runtime_limits, set_runtime_limits
 from core.safelog import logger
 from core.system_check import system_check as _system_check
+from core.unilog import write as uni_write
 
 logging.basicConfig(level=logging.INFO, format="%(asctime)s %(levelname)s %(name)s: %(message)s")
+uni_write("app.start", None, version="1.0", cwd=os.getcwd())
 
 
 POLICY_PLACEHOLDER = os.getenv("POLICY_PLACEHOLDER_ENABLED", "true").lower() == "true"  # logs only

--- a/core/audit.py
+++ b/core/audit.py
@@ -1,17 +1,44 @@
 import json, time, pathlib
+
+from core.unilog import write as uni_write
+
 LOG = pathlib.Path("reports/audit.log")
 LOG.parent.mkdir(parents=True, exist_ok=True)
 
-def write_audit(run_id: str, plugin: str, capability: str, scopes: list[str], outcome: str, ms: int, notes: str = ""):
+
+def write_audit(
+    run_id: str,
+    plugin: str,
+    capability: str,
+    scopes: list[str],
+    outcome: str,
+    ms: int,
+    notes: str = "",
+) -> None:
     LOG.write_text("", append=True) if not LOG.exists() else None
     with LOG.open("a", encoding="utf-8") as f:
-        f.write(json.dumps({
-            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
-            "run_id": run_id,
-            "plugin": plugin,
-            "capability": capability,
-            "scopes": scopes,
-            "outcome": outcome,
-            "ms": ms,
-            "notes": notes
-        }) + "\n")
+        f.write(
+            json.dumps(
+                {
+                    "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+                    "run_id": run_id,
+                    "plugin": plugin,
+                    "capability": capability,
+                    "scopes": scopes,
+                    "outcome": outcome,
+                    "ms": ms,
+                    "notes": notes,
+                }
+            )
+            + "\n"
+        )
+    uni_write(
+        "audit.entry",
+        run_id,
+        plugin=plugin,
+        capability=capability,
+        scopes=scopes,
+        outcome=outcome,
+        ms=ms,
+        notes=notes,
+    )

--- a/core/policy_log.py
+++ b/core/policy_log.py
@@ -3,16 +3,20 @@ import time
 import pathlib
 import hashlib
 
+from core.unilog import write as uni_write
+
 
 LOG = pathlib.Path("reports/policy.log")
 LOG.parent.mkdir(parents=True, exist_ok=True)
 
 
-def log_policy(raw_text: str, decision: dict):
+def log_policy(raw_text: str, decision: dict) -> None:
+    user_hash = hashlib.sha256(raw_text.encode()).hexdigest()[:16]
     entry = {
         "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ"),
-        "user_hash": hashlib.sha256(raw_text.encode()).hexdigest()[:16],
+        "user_hash": user_hash,
         "decision": decision,
     }
     with LOG.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
+    uni_write("policy.decision", None, user_hash=user_hash, decision=decision)

--- a/core/retention.py
+++ b/core/retention.py
@@ -76,13 +76,12 @@ def prune_old_runs(
 
     log_event(
         "retention.scan",
-        {
-            "keep_count": keep_value,
-            "prune_count": len(report.planned_prune_paths),
-            "keep_paths": _string_list(report.kept_paths, limit=50),
-            "prune_paths": _string_list(report.planned_prune_paths, limit=50),
-            "dry_run": dry_run,
-        },
+        None,
+        keep_count=keep_value,
+        prune_count=len(report.planned_prune_paths),
+        keep_paths=_string_list(report.kept_paths, limit=50),
+        prune_paths=_string_list(report.planned_prune_paths, limit=50),
+        dry_run=dry_run,
     )
 
     if verbose:
@@ -105,12 +104,12 @@ def prune_old_runs(
         except OSError as exc:
             message = f"Failed to delete {path}: {exc}"
             report.errors.append(message)
-            log_event("retention.error", {"path": str(path), "error": str(exc)})
+            log_event("retention.error", None, path=str(path), error=str(exc))
             if verbose:
                 print(message)
         else:
             report.pruned_paths.append(path)
-            log_event("retention.prune", {"path": str(path), "kind": candidate.kind})
+            log_event("retention.prune", None, path=str(path), kind=candidate.kind)
             if verbose:
                 print(f"Deleted {path}")
 
@@ -120,12 +119,11 @@ def prune_old_runs(
 
     log_event(
         "retention.summary",
-        {
-            "kept_dirs": len(report.kept_paths),
-            "pruned_dirs": len(report.pruned_paths) if not dry_run else 0,
-            "truncated_files": len(report.truncated_files),
-            "dry_run": dry_run,
-        },
+        None,
+        kept_dirs=len(report.kept_paths),
+        pruned_dirs=len(report.pruned_paths) if not dry_run else 0,
+        truncated_files=len(report.truncated_files),
+        dry_run=dry_run,
     )
 
     if dry_run and verbose and report.planned_prune_paths:
@@ -238,7 +236,7 @@ def _truncate_logs(
         except OSError as exc:
             message = f"Failed to read {path}: {exc}"
             report.errors.append(message)
-            log_event("retention.error", {"path": str(path), "error": str(exc)})
+            log_event("retention.error", None, path=str(path), error=str(exc))
             if verbose:
                 print(message)
             continue
@@ -257,12 +255,12 @@ def _truncate_logs(
         except OSError as exc:
             message = f"Failed to truncate {path}: {exc}"
             report.errors.append(message)
-            log_event("retention.error", {"path": str(path), "error": str(exc)})
+            log_event("retention.error", None, path=str(path), error=str(exc))
             if verbose:
                 print(message)
             continue
         truncated.append(path)
-        log_event("retention.truncate", {"path": str(path), "kept_lines": len(tail)})
+        log_event("retention.truncate", None, path=str(path), kept_lines=len(tail))
         if verbose:
             print(f"Truncated {path} to {len(tail)} lines (was {line_count})")
     return planned, truncated

--- a/core/system_check.py
+++ b/core/system_check.py
@@ -1,4 +1,5 @@
 from core.config_validate import validate_plugin_config
+from core.unilog import write as uni_write
 
 
 def system_check() -> None:
@@ -10,3 +11,4 @@ def system_check() -> None:
         print("\nSystem Check — MISSING\n" + "\n".join(f" - {x}" for x in issues))
     else:
         print("\nSystem Check — READY ✅")
+    uni_write("system_check", None, status=("READY" if not issues else "MISSING"), issues=issues)

--- a/tgc/actions/discover.py
+++ b/tgc/actions/discover.py
@@ -3,7 +3,9 @@
 from __future__ import annotations
 
 from dataclasses import dataclass
-from typing import List
+from typing import Dict, List
+
+from core.unilog import write as uni_write
 
 from ..controller import Controller
 from ..reporting import ActionResult, RunContext
@@ -31,6 +33,25 @@ class DiscoverAuditAction(SimpleAction):
     def run(self, controller: Controller, context: RunContext) -> ActionResult:
         lines: List[str] = []
         notes: List[str] = []
+        warnings_list: List[str] = []
+        errors_list: List[str] = []
+        adapter_status = controller.adapter_status()
+        for name, ready in adapter_status.items():
+            if not ready:
+                warnings_list.append(f"{name} adapter not ready")
+
+        notion_status_dict: Dict[str, object] = {
+            "adapter_ready": bool(adapter_status.get("notion")),
+        }
+        drive_status_dict: Dict[str, object] = {
+            "adapter_ready": bool(adapter_status.get("drive")),
+            "validation_errors": 0,
+            "validation_notes": 0,
+        }
+        sheets_status_dict: Dict[str, object] = {
+            "adapter_ready": bool(adapter_status.get("sheets")),
+        }
+
         for key, adapter in controller.adapters.items():
             capability_lines = getattr(adapter, "describe_capabilities", lambda: [])()
             lines.append(f"Adapter: {key}")
@@ -44,11 +65,14 @@ class DiscoverAuditAction(SimpleAction):
                 detail = access.get("detail")
                 if status:
                     lines.append(f"  - Inventory access status: {status}")
+                    notion_status_dict["inventory_status"] = status
                 if detail:
                     lines.append(f"    detail: {detail}")
+                    notion_status_dict["inventory_detail"] = detail
                 preview = access.get("preview_sample")
                 if isinstance(preview, list):
                     lines.append(f"    preview rows available: {len(preview)}")
+                    notion_status_dict["preview_rows"] = len(preview)
             if key == "drive":
                 from ..modules import GoogleDriveModule
 
@@ -58,18 +82,32 @@ class DiscoverAuditAction(SimpleAction):
                     if validation_lines:
                         lines.append("  - Drive module validation:")
                         lines.extend(f"    {line}" for line in validation_lines)
+                        drive_status_dict["validation_summary"] = validation_lines
                     details = module_obj.validation_details()
                     for message in details.get("errors", []):
                         notes.append(f"drive validation error: {message}")
+                        errors_list.append(str(message))
                     notes.extend(
                         f"drive validation note: {message}" for message in details.get("notes", [])
                     )
+                    drive_status_dict["validation_errors"] = len(details.get("errors", []))
+                    drive_status_dict["validation_notes"] = len(details.get("notes", []))
         context.log_notes("audit", lines)
         plan_text = controller.build_plan(self.id)
-        return ActionResult(
+        result = ActionResult(
             plan_text=plan_text,
             changes=[],
             errors=[],
             notes=notes or self._dry_run_message(),
             preview="\n".join(lines),
         )
+        uni_write(
+            "discover_audit.result",
+            context.run_id,
+            notion=notion_status_dict,
+            drive=drive_status_dict,
+            sheets=sheets_status_dict,
+            warnings=warnings_list,
+            errors=errors_list,
+        )
+        return result


### PR DESCRIPTION
## Summary
- add a core unified logging helper that writes JSONL events to the configured log path
- emit unified log events from application startup, system checks, Discover & Audit, and Master Index workflows
- mirror audit, policy, and retention events into the unified log stream for downstream fan-out

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ec7464c478832297696f9efdb5d181