### PR TITLE
Introduce command bus micro-kernel for master index

### DIFF
--- a/README.md
+++ b/README.md
@@ -474,3 +474,15 @@ Submenus use digits `1`–`9`; press `0` to go back and `q` from the root menu t
 3) Plugins Hub — Configure plugins (discover, auto-connect, test, enable/disable, view env schema)
 
 4) Controller Config & Tools — Base controller settings only (System Check, Logs, Retention, Update, Consents)
+
+## Architecture: Thin Core / Fat Plugins (Phase 1)
+
+Core provides contracts, action cards, approvals, backup snapshots, a command bus, and a plugin registry.
+Plugins implement effects via a standard interface:
+
+discover → propose → apply → rollback → health
+
+“Build Master Index” now runs as:
+discover (drive/notion/sheets) → plan (cards) → apply (writer.markdown)
+
+Phase 1 keeps outputs identical to previous versions.

--- a/config/plugins.json
+++ b/config/plugins.json
@@ -1,0 +1,6 @@
+{
+  "discovery.drive": true,
+  "discovery.notion": true,
+  "discovery.sheets": true,
+  "writer.markdown": true
+}

--- a/core/action_cards/__init__.py
+++ b/core/action_cards/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialization for action_cards."""

--- a/core/action_cards/model.py
+++ b/core/action_cards/model.py
@@ -1,0 +1,58 @@
+"""Action card models shared between the core and plugins."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List
+
+
+@dataclass
+class DiffEntry:
+    """Describe a change that an action card proposes."""
+
+    path: str
+    before: Any
+    after: Any
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.path, str) or not self.path:
+            raise ValueError("DiffEntry.path must be a non-empty string")
+
+
+@dataclass
+class ActionCard:
+    """Plan-time representation of a unit of work."""
+
+    id: str
+    kind: str
+    title: str
+    summary: str
+    proposed_by_plugin: str
+    data: Dict[str, Any] = field(default_factory=dict)
+    diff: List[DiffEntry] = field(default_factory=list)
+    risk: str = "low"
+    prerequisites: List[str] = field(default_factory=list)
+    approvals_required: int = 1
+    state: str = "proposed"
+
+    def __post_init__(self) -> None:
+        for attr in ("id", "kind", "title", "summary", "proposed_by_plugin", "risk"):
+            value = getattr(self, attr)
+            if not isinstance(value, str) or not value:
+                raise ValueError(f"{attr} must be a non-empty string")
+        if not isinstance(self.data, dict):
+            raise TypeError("data must be a dictionary")
+        if not isinstance(self.diff, list):
+            raise TypeError("diff must be a list of DiffEntry items")
+        for entry in self.diff:
+            if not isinstance(entry, DiffEntry):
+                raise TypeError("diff entries must be DiffEntry instances")
+        if not isinstance(self.prerequisites, list):
+            raise TypeError("prerequisites must be a list of card IDs")
+        for item in self.prerequisites:
+            if not isinstance(item, str):
+                raise TypeError("prerequisite values must be strings")
+        if not isinstance(self.approvals_required, int) or self.approvals_required < 1:
+            raise ValueError("approvals_required must be a positive integer")
+        if self.state not in {"proposed", "approved", "applied", "failed"}:
+            raise ValueError("state must be one of proposed, approved, applied, failed")

