### PR TITLE
Restructure CLI menu for status overview and data operations

### DIFF
--- a/README.md
+++ b/README.md
@@ -453,3 +453,24 @@ Example submenu (Status & Health):
 ```
 
 Submenus use digits `1`–`9`; press `0` to go back and `q` from the root menu to exit. Legacy numeric shortcuts continue to work for now so scripts and muscle memory stay compatible during the transition.
+
+## Navigation Model
+
+1) Status & Plugins — Read-only overview (no actions). Shows:
+   - Core readiness (SafeMode/Subprocess)
+   - API status (Notion/Drive/Sheets)
+   - Installed plugins with health/config status
+   - Indexing capabilities available (not executed)
+
+2) Data Operations — Where you run things:
+   - 12) Build Master Index
+   - 15) Build Sheets Index
+   - 2) Import from Gmail
+   - 3) Import CSV → Inventory
+   - 4) Sync metrics → Google Sheets
+   - 5) Link Drive PDFs to Notion
+   - 6) Contacts/Vendors
+
+3) Plugins Hub — Configure plugins (discover, auto-connect, test, enable/disable, view env schema)
+
+4) Controller Config & Tools — Base controller settings only (System Check, Logs, Retention, Update, Consents)

--- a/core/menu_render.py
+++ b/core/menu_render.py
@@ -1,25 +1,165 @@
+"""Renderer helpers for CLI menus."""
+
+from __future__ import annotations
+
+from typing import Any, Dict, Iterable
+
 from core.brand import NAME, VENDOR
-from core.menu_spec import ROOT_MENU, SUBMENUS
+from core.capabilities import REGISTRY
+from core.menu_spec import (
+    CONTROLLER_CONFIG_MENU,
+    MAIN_MENU,
+    STATUS_PLUGINS_SECTIONS,
+    SUBMENU_DATA_OPS,
+)
+from core.plugins_state import is_enabled as plugin_enabled
+from core.unilog import write as unilog_write
 
 
-def render_root(quiet: bool = False):
+def render_main_menu(quiet: bool = False) -> None:
     if not quiet:
         print(f"{NAME} — Controller Menu")
         print(f"made by: {VENDOR}")
         print()
-    for key, label in ROOT_MENU:
+    for key, label in MAIN_MENU:
         print(f" {key:>1}) {label}")
     print()
     print("Select an option (1–4, or q to quit): ", end="")
 
 
-def render_submenu(root_key: str):
+def render_data_ops_menu() -> None:
     print()
-    section_name = next((lbl for k,lbl in ROOT_MENU if k == root_key), "Menu")
-    print(section_name)
-    items = SUBMENUS.get(root_key, [])
-    for key, label, _handler in items:
+    print(MAIN_MENU[1][1])  # "Data Operations — …"
+    for key, label in SUBMENU_DATA_OPS:
         print(f"  {key}) {label}")
-    print("  0) Back")
     print()
-    print("Select an option (1–9, or 0 to go back): ", end="")
+    print("Select a workflow (12, 15, 2–6, or b to go back): ", end="")
+
+
+def render_controller_tools_menu() -> None:
+    print()
+    print(MAIN_MENU[3][1])  # "Controller Config & Tools — …"
+    for key, label in CONTROLLER_CONFIG_MENU:
+        print(f"  {key}) {label}")
+    print()
+    print("Select a controller tool (1–6, or b to go back): ", end="")
+
+
+def render_status_plugins_overview(payload: Dict[str, Any]) -> None:
+    sections = STATUS_PLUGINS_SECTIONS
+    core_label = sections[0]
+    apis_label = sections[1]
+    plugins_label = sections[2]
+    caps_label = sections[3]
+
+    core_block = payload.get("core", {}) or {}
+    plugin_block = payload.get("plugins", {}) or {}
+    items = plugin_block.get("items", []) or []
+    summary = plugin_block.get("summary", {}) or {}
+
+    flags = core_block.get("isolation", {}).get("flags", {}) or {}
+    ready_flag = bool(core_block.get("ready"))
+    safe_mode = "ON" if flags.get("OFFLINE_SAFE_MODE") else "OFF"
+    subprocess = "ON" if flags.get("PLUGIN_SUBPROCESS") else "OFF"
+    logging_info = core_block.get("logging", {}) or {}
+    log_path = logging_info.get("path")
+
+    print()
+    print(MAIN_MENU[0][1])
+    print("=" * len(MAIN_MENU[0][1]))
+    print(f"{core_label}:")
+    print(f"  Ready: {ready_flag}")
+    print(f"  SafeMode: {safe_mode} • Subprocess: {subprocess}")
+    if log_path:
+        print(f"  Unified log path: {log_path}")
+    print()
+
+    def _api_status(plugin_name: str, required_keys: Iterable[str] | None = None) -> str:
+        plugin_item = next((it for it in items if it.get("name") == plugin_name), None)
+        if not plugin_item:
+            return "MISSING"
+        if not plugin_item.get("enabled") or not plugin_item.get("manifest_ok"):
+            return "MISSING"
+        missing_env = set(plugin_item.get("config", {}).get("missing_env") or [])
+        if required_keys is None:
+            return "READY" if not missing_env else "MISSING"
+        return "READY" if not any(key in missing_env for key in required_keys) else "MISSING"
+
+    notion_status = _api_status("notion-plugin")
+    drive_status = _api_status(
+        "google-plugin",
+        ["GOOGLE_APPLICATION_CREDENTIALS", "DRIVE_ROOT_FOLDER_ID"],
+    )
+    sheets_status = _api_status(
+        "google-plugin",
+        ["GOOGLE_APPLICATION_CREDENTIALS", "SHEET_INVENTORY_ID"],
+    )
+    print(f"{apis_label}:")
+    print(f"  Notion: {notion_status}")
+    print(f"  Drive: {drive_status}")
+    print(f"  Sheets: {sheets_status}")
+    print()
+
+    print(f"{plugins_label}:")
+    if not items:
+        print("  (no plugins discovered)")
+    else:
+        for item in sorted(items, key=lambda it: str(it.get("name"))):
+            name = item.get("name") or "(unknown)"
+            version = item.get("version") or "?"
+            enabled = "enabled" if item.get("enabled") else "disabled"
+            manifest_state = "ok" if item.get("manifest_ok") else "error"
+            config_info = item.get("config", {}) or {}
+            missing_env = [str(v) for v in (config_info.get("missing_env") or [])]
+            config_state = "ok" if not missing_env else f"missing: {', '.join(missing_env)}"
+            health_info = item.get("health", {}) or {}
+            health_status = health_info.get("status") or "unknown"
+            print(
+                f"  - {name}@{version} [{enabled}; manifest={manifest_state}; "
+                f"config={config_state}; health={health_status}]"
+            )
+            notes = health_info.get("notes")
+            if isinstance(notes, list) and notes:
+                preview = "; ".join(str(n) for n in notes)
+                print(f"      notes: {preview}")
+    print()
+
+    index_caps = []
+    print(f"{caps_label}:")
+    for capability, meta in sorted(REGISTRY.items()):
+        if ".index" not in capability:
+            continue
+        index_caps.append(capability)
+        plugin_name = meta.get("plugin") or "?"
+        scopes = meta.get("scopes") or []
+        scope_text = ", ".join(scopes) if scopes else "(none)"
+        network_flag = "true" if meta.get("network") else "false"
+        plugin_state = "enabled" if plugin_enabled(plugin_name) else "disabled"
+        version = meta.get("version") or "?"
+        print(
+            "  - {cap} (plugin: {plugin}@{version}, scopes: {scopes}, "
+            "network={network}, plugin_state={state})".format(
+                cap=capability,
+                plugin=plugin_name,
+                version=version,
+                scopes=scope_text,
+                network=network_flag,
+                state=plugin_state,
+            )
+        )
+    if not index_caps:
+        print("  (no indexing capabilities registered)")
+
+    api_ready_count = sum(
+        1 for status in (notion_status, drive_status, sheets_status) if status == "READY"
+    )
+    enabled_count = sum(1 for item in items if item.get("enabled"))
+    counts = {
+        "core_ready": ready_flag,
+        "plugins_total": len(items),
+        "plugins_enabled": enabled_count,
+        "plugins_ok": summary.get("ok", 0),
+        "indexing_caps": len(index_caps),
+        "apis_ready": api_ready_count,
+    }
+    unilog_write("menu.view.status_plugins", None, counts=counts)

--- a/core/menu_spec.py
+++ b/core/menu_spec.py
@@ -1,53 +1,55 @@
-# Root categories: 1–4 only
-ROOT_MENU = [
-  ("1", "Status & Health"),
-  ("2", "Build & Indexing"),
-  ("3", "Data Operations"),
-  ("4", "Config & Tools"),
+"""Menu layout specification for the controller CLI."""
+
+MAIN_MENU = [
+  ("1", "Status & Plugins — Read-only overview (no actions)"),
+  ("2", "Data Operations — Run indexing/import/sync/link workflows"),
+  ("3", "Plugins Hub — Discover / Auto-connect / Debug / Configure plugins"),
+  ("4", "Controller Config & Tools — Base controller settings, logs, retention, update"),
   ("q", "Quit"),
 ]
 
-# Submenus: items numbered 1–9 only. Use existing actions/labels.
-SUBMENUS = {
-  "1": [  # Status & Health
-    ("1", "System Check — Validate credentials and status", "action_system_check"),
-    ("2", "Discover & Audit — Read-only adapter audit", "action_discover_audit"),
-    ("3", "Plugins Hub — Discover / Auto-connect / Debug / Configure", "action_plugins_hub"),
-  ],
-  "2": [  # Build & Indexing
-    ("1", "Build Master Index — Notion, Drive, (Sheets) → Markdown", "action_build_master_index"),
-    ("2", "Build Sheets Index — Enumerate spreadsheets & tabs", "action_build_sheets_index"),
-  ],
-  "3": [  # Data Operations
-    ("1", "Import from Gmail — Stage vendor quotes/orders", "action_import_gmail"),
-    ("2", "Import CSV → Inventory — Map CSV columns", "action_import_csv"),
-    ("3", "Sync metrics → Google Sheets — Preview/push", "action_sync_metrics"),
-    ("4", "Link Drive PDFs to Notion — Match and attach", "action_link_drive_pdfs"),
-    ("5", "Contacts/Vendors — Normalize & dedupe", "action_contacts_vendors"),
-    ("6", "Wave — Discover Wave data and plan exports", "action_wave"),
-  ],
-  "4": [  # Config & Tools
-    ("1", "Settings & IDs — View environment and saved queries", "action_settings_ids"),
-    ("2", "Logs & Reports — List recent run directories", "action_logs_reports"),
-    ("3", "Update from repository — Fetch and merge latest code", "action_update_repo"),
-  ],
-}
+SUBMENU_DATA_OPS = [
+  ("12", "Build Master Index — Notion, Drive, (Sheets) → Markdown"),
+  ("15", "Build Sheets Index — Enumerate spreadsheets & tabs"),
+  ("2",  "Import from Gmail — Stage vendor quotes/orders"),
+  ("3",  "Import CSV → Inventory — Map CSV columns"),
+  ("4",  "Sync metrics → Google Sheets — Preview/push"),
+  ("5",  "Link Drive PDFs to Notion — Match and attach"),
+  ("6",  "Contacts/Vendors — Normalize & dedupe"),
+  ("b",  "Back"),
+]
 
-# Legacy shim: map old flat hotkeys to new (section, item) actions.
-# Keys are the user input strings you already supported.
-LEGACY_SHIMS = {
-  "0":  ("1","1"),  # System Check
-  "1":  ("1","2"),  # Discover & Audit
-  "12": ("2","1"),  # Build Master Index
-  "15": ("2","2"),  # Build Sheets Index
-  "2":  ("3","1"),  # Import Gmail
-  "3":  ("3","2"),  # Import CSV
-  "4":  ("3","3"),  # Sync metrics
-  "5":  ("3","4"),  # Link PDFs
-  "6":  ("3","5"),  # Contacts/Vendors
-  "7":  ("4","1"),  # Settings & IDs
-  "8":  ("4","2"),  # Logs & Reports
-  "9":  ("3","6"),  # Wave
-  "20": ("1","3"),  # Plugins Hub
-  "0U": ("4","3"),  # Update repo (if you used that alias)
+CONTROLLER_CONFIG_MENU = [
+  ("1", "System Check — Validate credentials and status"),
+  ("2", "Logs & Reports — List recent run directories"),
+  ("3", "Retention — Prune old runs"),
+  ("4", "Update from repository — Fetch and merge latest code"),
+  ("5", "Consent management — Grant/revoke plugin scopes"),
+  ("6", "About / Versions — Core build & plugin summary"),
+  ("b", "Back"),
+]
+
+# Read-only “Status & Plugins” sections pulled from runtime_state & registry
+STATUS_PLUGINS_SECTIONS = [
+  "Core Status",          # Ready flags, SafeMode/Subprocess flags
+  "APIs (Notion/Drive/Sheets)",   # READY/MISSING
+  "Installed Plugins",    # name@version, enabled, config ok/missing, health
+  "Indexing Capabilities" # list of capabilities that match *.index* (NOT running)
+]
+
+LEGACY_ACTIONS = {
+  "0": "action_system_check",
+  "1": "action_discover_audit",
+  "12": "action_build_master_index",
+  "15": "action_build_sheets_index",
+  "2": "action_import_gmail",
+  "3": "action_import_csv",
+  "4": "action_sync_metrics",
+  "5": "action_link_drive_pdfs",
+  "6": "action_contacts_vendors",
+  "7": "action_settings_ids",
+  "8": "action_logs_reports",
+  "9": "action_wave",
+  "20": "action_plugins_hub",
+  "0U": "action_update_repo",
 }


### PR DESCRIPTION
## Summary
- reorganized the controller CLI into the new navigation model with a read-only status view, data-ops submenu, and controller tools routing
- added logging hooks, indexing capability discovery, and README documentation for the updated menu flow

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed18f8348c83228c5886f629a8801b