### PR TITLE
Add render_root alias for legacy app compatibility

### DIFF
--- a/core/menu_render.py
+++ b/core/menu_render.py
@@ -163,3 +163,9 @@ def render_status_plugins_overview(payload: Dict[str, Any]) -> None:
         "apis_ready": api_ready_count,
     }
     unilog_write("menu.view.status_plugins", None, counts=counts)
+
+
+# --- Backward compatibility alias (legacy support for app.py) ---
+def render_root(quiet: bool = False) -> None:
+    """Legacy entrypoint. Calls render_main_menu()."""
+    return render_main_menu(quiet=quiet)


### PR DESCRIPTION
## Summary
- add a legacy render_root alias that delegates to render_main_menu to restore compatibility with older app entrypoints

## Testing
- python -c "import core.menu_render as m; print('has render_root:', hasattr(m,'render_root'))"
- python app.py


------
https://chatgpt.com/codex/tasks/task_e_68ed2bd8eacc8322a62410bbaa5a59e7