--- a/core/action_cards/planner.py
+++ b/core/action_cards/planner.py
@@ -1,0 +1,108 @@
+"""Planner helpers that translate findings into action cards."""
+
+from __future__ import annotations
+
+from dataclasses import asdict
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Mapping
+from uuid import uuid4
+
+from .model import ActionCard
+
+
+def _coerce_mapping(value: Any) -> Mapping[str, Any]:
+    if value is None:
+        return {}
+    if isinstance(value, Mapping):
+        return value
+    if hasattr(value, "__dict__"):
+        return {**asdict(value)} if hasattr(value, "__dataclass_fields__") else vars(value)
+    return {}
+
+
+def _extract_records(finding: Mapping[str, Any]) -> List[Dict[str, Any]]:
+    records = finding.get("records")
+    if isinstance(records, list):
+        normalised: List[Dict[str, Any]] = []
+        for item in records:
+            if isinstance(item, Mapping):
+                normalised.append(dict(item))
+            else:
+                try:
+                    normalised.append(dict(item))
+                except Exception:  # pragma: no cover - defensive
+                    continue
+        return normalised
+    return []
+
+
+def _extract_errors(finding: Mapping[str, Any]) -> List[str]:
+    errors = finding.get("errors")
+    if isinstance(errors, Iterable) and not isinstance(errors, (str, bytes)):
+        return [str(item) for item in errors if item]
+    return []
+
+
+def build_cards_from_findings(findings: Mapping[str, Any]) -> List[ActionCard]:
+    """Produce action cards from discovery findings."""
+
+    notion = _coerce_mapping(findings.get("discovery.notion"))
+    drive = _coerce_mapping(findings.get("discovery.drive"))
+    sheets = _coerce_mapping(findings.get("discovery.sheets"))
+
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    output_dir = Path("docs") / "master_index_reports" / f"master_index_{timestamp}"
+
+    notion_records = _extract_records(notion)
+    drive_records = _extract_records(drive)
+    sheets_rows = _extract_records(sheets)
+
+    summary = (
+        f"Plan to write Master Index Markdown (Notion={len(notion_records)}, "
+        f"Drive={len(drive_records)}, Sheets tabs={len(sheets_rows)})"
+    )
+
+    card = ActionCard(
+        id=str(uuid4()),
+        kind="index.markdown",
+        title="Write Master Index Markdown",
+        summary=summary,
+        proposed_by_plugin="writer.markdown",
+        data={
+            "generated_at": datetime.now(UTC).isoformat(timespec="seconds").replace("+00:00", "Z"),
+            "output_dir": str(output_dir),
+            "notion": {
+                "records": notion_records,
+                "errors": _extract_errors(notion),
+                "roots": list(notion.get("roots", [])),
+                "elapsed": notion.get("elapsed"),
+                "message": notion.get("message"),
+                "partial": bool(notion.get("partial")),
+                "reason": notion.get("reason"),
+            },
+            "drive": {
+                "records": drive_records,
+                "errors": _extract_errors(drive),
+                "roots": list(drive.get("roots", [])),
+                "elapsed": drive.get("elapsed"),
+                "message": drive.get("message"),
+                "partial": bool(drive.get("partial")),
+                "reason": drive.get("reason"),
+            },
+            "sheets": {
+                "records": sheets_rows,
+                "errors": _extract_errors(sheets),
+                "roots": list(sheets.get("roots", [])),
+                "elapsed": sheets.get("elapsed"),
+                "message": sheets.get("message"),
+                "partial": bool(sheets.get("partial")),
+                "reason": sheets.get("reason"),
+            },
+        },
+        diff=[],
+        risk="low",
+        prerequisites=[],
+    )
+
+    return [card]

--- a/core/backup/__init__.py
+++ b/core/backup/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialization for backup."""

--- a/core/backup/snapshot.py
+++ b/core/backup/snapshot.py
@@ -1,0 +1,42 @@
+"""Backup helpers for snapshotting state before applying changes."""
+
+from __future__ import annotations
+
+import logging
+from datetime import UTC, datetime
+from pathlib import Path
+import zipfile
+
+from core.unilog import write as uni_write
+
+
+_SNAPSHOT_ROOT = Path("reports") / "snapshots"
+
+
+def create_snapshot(run_id: str) -> Path | None:
+    """Create a zip snapshot of the master index reports directory."""
+
+    base_dir = Path("docs") / "master_index_reports"
+    timestamp = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
+    snapshot_path = _SNAPSHOT_ROOT / f"{run_id}_{timestamp}.zip"
+    _SNAPSHOT_ROOT.mkdir(parents=True, exist_ok=True)
+
+    if not base_dir.exists():
+        # Nothing to snapshot yet; still emit an event for traceability.
+        with zipfile.ZipFile(snapshot_path, "w", compression=zipfile.ZIP_DEFLATED):
+            pass
+        uni_write("backup.snapshot.created", run_id, path=str(snapshot_path), empty=True)
+        return snapshot_path
+
+    try:
+        with zipfile.ZipFile(snapshot_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+            for item in base_dir.rglob("*"):
+                if item.is_file():
+                    archive.write(item, item.relative_to(base_dir.parent))
+    except OSError as exc:
+        logging.getLogger(__name__).warning("snapshot.failed", exc_info=exc)
+        uni_write("backup.snapshot.error", run_id, error=str(exc))
+        return None
+
+    uni_write("backup.snapshot.created", run_id, path=str(snapshot_path), empty=False)
+    return snapshot_path

--- a/core/bus/__init__.py
+++ b/core/bus/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialization for bus."""

