### PR TITLE
Refine credential resolution and alpha boot reporting

### DIFF
--- a/tgc/bootstrap_fs.py
+++ b/tgc/bootstrap_fs.py
@@ -58,21 +58,22 @@ def detect_credentials() -> Tuple[bool, Dict[str, str], str]:
     """Returns (present, meta, hint)."""
 
     creds_path = resolve_service_account_path()
+    meta: Dict[str, str] = {"path": str(creds_path)}
     if creds_path.is_file():
-        meta = _read_json_head(creds_path)
+        meta.update(_read_json_head(creds_path))
         if meta.get("type") == "service_account":
             return True, meta, f"Using credentials at: {creds_path}"
         return False, meta, (
-            "Credentials file found but not a service account JSON: " f"{creds_path}"
+            "Credentials file found but not a service account JSON: "
+            f"{creds_path}"
         )
     if creds_path.exists():
-        return False, {}, f"Credentials path is not a file: {creds_path}"
-    return (
-        False,
-        {},
-        "Missing credentials. Place your service account JSON at: "
-        f"{creds_path} or set GOOGLE_APPLICATION_CREDENTIALS (see .env).",
-    )
+        return False, meta, f"Credentials path is not a file: {creds_path}"
+    hint_lines = [
+        f"Missing credentials at {creds_path}",
+        "Place your Google service account JSON there or set GOOGLE_APPLICATION_CREDENTIALS.",
+    ]
+    return False, meta, "\n".join(hint_lines)
 
 
 def ensure_first_run() -> Dict[str, str]:
@@ -86,6 +87,7 @@ def ensure_first_run() -> Dict[str, str]:
         "creds_present": "yes" if present else "no",
         "creds_email": meta.get("client_email", "") if present else "",
         "creds_project": meta.get("project_id", "") if present else "",
+        "creds_path": meta.get("path", ""),
         "hint": hint,
     }
     return status

--- a/tgc/cli_main.py
+++ b/tgc/cli_main.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 
 import argparse
 import json
+import logging
 from datetime import UTC, datetime
 from typing import Dict, List, Optional
 
@@ -12,6 +13,9 @@ from core.conn_broker import ConnectionBroker
 from core.plugins_alpha import discover_alpha_plugins as _discover_alpha_plugins
 from tgc.bootstrap import bootstrap_controller
 from tgc.bootstrap_fs import ensure_first_run
+
+
+logger = logging.getLogger(__name__)
 
 
 def _mk_context(controller, run_id: str, *, dry_run: bool = False) -> CommandContext:
@@ -35,30 +39,39 @@ def _effective_config(args) -> Dict[str, object]:
     }
 
 
-def _print_status(output, run_id: str, services: Dict[str, dict], plugins: List[str], effective: Dict[str, object]):
-    def _fmt_status(value: Dict[str, object]) -> str:
-        if value.get("ok"):
-            return "OK"
-        detail = value.get("detail", "")
-        if detail in {"missing_credentials", "creds_path_missing", "not_configured"}:
-            return "PENDING"
-        return "FAIL"
+def _plugin_display_name(plugin) -> str:
+    plugin_id = getattr(plugin, "id", "")
+    module_name = getattr(plugin.__class__, "__module__", "")
+    if isinstance(plugin_id, str) and plugin_id.startswith("plugins"):
+        return plugin_id
+    if module_name:
+        return module_name
+    if plugin_id:
+        return plugin_id
+    return plugin.__class__.__name__
 
