### PR TITLE
Normalize Drive credential path resolution

### DIFF
--- a/tgc/integration_support.py
+++ b/tgc/integration_support.py
@@ -6,6 +6,8 @@ import json
 from pathlib import Path
 from typing import Optional
 
+from core.conn_broker import resolve_service_account_path
+
 from .modules.google_drive import DriveModuleConfig
 
 _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER = "service-account@example.com"
@@ -36,10 +38,30 @@ def service_account_email(module_config: DriveModuleConfig) -> Optional[str]:
     return None
 
 
+def _read_service_account_email(creds_path: Path) -> Optional[str]:
+    try:
+        data = json.loads(creds_path.read_text(encoding="utf-8"))
+    except Exception:
+        return None
+    email = data.get("client_email")
+    if isinstance(email, str):
+        trimmed = email.strip()
+        if trimmed:
+            return trimmed
+    return None
+
+
+def _resolved_service_account_email() -> Optional[str]:
+    creds_path = resolve_service_account_path()
+    if not creds_path.is_file():
+        return None
+    return _read_service_account_email(creds_path)
+
+
 def format_sheets_missing_env_message(email: Optional[str]) -> str:
     """Return a consistent warning about missing Sheets configuration."""
 
-    share_target = email or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
+    share_target = email or _resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
     return (
         "Sheets is not configured. Set SHEET_INVENTORY_ID in .env (File → Share with: "
         f"{share_target})."
@@ -49,7 +71,7 @@ def format_sheets_missing_env_message(email: Optional[str]) -> str:
 def sheets_share_hint(email: Optional[str]) -> str:
     """Return guidance for sharing the spreadsheet with the service account."""
 
-    share_target = email or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
+    share_target = email or _resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
     return (
         f"Share the sheet with {share_target} as Viewer. Set SHEET_INVENTORY_ID in .env."
     )
@@ -58,7 +80,7 @@ def sheets_share_hint(email: Optional[str]) -> str:
 def format_drive_share_message(root_id: str, email: Optional[str]) -> str:
     """Return a consistent instruction to share a Drive root with the service account."""
 
-    share_target = email or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
+    share_target = email or _resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
     return f"Share {root_id} with {share_target} and retry."
 
 


### PR DESCRIPTION
## Summary
- add a canonical resolver for the Google service account credentials path that prefers the bundled credentials file and logs missing files only once
- surface the resolved credentials metadata during bootstrap with clearer hints when the file is missing or invalid
- update Sheets and Drive share guidance to read the actual service-account email when available

## Testing
- pytest tests/test_master_index.py

------
https://chatgpt.com/codex/tasks/task_e_68ed8129db3c83229e1704143b9c7b25