--- a/core/bus/command_bus.py
+++ b/core/bus/command_bus.py
@@ -1,0 +1,228 @@
+"""Command bus orchestration for the thin core."""
+
+from __future__ import annotations
+
+import importlib
+import logging
+import time
+from typing import Dict, List, Tuple
+
+from core.action_cards.planner import build_cards_from_findings
+from core.audit import write_audit
+from core.backup.snapshot import create_snapshot
+from core.policy import approvals
+from core.registry import plugins_json
+from core.unilog import write as uni_write
+
+from .models import ApplyResult, CommandContext, PluginFinding
+
+_DISCOVERY_PLUGINS: Tuple[str, ...] = (
+    "discovery.notion",
+    "discovery.drive",
+    "discovery.sheets",
+)
+
+_PLUGIN_MODULES: Dict[str, str] = {
+    "discovery.notion": "plugins.discovery.notion",
+    "discovery.drive": "plugins.discovery.drive",
+    "discovery.sheets": "plugins.discovery.sheets",
+    "writer.markdown": "plugins.writer.markdown",
+}
+
+
+def _load_plugin(name: str):
+    module_path = _PLUGIN_MODULES.get(name)
+    if module_path is None:
+        raise KeyError(f"Unknown plugin '{name}'")
+    return importlib.import_module(module_path)
+
+
+def _normalise_finding(plugin: str, payload) -> PluginFinding:
+    if isinstance(payload, PluginFinding):
+        return payload
+    records = []
+    errors: List[str] = []
+    metadata: Dict[str, object] = {}
+    partial = False
+    reason = None
+    if isinstance(payload, dict):
+        records = payload.get("records") or []
+        errors = payload.get("errors") or []
+        metadata = {
+            key: value
+            for key, value in payload.items()
+            if key not in {"records", "errors", "partial", "reason"}
+        }
+        partial = bool(payload.get("partial"))
+        reason = payload.get("reason")
+    elif payload is None:
+        records = []
+    else:
+        metadata["payload"] = payload
+    if not isinstance(records, list):
+        records = []
+    if not isinstance(errors, list):
+        errors = [str(errors)] if errors else []
+    finding = PluginFinding(
+        plugin=plugin,
+        records=[dict(item) for item in records if isinstance(item, dict)],
+        errors=[str(err) for err in errors],
+        metadata=metadata,
+        partial=partial,
+        reason=str(reason) if reason else None,
+    )
+    return finding
+
+
+def _finding_to_mapping(finding: PluginFinding) -> Dict[str, object]:
+    payload = {
+        "records": finding.records,
+        "errors": finding.errors,
+        "partial": finding.partial,
+        "reason": finding.reason,
+    }
+    payload.update(finding.metadata)
+    return payload
+
+
+def discover(ctx: CommandContext) -> Dict[str, PluginFinding]:
+    """Run all discovery plugins and aggregate findings."""
+
+    logger = ctx.logger or logging.getLogger(__name__)
+    findings: Dict[str, PluginFinding] = {}
+    plugin_counts: Dict[str, int] = {}
+    for plugin in _DISCOVERY_PLUGINS:
+        if not plugins_json.enabled(plugin):
+            uni_write("plugin.skipped_disabled", ctx.run_id, plugin=plugin)
+            continue
+        try:
+            module = _load_plugin(plugin)
+            discover_fn = getattr(module, "discover", None)
+            if discover_fn is None:
+                continue
+            start = time.perf_counter()
+            payload = discover_fn(ctx)
+            elapsed_ms = int((time.perf_counter() - start) * 1000)
+        except Exception as exc:  # pragma: no cover - defensive
+            logger.exception("discover.failed", extra={"plugin": plugin})
+            finding = PluginFinding(plugin=plugin, records=[], errors=[str(exc)])
+            elapsed_ms = 0
+        else:
+            finding = _normalise_finding(plugin, payload)
+        findings[plugin] = finding
+        plugin_counts[plugin] = finding.count()
+        uni_write(
+            "bus.discover.plugin",
+            ctx.run_id,
+            plugin=plugin,
+            count=finding.count(),
+            errors=len(finding.errors),
+            ms=elapsed_ms,
+        )
+    ctx.findings = findings
+    uni_write(
+        "bus.discover.done",
+        ctx.run_id,
+        counts={name: count for name, count in plugin_counts.items()},
+    )
+    return findings
+
+
+def plan(ctx: CommandContext, findings: Dict[str, PluginFinding]):
+    """Convert findings into action cards."""
+
+    mapping = {name: _finding_to_mapping(finding) for name, finding in findings.items()}
+    cards = build_cards_from_findings(mapping)
+    ctx.cards = {card.id: card for card in cards}
+    uni_write("bus.plan.cards", ctx.run_id, count=len(cards))
+    return cards
+
+
+def _normalise_apply_result(payload) -> ApplyResult:
+    if isinstance(payload, ApplyResult):
+        return payload
+    if isinstance(payload, dict):
+        ok = bool(payload.get("ok"))
+        data = payload.get("data") if isinstance(payload.get("data"), dict) else {}
+        errors = payload.get("errors") or []
+        notes = payload.get("notes") or []
+        ms = int(payload.get("ms") or 0)
+        return ApplyResult(ok=ok, data=data, errors=list(errors), notes=list(notes), ms=ms)
+    if isinstance(payload, tuple) and payload:
+        ok = bool(payload[0])
+        return ApplyResult(ok=ok)
+    return ApplyResult(ok=bool(payload))
+
+
+def apply(ctx: CommandContext, card_id: str) -> ApplyResult:
+    """Apply the action card by invoking the responsible plugin."""
+
+    logger = ctx.logger or logging.getLogger(__name__)
+    card = ctx.get_card(card_id)
+    if card is None:
+        return ApplyResult(ok=False, errors=[f"Unknown card {card_id}"])
+
+    approval_token = approvals.request_approval(card)
+    if approval_token is None or not approvals.can_apply(card):
+        return ApplyResult(ok=False, errors=["Approval denied"])
+
+    snapshot_path = create_snapshot(ctx.run_id)
+    module_name = card.proposed_by_plugin
+    try:
+        module = _load_plugin(module_name)
+        apply_fn = getattr(module, "apply", None)
+        if apply_fn is None:
+            return ApplyResult(ok=False, errors=["Plugin missing apply()"])
+        start = time.perf_counter()
+        payload = apply_fn(ctx, card_id, approval_token)
+        elapsed_ms = int((time.perf_counter() - start) * 1000)
+    except Exception as exc:  # pragma: no cover - defensive
+        logger.exception("apply.failed", extra={"card_id": card_id, "plugin": module_name})
+        elapsed_ms = 0
+        result = ApplyResult(ok=False, errors=[str(exc)])
+    else:
+        result = _normalise_apply_result(payload)
+        if result.ms == 0:
+            result.ms = elapsed_ms
+        if snapshot_path and "snapshot" not in result.data:
+            result.data.setdefault("snapshot", str(snapshot_path))
+        if result.ok:
+            card.state = "applied"
+    write_audit(
+        ctx.run_id,
+        plugin=module_name,
+        capability=card.kind,
+        scopes=[card.kind],
+        outcome="ok" if result.ok else "error",
+        ms=result.ms,
+        notes="; ".join(result.errors or result.notes),
+    )
+    uni_write(
+        "bus.apply.result",
+        ctx.run_id,
+        card_id=card_id,
+        ok=result.ok,
+        ms=result.ms,
+        errors=result.errors,
+    )
+    return result
+
+
+def run_master_index(ctx: CommandContext):
+    """Back-compat shim for the master index orchestration."""
+
+    findings = discover(ctx)
+    cards = plan(ctx, findings)
+    results: List[Tuple[str, ApplyResult]] = []
+    if not ctx.dry_run:
+        for card in cards:
+            if card.kind != "index.markdown":
+                continue
+            result = apply(ctx, card.id)
+            results.append((card.id, result))
+    ctx.extras["apply_results"] = results
+    return {
+        "findings": findings,
+        "cards": cards,
+        "apply_results": results,
+    }