-    output(
-        f"[run:{run_id}] mode=alpha fast={bool(effective.get('fast'))} "
-        f"timeout_sec={effective.get('timeout_sec')} max_files={effective.get('max_files')} "
-        f"max_pages={effective.get('max_pages')} page_size={effective.get('page_size')}"
-    )
-    output("Services:")
-    for service, result in sorted(services.items()):
-        badge = _fmt_status(result if isinstance(result, dict) else {"ok": False})
-        hint = ""
-        if isinstance(result, dict):
-            hint = result.get("hint") or result.get("error") or result.get("detail") or ""
-        output(f"  - {service}: {badge}{f' ({hint})' if hint else ''}")
-    output(f"Plugins enabled: {len(plugins)}")
-    for plugin in sorted(plugins):
-        output(f"  - {plugin}")
+
+def _summarize_probe_result(result: object) -> Dict[str, Optional[str]]:
+    summary: Dict[str, Optional[str]] = {"status": "OK", "note": None, "detail": None}
+    if not isinstance(result, dict):
+        summary.update({"status": "WARN", "note": "unexpected probe response"})
+        return summary
+    ok_value = result.get("ok")
+    detail = str(result.get("detail", "") or "").strip()
+    hint = str(result.get("hint", "") or "").strip() or None
+    if ok_value in (True, None):
+        summary.update({"detail": detail or None})
+        return summary
+    if detail in {"creds_path_missing", "missing_credentials", "client_unavailable"}:
+        summary.update({"status": "ERROR", "note": "see log", "detail": detail or None})
+        return summary
+    if detail == "not_configured":
+        note = "no SHEET_INVENTORY_ID" if hint and "SHEET_INVENTORY_ID" in hint else "not configured"
+        summary.update({"status": "WARN", "note": note, "detail": detail})
+        return summary
+    note = hint or detail or None
+    summary.update({"status": "WARN", "note": note, "detail": detail or None})
+    return summary
 
 
 def _start_full_crawl(context: CommandContext, effective_options: Dict[str, object]):
@@ -72,13 +85,23 @@ def alpha_boot(args):
     output = print
     bootstrap = ensure_first_run()
     output("=== TGC Alpha Boot ===")
-    project = f" project={bootstrap['creds_project']}" if bootstrap.get("creds_project") else ""
-    email = f" email={bootstrap['creds_email']}" if bootstrap.get("creds_email") else ""
-    output(
-        f"Setup: env_created={bootstrap['env_created']} creds_present={bootstrap['creds_present']}{project}{email}"
-    )
-    if bootstrap.get("hint"):
-        output(f"Hint: {bootstrap['hint']}")
+    parts = [
+        f"env_created={bootstrap['env_created']}",
+        f"creds_present={bootstrap['creds_present']}",
+    ]
+    if bootstrap.get("creds_project"):
+        parts.append(f"project={bootstrap['creds_project']}")
+    if bootstrap.get("creds_email"):
+        parts.append(f"email={bootstrap['creds_email']}")
+    output(f"Setup: {' '.join(parts)}")
+    hint = bootstrap.get("hint")
+    if hint:
+        lines = str(hint).splitlines()
+        if lines:
+            output(f"Hint: {lines[0]}")
+            indent = " " * len("Hint: ")
+            for line in lines[1:]:
+                output(f"{indent}{line}")
     controller = bootstrap_controller()
     run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     context = _mk_context(controller, run_id, dry_run=bool(getattr(args, "dry_run", False)))
@@ -86,25 +109,65 @@ def alpha_boot(args):
     context.extras["conn_broker"] = broker
 
     plugins_instances = _discover_alpha_plugins()
-    plugin_names = [getattr(plugin, "name", getattr(plugin, "id", "plugin")) for plugin in plugins_instances]
-
+    plugin_names: List[str] = []
+    plugin_summaries: List[Dict[str, object]] = []
     services: Dict[str, dict] = {}
     for plugin in plugins_instances:
+        display_name = _plugin_display_name(plugin)
+        plugin_names.append(display_name)
+        summary: Dict[str, object] = {"plugin": display_name, "status": "OK", "note": None}
         try:
             description = plugin.describe() or {}
-        except Exception as exc:
-            services[f"plugin:{getattr(plugin, 'id', 'unknown')}"] = {"ok": False, "detail": str(exc)}
+        except Exception:
+            logger.exception("alpha.plugin.describe_failed", extra={"plugin": display_name})
+            summary.update({"status": "ERROR", "note": "see log", "detail": "describe_failed"})
+            plugin_summaries.append(summary)
             continue
-        for svc in description.get("services", []):
-            if svc not in services:
-                services[svc] = broker.probe(svc)
+        services_list = [svc for svc in description.get("services", []) if isinstance(svc, str)]
+        pending_services = [svc for svc in services_list if svc not in services]
         try:
-            plugin.probe(broker)
-        except Exception as exc:
-            services[f"plugin:{getattr(plugin, 'id', 'unknown')}"] = {"ok": False, "detail": str(exc)}
+            probe_result = plugin.probe(broker)
+        except Exception:
+            logger.exception("alpha.plugin.probe_failed", extra={"plugin": display_name})
+            summary.update({"status": "ERROR", "note": "see log", "detail": "probe_failed"})
+            plugin_summaries.append(summary)
+            continue
+        probe_summary = _summarize_probe_result(probe_result)
+        summary.update(probe_summary)
+        if summary.get("status") != "OK":
+            logger.warning(
+                "alpha.plugin.probe_status",
+                extra={
+                    "plugin": display_name,
+                    "status": summary.get("status"),
+                    "detail": summary.get("detail") or summary.get("note"),
+                },
+            )
+        if isinstance(probe_result, dict):
+            summary["probe"] = probe_result
+            service_name = probe_result.get("service")
+            if isinstance(service_name, str) and service_name not in services:
+                services[service_name] = probe_result
+                if service_name in pending_services:
+                    pending_services.remove(service_name)
+        else:
+            summary["probe"] = None
+        for svc in pending_services:
+            services[svc] = broker.probe(svc)
+        plugin_summaries.append(summary)
+
+    output("Services:")
+    if plugin_summaries:
+        for summary in plugin_summaries:
+            line = f"  - {summary['plugin']}: {summary['status']}"
+            note = summary.get("note")
+            if note:
+                line += f" ({note})"
+            output(line)
+    else:
+        output("  - (no plugins discovered)")
 
     effective = _effective_config(args)
-    _print_status(output, run_id, services, plugin_names, effective)
 
     if getattr(args, "json", False):
         summary = {
@@ -112,6 +175,7 @@ def alpha_boot(args):
             "mode": "alpha",
             "services": services,
             "plugins": plugin_names,
+            "plugin_status": plugin_summaries,
             "effective": effective,
         }
         output(json.dumps(summary, indent=2, sort_keys=True))

--- a/tgc/integration_support.py
+++ b/tgc/integration_support.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Optional
 
-from core.conn_broker import resolve_service_account_path
+from core.conn_broker import resolved_service_account_email
 
 from .modules.google_drive import DriveModuleConfig
 
@@ -38,30 +38,10 @@ def service_account_email(module_config: DriveModuleConfig) -> Optional[str]:
     return None
 
 
-def _read_service_account_email(creds_path: Path) -> Optional[str]:
-    try:
-        data = json.loads(creds_path.read_text(encoding="utf-8"))
-    except Exception:
-        return None
-    email = data.get("client_email")
-    if isinstance(email, str):
-        trimmed = email.strip()
-        if trimmed:
-            return trimmed
-    return None
-
-
-def _resolved_service_account_email() -> Optional[str]:
-    creds_path = resolve_service_account_path()
-    if not creds_path.is_file():
-        return None
-    return _read_service_account_email(creds_path)
-
-
 def format_sheets_missing_env_message(email: Optional[str]) -> str:
     """Return a consistent warning about missing Sheets configuration."""
 
-    share_target = email or _resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
+    share_target = email or resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
     return (
         "Sheets is not configured. Set SHEET_INVENTORY_ID in .env (File → Share with: "
         f"{share_target})."
@@ -71,7 +51,7 @@ def format_sheets_missing_env_message(email: Optional[str]) -> str:
 def sheets_share_hint(email: Optional[str]) -> str:
     """Return guidance for sharing the spreadsheet with the service account."""
 
-    share_target = email or _resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
+    share_target = email or resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
     return (
         f"Share the sheet with {share_target} as Viewer. Set SHEET_INVENTORY_ID in .env."
     )
@@ -80,7 +60,7 @@ def sheets_share_hint(email: Optional[str]) -> str:
 def format_drive_share_message(root_id: str, email: Optional[str]) -> str:
     """Return a consistent instruction to share a Drive root with the service account."""
 
-    share_target = email or _resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
+    share_target = email or resolved_service_account_email() or _DEFAULT_SERVICE_ACCOUNT_PLACEHOLDER
     return f"Share {root_id} with {share_target} and retry."
 
 


### PR DESCRIPTION
## Summary
- update the connection broker to prefer explicit GOOGLE_APPLICATION_CREDENTIALS paths, fall back to the repo credentials directory, and expose the resolved service-account email
- improve bootstrap credential detection hints so missing and present credentials report clear paths and metadata
- restructure the alpha boot console flow to show core status then plugin handshakes with concise OK/WARN/ERROR summaries and surface real Sheets share targets

## Testing
- python app.py
- python app.py alpha --json

------
https://chatgpt.com/codex/tasks/task_e_68ed88aaee5c8322bd281c25f85aa5d5