### PR TITLE
Add unified logging fan-out and normalize CLI menu layout

### DIFF
--- a/README.md
+++ b/README.md
@@ -370,3 +370,38 @@ The controller can prune old runs to keep the repo tidy.
 
 Unified events are written to `reports/all.log` with types:
 `retention.scan` • `retention.prune` • `retention.truncate` • `retention.summary` • `retention.error`
+
+## CLI Layout (normalized)
+
+Banner:
+TGC Frame — Controller Menu
+made by: TGC Systems
+
+Sample menu:
+Core
+  0)  System Check — Validate credentials and status
+  0U) Update from repository — Fetch and merge latest code
+  1)  Discover & Audit — Read-only adapter audit
+
+Build
+  12) Build Master Index — Notion, Drive, (Sheets) → Markdown
+  15) Build Sheets Index — Enumerate spreadsheets & tabs
+
+Imports & Sync
+  2)  Import from Gmail — Stage vendor quotes/orders
+  3)  Import CSV → Inventory — Map CSV columns
+  4)  Sync metrics → Google Sheets — Preview/push
+
+Linking & Data
+  5)  Link Drive PDFs to Notion — Match and attach
+  6)  Contacts/Vendors — Normalize & dedupe
+
+Config & Reports
+  7)  Settings & IDs — View environment and saved queries
+  8)  Logs & Reports — List recent run directories
+
+Optional
+  9)  Wave — Discover Wave data and plan exports
+
+Exit
+  q)  Quit

--- a/app.py
+++ b/app.py
@@ -35,6 +35,7 @@ from core.permissions import require
 from core.plugin_api import Context
 from core.plugin_manager import load_plugins
 from core.policy_log import log_policy
+from core.menu_render import render_menu
 from core import retention
 from core.runtime import get_runtime_limits, set_runtime_limits
 from core.safelog import logger
@@ -214,6 +215,10 @@ def main() -> None:
     if args.quiet:
         level = logging.WARNING
     logging.getLogger().setLevel(level)