--- a/core/bus/models.py
+++ b/core/bus/models.py
@@ -1,0 +1,69 @@
+"""Data models used by the command bus."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from typing import Any, Dict, List, Optional
+
+from core.action_cards.model import ActionCard
+
+
+@dataclass
+class PluginFinding:
+    """Discovery output from a plugin."""
+
+    plugin: str
+    records: List[Dict[str, Any]] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+    metadata: Dict[str, Any] = field(default_factory=dict)
+    partial: bool = False
+    reason: Optional[str] = None
+
+    def count(self) -> int:
+        return len(self.records)
+
+
+@dataclass
+class ApplyResult:
+    """Result returned from plugin apply hooks."""
+
+    ok: bool
+    data: Dict[str, Any] = field(default_factory=dict)
+    errors: List[str] = field(default_factory=list)
+    notes: List[str] = field(default_factory=list)
+    ms: int = 0
+
+
+@dataclass
+class RollbackResult:
+    """Result returned from plugin rollback hooks."""
+
+    ok: bool
+    notes: List[str] = field(default_factory=list)
+    errors: List[str] = field(default_factory=list)
+
+
+@dataclass
+class HealthStatus:
+    """Plugin health status response."""
+
+    ok: Optional[bool]
+    notes: List[str] = field(default_factory=list)
+
+
+@dataclass
+class CommandContext:
+    """Runtime context passed to bus operations and plugins."""
+
+    controller: Any
+    run_id: str
+    dry_run: bool
+    limits: Any = None
+    options: Dict[str, Any] = field(default_factory=dict)
+    logger: Any = None
+    findings: Dict[str, PluginFinding] = field(default_factory=dict)
+    cards: Dict[str, ActionCard] = field(default_factory=dict)
+    extras: Dict[str, Any] = field(default_factory=dict)
+
+    def get_card(self, card_id: str) -> Optional[ActionCard]:
+        return self.cards.get(card_id)

--- a/core/contracts/__init__.py
+++ b/core/contracts/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialization for contracts."""

--- a/core/contracts/common.py
+++ b/core/contracts/common.py
@@ -1,0 +1,69 @@
+"""Common contract primitives for core data transfer objects."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from datetime import datetime
+from pathlib import Path
+
+
+@dataclass(frozen=True)
+class ID:
+    """Strongly-typed identifier wrapper."""
+
+    value: str
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str) or not self.value.strip():
+            raise ValueError("ID must be a non-empty string")
+
+    def __str__(self) -> str:
+        return self.value
+
+
+@dataclass(frozen=True)
+class Timestamp:
+    """Immutable timestamp container."""
+
+    value: datetime
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, datetime):
+            raise TypeError("Timestamp value must be a datetime instance")
+
+    def isoformat(self) -> str:
+        return self.value.isoformat()
+
+    def __str__(self) -> str:
+        return self.isoformat()
+
+
+@dataclass(frozen=True)
+class PathRef:
+    """Filesystem path reference."""
+
+    value: Path
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, Path):
+            raise TypeError("PathRef value must be a pathlib.Path instance")
+
+    def __str__(self) -> str:
+        return str(self.value)
+
+
+@dataclass(frozen=True)
+class Checksum:
+    """Represents a checksum digest."""
+
+    value: str
+    algorithm: str = "sha256"
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.value, str) or not self.value:
+            raise ValueError("Checksum value must be a non-empty string")
+        if not isinstance(self.algorithm, str) or not self.algorithm:
+            raise ValueError("Checksum algorithm must be a non-empty string")
+
+    def __str__(self) -> str:
+        return f"{self.algorithm}:{self.value}"

--- a/core/contracts/inventory.py
+++ b/core/contracts/inventory.py
@@ -1,0 +1,52 @@
+"""Inventory contracts used across plugins and the controller core."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass, field
+from datetime import datetime
+from typing import List, Optional
+
+from .common import ID
+
+
+@dataclass
+class InventoryItem:
+    """Serializable representation of an inventory item."""
+
+    id: ID
+    sku: str
+    title: str
+    qty: int
+    cost: float
+    price: float
+    vendor_id: Optional[ID]
+    drive_file_ids: List[str] = field(default_factory=list)
+    notion_page_id: Optional[str] = None
+    created_at: Optional[datetime] = None
+    updated_at: Optional[datetime] = None
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, ID):
+            raise TypeError("id must be an ID instance")
+        if not isinstance(self.sku, str):
+            raise TypeError("sku must be a string")
+        if not isinstance(self.title, str):
+            raise TypeError("title must be a string")
+        if not isinstance(self.qty, int):
+            raise TypeError("qty must be an int")
+        for field_name, value in ("cost", self.cost), ("price", self.price):
+            if not isinstance(value, (int, float)):
+                raise TypeError(f"{field_name} must be numeric")
+        if self.vendor_id is not None and not isinstance(self.vendor_id, ID):
+            raise TypeError("vendor_id must be an ID or None")
+        if not isinstance(self.drive_file_ids, list):
+            raise TypeError("drive_file_ids must be a list")
+        for entry in self.drive_file_ids:
+            if not isinstance(entry, str):
+                raise TypeError("drive_file_ids entries must be strings")
+        if self.notion_page_id is not None and not isinstance(self.notion_page_id, str):
+            raise TypeError("notion_page_id must be a string or None")
+        for attr in ("created_at", "updated_at"):
+            value = getattr(self, attr)
+            if value is not None and not isinstance(value, datetime):
+                raise TypeError(f"{attr} must be datetime or None")

--- a/core/contracts/vendor.py
+++ b/core/contracts/vendor.py
@@ -1,0 +1,30 @@
+"""Vendor contracts used for inventory coordination."""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Optional
+
+from .common import ID
+
+
+@dataclass
+class Vendor:
+    """Serializable vendor record."""
+
+    id: ID
+    name: str
+    email: Optional[str]
+    phone: Optional[str]
+    drive_folder_id: Optional[str]
+    notion_page_id: Optional[str]
+
+    def __post_init__(self) -> None:
+        if not isinstance(self.id, ID):
+            raise TypeError("id must be an ID instance")
+        if not isinstance(self.name, str) or not self.name.strip():
+            raise ValueError("name must be a non-empty string")
+        for attr in ("email", "phone", "drive_folder_id", "notion_page_id"):
+            value = getattr(self, attr)
+            if value is not None and not isinstance(value, str):
+                raise TypeError(f"{attr} must be a string or None")