+
+    if args.menu_only and not args.action:
+        render_menu(quiet=("--quiet" in sys.argv))
+        return
 
     if args.prune_only:
         report = retention.prune_old_runs(

--- a/core/menu_render.py
+++ b/core/menu_render.py
@@ -4,6 +4,9 @@ from __future__ import annotations
 
 from typing import Iterable, Mapping, Sequence, Tuple
 
+from core.brand import NAME, VENDOR
+from core.menu_spec import MENU_SPEC
+
 from . import brand
 
 MenuItems = Sequence[Tuple[str, str]]
@@ -20,13 +23,11 @@ def format_banner(*, debug: bool = False) -> str:
     return "\n".join(lines)
 
 
-def render_menu(
+def _render_menu_text(
     menu_spec: MenuSpec,
     *,
     available: Mapping[str, Tuple[str, str]] | None = None,
 ) -> str:
-    """Render the menu using ``menu_spec`` and optional overrides."""
-
     resolved: list[tuple[str, list[tuple[str, str]]]] = []
     for section, items in menu_spec:
         section_entries: list[Tuple[str, str]] = []
@@ -41,22 +42,49 @@ def render_menu(
             else:
                 display = label
             section_entries.append((key, display))
-        resolved.append((section, section_entries))
+        if section_entries:
+            resolved.append((section, section_entries))
 
-    number_width = max(
-        (len(key) for _, entries in resolved for key, _ in entries),
-        default=1,
-    )
+    number_width = max((len(key) for _, entries in resolved for key, _ in entries), default=1)
     lines: list[str] = []
-    for idx, (section, entries) in enumerate(resolved):
-        if not entries:
-            continue
+    for index, (section, entries) in enumerate(resolved):
         if lines:
             lines.append("")
         lines.append(section)
         for key, label in entries:
             lines.append(f"  {key.ljust(number_width)}  {label}")
     return "\n".join(lines)
+
+
+def render_menu(quiet: bool = False, *legacy_args, **legacy_kwargs):
+    """Render the normalized menu.
+
+    When invoked with a boolean ``quiet`` flag (the new interface), the menu is
+    printed directly. Legacy callers can continue to pass a ``menu_spec`` and
+    optional ``available`` mapping to receive a formatted string.
+    """
+
+    if not isinstance(quiet, bool) or legacy_args or legacy_kwargs:
+        if isinstance(quiet, bool):
+            menu_spec = legacy_kwargs.pop("menu_spec", MENU_SPEC)
+            available = legacy_kwargs.get("available")
+        else:
+            menu_spec = quiet  # type: ignore[assignment]
+            available = legacy_kwargs.get("available")
+        return _render_menu_text(menu_spec, available=available)
+
+    if not quiet:
+        print(f"{NAME} — Controller Menu")
+        print(f"made by: {VENDOR}")
+        print()
+
+    for section, items in MENU_SPEC:
+        print(section)
+        for key, label in items:
+            print(f"{key:>3}) {label}")
+        print()
+
+    print("Select an option (or q to quit): ", end="")
 
 
 def format_help_lines(*, debug: bool = False) -> Iterable[str]:

--- a/core/menu_spec.py
+++ b/core/menu_spec.py
@@ -5,22 +5,21 @@ MENU_SPEC = [
         "Core",
         [
             ("0", "System Check — Validate credentials and status"),
-            ("1", "Discover & Audit — Read-only adapter audit"),
             ("U", "Update from repository — Fetch and merge latest code"),
+            ("1", "Discover & Audit — Read-only adapter audit"),
         ],
     ),
     (
         "Build",
         [
             ("12", "Build Master Index — Notion, Drive, (Sheets) → Markdown"),
-            ("13", "Master Index Snapshot (debug) — Print JSON for inspection"),
             ("14", "Build Sheets Index — Enumerate spreadsheets & tabs"),
         ],
     ),
     (
         "Imports & Sync",
         [
-            ("2", "Import from Gmail — Stage vendor quotes/orders (optional)"),
+            ("2", "Import from Gmail — Stage vendor quotes/orders"),
             ("3", "Import CSV → Inventory — Map CSV columns"),
             ("4", "Sync metrics → Google Sheets — Preview/push"),
         ],
@@ -29,7 +28,7 @@ MENU_SPEC = [
         "Linking & Data",
         [
             ("5", "Link Drive PDFs to Notion — Match and attach"),
-            ("6", "Contacts & Vendors — Normalize & dedupe"),
+            ("6", "Contacts/Vendors — Normalize & dedupe"),
         ],
     ),
     (
@@ -37,10 +36,6 @@ MENU_SPEC = [
         [
             ("7", "Settings & IDs — View environment and saved queries"),
             ("8", "Logs & Reports — List recent run directories"),
-            ("10", "Google Drive Module — Configure sharing & validation"),
-            ("11", "Notion Module — Review access & troubleshooting"),
-            ("15", "Plugin Consents — Grant or revoke scopes"),
-            ("17", "Retention Cleanup — Preview or prune historical runs"),
         ],
     ),
     (
@@ -49,5 +44,10 @@ MENU_SPEC = [
             ("9", "Wave — Discover Wave data and plan exports"),
         ],
     ),
-    ("Exit", [("q", "Quit")]),
+    (
+        "Exit",
+        [
+            ("q", "Quit"),
+        ],
+    ),
 ]

--- a/core/plugin_manager.py
+++ b/core/plugin_manager.py
@@ -7,6 +7,7 @@ import tomllib
 
 from core.capabilities import register
 from core.signing import PUBLIC_KEY_HEX, verify_plugin_signature
+from core.unilog import write as uni_write
 
 CORE_VERSION = "0.1.0"
 SECURITY_LOG = pathlib.Path("reports/security.log")
@@ -99,6 +100,7 @@ def _log_security_event(message: str) -> None:
     SECURITY_LOG.parent.mkdir(parents=True, exist_ok=True)
     with SECURITY_LOG.open("a", encoding="utf-8") as fh:
         fh.write(f"{message}\n")
+    uni_write("security.note", None, message=message)
 
 
 def _load_denylist() -> set[tuple[str, str]]:

--- a/core/policy_log.py
+++ b/core/policy_log.py
@@ -19,4 +19,4 @@ def log_policy(raw_text: str, decision: dict) -> None:
     }
     with LOG.open("a", encoding="utf-8") as f:
         f.write(json.dumps(entry) + "\n")
-    uni_write("policy.decision", None, user_hash=user_hash, decision=decision)
+    uni_write("policy.decision", decision.get("run_id"), user_hash=user_hash, decision=decision)


### PR DESCRIPTION
## Summary
- add unified log fan-out for security and policy logs and expose the normalized menu renderer for CLI usage
- normalize the shared menu specification/renderer and document the layout in the README
- support the `--menu-only` entrypoint by printing the normalized menu banner

## Testing
- python app.py --menu-only *(fails: ModuleNotFoundError: No module named 'nacl')*

------
https://chatgpt.com/codex/tasks/task_e_68ec8648cbcc832282640dece471aba6