--- a/core/policy/__init__.py
+++ b/core/policy/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialization for policy."""

--- a/core/policy/approvals.py
+++ b/core/policy/approvals.py
@@ -1,0 +1,59 @@
+"""Approval helpers for gating state-changing operations."""
+
+from __future__ import annotations
+
+import os
+from typing import Optional
+from uuid import uuid4
+
+from core import policy_log
+from core.action_cards.model import ActionCard
+from core.unilog import write as uni_write
+
+
+def _auto_approve_enabled() -> bool:
+    """Return True when AUTO_APPROVE flag enables auto approvals."""
+
+    value = os.getenv("AUTO_APPROVE", "true").strip().lower()
+    return value in {"1", "true", "yes", "on"}
+
+
+def request_approval(card: ActionCard) -> Optional[str]:
+    """Request approval for the provided action card."""
+
+    uni_write("approvals.request", None, card_id=card.id, kind=card.kind)
+    token = f"approval-{uuid4()}"
+    if _auto_approve_enabled():
+        card.state = "approved"
+        uni_write("approvals.granted", None, card_id=card.id, token=token)
+        record_approval(token, card.id)
+        return token
+
+    answer = input(f"Approve action card {card.title}? [y/N]: ").strip().lower()
+    if answer not in {"y", "yes"}:
+        uni_write("approvals.denied", None, card_id=card.id)
+        return None
+
+    card.state = "approved"
+    uni_write("approvals.granted", None, card_id=card.id, token=token)
+    record_approval(token, card.id)
+    return token
+
+
+def record_approval(op_id: str, card_id: str, *, user: str = "local") -> None:
+    """Record an approval decision to the policy log."""
+
+    decision = {
+        "run_id": None,
+        "card_id": card_id,
+        "op_id": op_id,
+        "user": user,
+        "approved": True,
+    }
+    policy_log.log_policy(f"card:{card_id}", decision)
+
+
+def can_apply(card: ActionCard) -> bool:
+    """Return True if the card may proceed to apply."""
+
+    return card.state in {"approved", "applied"}

--- a/core/registry/__init__.py
+++ b/core/registry/__init__.py
@@ -1,0 +1,1 @@
+"""Package initialization for registry."""

--- a/core/registry/plugins_json.py
+++ b/core/registry/plugins_json.py
@@ -1,0 +1,36 @@
+"""Simple plugin registry backed by config/plugins.json."""
+
+from __future__ import annotations
+
+import json
+from functools import lru_cache
+from pathlib import Path
+from typing import Any
+
+from core.unilog import write as uni_write
+
+_CONFIG_PATH = Path("config") / "plugins.json"
+
+
+@lru_cache(maxsize=1)
+def _load_config() -> dict[str, Any]:
+    if not _CONFIG_PATH.exists():
+        return {}
+    try:
+        content = json.loads(_CONFIG_PATH.read_text(encoding="utf-8"))
+    except json.JSONDecodeError as exc:
+        uni_write("plugin.registry.error", None, error=str(exc), path=str(_CONFIG_PATH))
+        return {}
+    if not isinstance(content, dict):
+        return {}
+    return content
+
+
+def enabled(name: str) -> bool:
+    """Return True when the plugin is enabled in the registry."""
+
+    config = _load_config()
+    value = config.get(name)
+    if value is None:
+        return True
+    return bool(value)

--- a/plugins/discovery.drive/__init__.py
+++ b/plugins/discovery.drive/__init__.py
@@ -1,0 +1,88 @@
+"""Discovery plugin for Google Drive files."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, List
+
+from core.bus.models import ApplyResult, CommandContext, HealthStatus, RollbackResult
+from tgc.master_index_controller import MasterIndexController, TraversalLimits, collect_drive_files
+
+
+def discover(ctx: CommandContext) -> Dict[str, object]:
+    controller = getattr(ctx, "controller", None)
+    if controller is None:
+        return {"records": [], "errors": ["controller unavailable"], "roots": []}
+
+    master = MasterIndexController(controller)
+    drive_module = master._drive_module()
+    if drive_module is None:
+        return {
+            "records": [],
+            "errors": ["Google Drive module unavailable"],
+            "roots": [],
+            "message": "Google Drive module unavailable",
+        }
+
+    roots = master._drive_root_ids(drive_module)
+    ctx.extras.setdefault("drive_roots", roots)
+    metadata: Dict[str, object] = {"roots": roots}
+
+    start = time.perf_counter()
+    if ctx.dry_run and roots:
+        records = [
+            {
+                "name": f"(dry-run placeholder for root {root[:8]}…)",
+                "file_id": root,
+                "path_or_link": "/",
+                "mimeType": "",
+                "modifiedTime": "",
+                "size": "",
+            }
+            for root in roots
+        ]
+        metadata["elapsed"] = time.perf_counter() - start
+        return {"records": records, "errors": [], **metadata}
+
+    if not roots:
+        metadata["elapsed"] = time.perf_counter() - start
+        return {"records": [], "errors": [], **metadata}
+
+    mime_whitelist = list(drive_module.config.mime_whitelist) or None
+    limits = ctx.limits if isinstance(ctx.limits, TraversalLimits) else ctx.limits
+    result = collect_drive_files(
+        drive_module,
+        roots,
+        mime_whitelist=mime_whitelist,
+        max_depth=drive_module.config.max_depth,
+        page_size=drive_module.config.page_size,
+        limits=limits,
+    )
+    metadata["elapsed"] = time.perf_counter() - start
+    metadata["partial"] = result.partial
+    metadata["reason"] = result.reason
+    return {
+        "records": result.records,
+        "errors": result.errors,
+        **metadata,
+    }
+
+
+def propose(ctx: CommandContext, findings) -> List[Dict[str, object]]:  # pragma: no cover - optional hook
+    _ = ctx, findings
+    return []
+
+
+def apply(ctx: CommandContext, card_id: str, approval_token: str) -> ApplyResult:
+    _ = ctx, card_id, approval_token
+    return ApplyResult(ok=True)
+
+
+def rollback(ctx: CommandContext, op_id: str) -> RollbackResult:
+    _ = ctx, op_id
+    return RollbackResult(ok=True, notes=["Rollback not implemented for discovery plugins."])
+
+
+def health(ctx: CommandContext) -> HealthStatus:
+    _ = ctx
+    return HealthStatus(ok=True, notes=["Drive discovery available"])

--- a/plugins/discovery.notion/__init__.py
+++ b/plugins/discovery.notion/__init__.py
@@ -1,0 +1,85 @@
+"""Discovery plugin for Notion pages."""
+
+from __future__ import annotations
+
+import time
+from typing import Dict, List
+
+from core.bus.models import ApplyResult, CommandContext, HealthStatus, RollbackResult
+from tgc.master_index_controller import MasterIndexController, TraversalLimits, collect_notion_pages
+
+
+def discover(ctx: CommandContext) -> Dict[str, object]:
+    controller = getattr(ctx, "controller", None)
+    if controller is None:
+        return {"records": [], "errors": ["controller unavailable"], "roots": []}
+
+    master = MasterIndexController(controller)
+    notion_module = master._notion_module()
+    if notion_module is None:
+        return {
+            "records": [],
+            "errors": ["Notion module unavailable"],
+            "roots": [],
+            "message": "Notion module unavailable",
+        }
+
+    roots = master._notion_root_ids(notion_module)
+    ctx.extras.setdefault("notion_roots", roots)
+    metadata: Dict[str, object] = {"roots": roots}
+
+    start = time.perf_counter()
+    if ctx.dry_run and roots:
+        records = [
+            {
+                "title": f"(dry-run placeholder for root {root[:8]}…)",
+                "page_id": root,
+                "url": "",
+                "parent": "/",
+                "last_edited": "",
+            }
+            for root in roots
+        ]
+        metadata["elapsed"] = time.perf_counter() - start
+        return {"records": records, "errors": [], **metadata}
+
+    if not roots:
+        metadata["elapsed"] = time.perf_counter() - start
+        return {"records": [], "errors": [], **metadata}
+
+    limits = ctx.limits if isinstance(ctx.limits, TraversalLimits) else ctx.limits
+    result = collect_notion_pages(
+        notion_module,
+        roots,
+        max_depth=notion_module.config.max_depth,
+        page_size=notion_module.config.page_size,
+        limits=limits,
+    )
+    metadata["elapsed"] = time.perf_counter() - start
+    metadata["partial"] = result.partial
+    metadata["reason"] = result.reason
+    return {
+        "records": result.records,
+        "errors": result.errors,
+        **metadata,
+    }
+
+
+def propose(ctx: CommandContext, findings) -> List[Dict[str, object]]:  # pragma: no cover - optional hook
+    _ = ctx, findings
+    return []
+
+
+def apply(ctx: CommandContext, card_id: str, approval_token: str) -> ApplyResult:
+    _ = ctx, card_id, approval_token
+    return ApplyResult(ok=True)
+
+
+def rollback(ctx: CommandContext, op_id: str) -> RollbackResult:
+    _ = ctx, op_id
+    return RollbackResult(ok=True, notes=["Rollback not implemented for discovery plugins."])
+
+
+def health(ctx: CommandContext) -> HealthStatus:
+    _ = ctx
+    return HealthStatus(ok=True, notes=["Notion discovery available"])

--- a/plugins/discovery.sheets/__init__.py
+++ b/plugins/discovery.sheets/__init__.py
@@ -1,0 +1,37 @@
+"""Discovery plugin placeholder for Sheets index data."""
+
+from __future__ import annotations
+
+from typing import Dict, List
+
+from core.bus.models import ApplyResult, CommandContext, HealthStatus, RollbackResult
+
+
+def discover(ctx: CommandContext) -> Dict[str, object]:
+    roots = ctx.extras.get("drive_roots", [])
+    return {
+        "records": [],
+        "errors": [],
+        "roots": roots,
+        "message": "Sheets discovery deferred to writer plugin",
+    }
+
+
+def propose(ctx: CommandContext, findings) -> List[Dict[str, object]]:  # pragma: no cover - optional hook
+    _ = ctx, findings
+    return []
+
+
+def apply(ctx: CommandContext, card_id: str, approval_token: str) -> ApplyResult:
+    _ = ctx, card_id, approval_token
+    return ApplyResult(ok=True)
+
+
+def rollback(ctx: CommandContext, op_id: str) -> RollbackResult:
+    _ = ctx, op_id
+    return RollbackResult(ok=True, notes=["Sheets discovery has no side effects."])
+
+
+def health(ctx: CommandContext) -> HealthStatus:
+    _ = ctx
+    return HealthStatus(ok=True, notes=["Sheets discovery delegated to writer"]) 

--- a/plugins/writer.markdown/__init__.py
+++ b/plugins/writer.markdown/__init__.py
@@ -1,0 +1,77 @@
+"""Writer plugin that produces Master Index markdown reports."""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Dict, List
+
+from core.bus.models import ApplyResult, CommandContext, HealthStatus, RollbackResult
+from tgc.master_index_controller import NOTION_COLUMNS, render_markdown
+from tgc.reporting import write_drive_files_markdown
+
+
+def propose(ctx: CommandContext, input_data) -> List[Dict[str, object]]:  # pragma: no cover - optional hook
+    _ = ctx, input_data
+    return []
+
+
+def apply(ctx: CommandContext, card_id: str, approval_token: str) -> ApplyResult:
+    _ = approval_token
+    card = ctx.get_card(card_id)
+    if card is None:
+        return ApplyResult(ok=False, errors=[f"Unknown card {card_id}"])
+
+    data = card.data or {}
+    output_dir = Path(data.get("output_dir") or "docs/master_index_reports/unknown_run")
+    generated_at = data.get("generated_at") or ""
+
+    notion = data.get("notion", {})
+    drive = data.get("drive", {})
+
+    notion_records = notion.get("records") or []
+    drive_records = drive.get("records") or []
+
+    notion_errors: List[str] = list(notion.get("errors") or [])
+    drive_errors: List[str] = list(drive.get("errors") or [])
+
+    output_dir.mkdir(parents=True, exist_ok=True)
+
+    notion_path = output_dir / "notion_pages.md"
+    drive_paths: List[Path] = []
+
+    try:
+        notion_markdown = render_markdown(notion_records, "Master Index — Notion Pages", NOTION_COLUMNS, generated_at)
+        notion_path.write_text(notion_markdown, encoding="utf-8")
+    except OSError as exc:
+        notion_errors.append(f"Failed to write Notion index: {exc}")
+
+    try:
+        drive_paths = write_drive_files_markdown(output_dir, drive_records)
+    except OSError as exc:
+        drive_errors.append(f"Failed to write Drive index: {exc}")
+
+    errors = notion_errors + drive_errors
+    ok = not errors
+
+    payload = {
+        "output_dir": str(output_dir),
+        "notion_output": str(notion_path),
+        "drive_outputs": [str(path) for path in drive_paths],
+        "notion_errors": notion_errors,
+        "drive_errors": drive_errors,
+        "notion_count": len(notion_records),
+        "drive_count": len(drive_records),
+        "message": drive.get("message") or notion.get("message"),
+    }
+
+    return ApplyResult(ok=ok, data=payload, errors=errors)
+
+
+def rollback(ctx: CommandContext, op_id: str) -> RollbackResult:
+    _ = ctx, op_id
+    return RollbackResult(ok=True, notes=["Rollback not implemented for markdown writer"])
+
+
+def health(ctx: CommandContext) -> HealthStatus:
+    _ = ctx
+    return HealthStatus(ok=True, notes=["Markdown writer ready"])

--- a/tests/test_master_index.py
+++ b/tests/test_master_index.py
@@ -415,7 +415,7 @@ def test_master_index_action_writes_sheets_index(monkeypatch, tmp_path):
         def __init__(self, controller):
             self.controller = controller
 
-        def run_master_index(self, dry_run, *, limits=None):
+        def run_master_index(self, dry_run, *, limits=None, run_context=None):
             return {
                 "status": "ok",
                 "dry_run": dry_run,

--- a/tgc/actions/master_index.py
+++ b/tgc/actions/master_index.py
@@ -72,7 +72,9 @@ class MasterIndexAction(SimpleAction):
         plan_text = controller.build_plan(self.id)
         master = MasterIndexController(controller)
         limits = self._limits_from_context(context)
-        summary = master.run_master_index(dry_run=not context.apply, limits=limits)
+        summary = master.run_master_index(
+            dry_run=not context.apply, limits=limits, run_context=context
+        )
 
         notion_count = int(summary.get("notion_count", 0))
         drive_count = int(summary.get("drive_count", 0))


### PR DESCRIPTION
## Summary
- add core contracts, action card planner, approvals policy, backup snapshots, and a plugin registry for the thin core
- route the master index controller through a new command bus that discovers, plans, and applies via plugins while keeping existing behaviour
- adapt discovery and writer plugins to the new interface and preserve markdown outputs with the new configuration switch

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68ed1d16bc448322b51bf1b87ceec8f9