### PR TITLE
Add HTTP core server with plugin v2 discovery

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,24 +24,36 @@ Google Drive, Sheets, Notion, and any other integrations live entirely in plugin
 
 ---
 
-## Quickstart (HTTP)
+## Alpha Core (HTTP) — v.a0.01.2
 
-```bash
+Install deps:
+
+```
 python -m pip install -r requirements.txt
+python -m pip install fastapi uvicorn[standard] pydantic
+```
+
+Start server:
+
+```
 python app.py serve
-# Copy the session token from console or data\session_token.txt
+# or: python app.py alpha --serve
 ```
 
-```powershell
-$token = type .\data\session_token.txt
-irm http://127.0.0.1:8765/health -Headers @{ 'X-Session-Token' = $token }
-irm http://127.0.0.1:8765/plugins -Headers @{ 'X-Session-Token' = $token }
-irm http://127.0.0.1:8765/probe -Method Post -Headers @{ 'X-Session-Token' = $token } -ContentType "application/json" -Body "{}"
+Auth:
+
+```
+$token = Get-Content .\data\session_token.txt
+irm http://127.0.0.1:8765/health  -Headers @{ 'X-Session-Token'=$token }
+irm http://127.0.0.1:8765/plugins -Headers @{ 'X-Session-Token'=$token }
+irm http://127.0.0.1:8765/probe   -Method Post -Headers @{ 'X-Session-Token'=$token } -ContentType application/json -Body "{}"
 ```
 
-* `/health` reports the running version and session.
-* `/plugins` lists the plugins that registered providers.
-* `/probe` asks the broker to check each requested service.
+Plugins:
+
+* Put plugins under `plugins_alpha/<your_plugin>/plugin.py`
+* Implement `Plugin(PluginV2)` with `describe()` and `register_broker()`
+* Core remains silent until a plugin declares services.
 
 ---
 

--- a/core/api/http.py
+++ b/core/api/http.py
@@ -4,24 +4,29 @@ import secrets
 import threading
 import time
 from datetime import datetime, timezone
-from typing import Any, Dict, List, Optional, Tuple
+from typing import Any, Dict, List, Optional
 
 from fastapi import FastAPI, Header, HTTPException
 from pydantic import BaseModel
 
 from core.conn_broker import ConnectionBroker
 from core.version import VERSION
-from tgc.bootstrap_fs import LOGS, TOKEN_FILE, ensure_first_run
+from tgc.bootstrap_fs import DATA, LOGS, ensure_first_run
 
-# Ensure filesystem bootstrap happens before any runtime writes.
 ensure_first_run()
 
 APP = FastAPI(title="TGC Alpha Core", version=VERSION)
 RUN_ID = datetime.now(timezone.utc).strftime("%Y%m%dT%H%M%SZ")
 SESSION_TOKEN = secrets.token_urlsafe(24)
-TOKEN_FILE.write_text(SESSION_TOKEN, encoding="utf-8")
+(DATA / "session_token.txt").write_text(SESSION_TOKEN, encoding="utf-8")
 
 LOG_FILE = LOGS / f"core_{RUN_ID}.log"
+
+
+def log(msg: str) -> None:
+    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
+    with LOG_FILE.open("a", encoding="utf-8") as handle:
+        handle.write(msg.rstrip() + "\n")
 
 
 class ProbeReq(BaseModel):
@@ -36,12 +41,6 @@ class CrawlReq(BaseModel):
 _CRAWLS: Dict[str, Dict[str, Any]] = {}
 
 
-def _log(msg: str) -> None:
-    LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
-    with LOG_FILE.open("a", encoding="utf-8") as fh:
-        fh.write(msg.rstrip() + "\n")
-
-
 def _require_token(token: Optional[str]) -> None:
     if token != SESSION_TOKEN:
         raise HTTPException(status_code=401, detail="Invalid session token")
@@ -49,43 +48,44 @@ def _require_token(token: Optional[str]) -> None:
 
 def _discover_plugins() -> List[Any]:
     try:
-        from core.plugins_alpha import discover_alpha_plugins  # v2-only loader
+        from core.plugins_alpha import discover_alpha_plugins
 
         return discover_alpha_plugins()
     except Exception:
         return []
 
 
+def _register_providers(broker: ConnectionBroker, plugins: List[Any]) -> None:
+    for plugin in plugins:
+        if hasattr(plugin, "register_broker"):
+            try:
+                plugin.register_broker(broker)
+            except Exception:
+                pass
+
+
 def _probe_services(broker: ConnectionBroker, services: List[str]) -> Dict[str, Dict[str, Any]]:
-    results: Dict[str, Dict[str, Any]] = {}
-    for svc in services:
-        results[svc] = broker.probe(svc)
-    return results
+    return {service: broker.probe(service) for service in services}
 
 
-def _start_crawl_async(run_id: str, limits: Optional[Dict[str, Any]] = None) -> None:
-    state = _CRAWLS[run_id] = {
-        "state": "running",
-        "progress": 0,
-        "stats": {},
-        "last_error": None,
-    }
+def _start_crawl_async(run_id: str, limits: Dict[str, Any]) -> None:
+    state = _CRAWLS[run_id] = {"state": "running", "progress": 0, "stats": {}, "last_error": None}
 
-    def worker() -> None:
+    def work() -> None:
         try:
             for index in range(1, 11):
                 time.sleep(0.5)
                 state["progress"] = index * 10
-                _log(f"[{run_id}] progress={state['progress']}")
+                log(f"[{run_id}] progress={state['progress']}")
             state["state"] = "done"
             state["stats"] = {"items": 123, "duration_sec": 5}
-            _log(f"[{run_id}] done")
+            log(f"[{run_id}] done")
         except Exception as exc:  # pragma: no cover - defensive guard
             state["state"] = "error"
             state["last_error"] = str(exc)
-            _log(f"[{run_id}] error: {exc}")
+            log(f"[{run_id}] error: {exc}")
 
-    threading.Thread(target=worker, name=f"crawl-{run_id}", daemon=True).start()
+    threading.Thread(target=work, daemon=True).start()
 
 
 @APP.get("/health")
@@ -99,40 +99,35 @@ def plugins(x_session_token: Optional[str] = Header(default=None, convert_unders
     _require_token(x_session_token)
     plugs = _discover_plugins()
     out: List[Dict[str, Any]] = []
-    for p in plugs:
+    for plugin in plugs:
         try:
-            desc = p.describe() or {}
+            desc = plugin.describe() or {}
         except Exception:
             desc = {}
         out.append(
             {
-                "id": getattr(p, "id", p.__class__.__name__),
-                "name": getattr(p, "name", p.__class__.__name__),
+                "id": getattr(plugin, "id", plugin.__class__.__name__),
+                "name": getattr(plugin, "name", plugin.__class__.__name__),
                 "services": list(desc.get("services", [])),
                 "scopes": list(desc.get("scopes", [])),
-                "version": getattr(p, "version", "0"),
+                "version": getattr(plugin, "version", "0"),
             }
         )
     return out
 
 
 @APP.post("/probe")
-def probe(
-    body: ProbeReq,
-    x_session_token: Optional[str] = Header(default=None, convert_underscores=False),
-) -> Dict[str, Any]:
+def probe(body: ProbeReq, x_session_token: Optional[str] = Header(default=None, convert_underscores=False)) -> Dict[str, Any]:
     _require_token(x_session_token)
     bootstrap = ensure_first_run()
     plugs = _discover_plugins()
     broker = ConnectionBroker(controller=None)
-    for p in plugs:
-        if hasattr(p, "register_broker"):
-            p.register_broker(broker)
+    _register_providers(broker, plugs)
     declared = sorted(
         {
             svc
-            for p in plugs
-            for svc in (getattr(p, "describe", lambda: {})() or {}).get("services", [])
+            for plugin in plugs
+            for svc in (getattr(plugin, "describe", lambda: {})() or {}).get("services", [])
         }
     )
     services = body.services or declared
@@ -143,10 +138,7 @@ def probe(
 
 
 @APP.post("/crawl")
-def crawl(
-    body: CrawlReq,
-    x_session_token: Optional[str] = Header(default=None, convert_underscores=False),
-) -> Dict[str, str]:
+def crawl(body: CrawlReq, x_session_token: Optional[str] = Header(default=None, convert_underscores=False)) -> Dict[str, str]:
     _require_token(x_session_token)
     run_id = f"crawl-{int(time.time())}"
     _start_crawl_async(run_id, body.limits or {})
@@ -154,9 +146,7 @@ def crawl(
 
 
 @APP.get("/crawl/{run_id}/status")
-def crawl_status(
-    run_id: str, x_session_token: Optional[str] = Header(default=None, convert_underscores=False)
-) -> Dict[str, Any]:
+def crawl_status(run_id: str, x_session_token: Optional[str] = Header(default=None, convert_underscores=False)) -> Dict[str, Any]:
     _require_token(x_session_token)
     return _CRAWLS.get(run_id, {"state": "unknown"})
 
@@ -166,15 +156,10 @@ def logs(x_session_token: Optional[str] = Header(default=None, convert_underscor
     _require_token(x_session_token)
     if not LOG_FILE.exists():
         return "no logs yet"
-    lines = LOG_FILE.read_text(encoding="utf-8").splitlines()
-    tail = lines[-200:]
-    return "\n".join(tail)
+    return "\n".join(LOG_FILE.read_text(encoding="utf-8").splitlines()[-200:])
 
 
-def build_app() -> Tuple[FastAPI, str]:
+def build_app():
     ensure_first_run()
-    _log(f"session_token={SESSION_TOKEN}")
+    log(f"session_token={SESSION_TOKEN}")
     return APP, SESSION_TOKEN
-
-
-__all__ = ["APP", "build_app"]

--- a/core/contracts/plugin_v2.py
+++ b/core/contracts/plugin_v2.py
@@ -7,12 +7,12 @@ class PluginV2:
     id: str = "plugin"
     name: str = "Alpha Plugin"
     version: str = "0.1"
+    api_version: str = "2"
 
     def describe(self) -> Dict[str, Any]:
         return {"services": [], "scopes": ["read_base"]}
 
     def register_broker(self, broker: ConnectionBroker) -> None:
-        """Plugins must call broker.register(service, provider=..., probe=...) for each service."""
         raise NotImplementedError
 
     def run(self, broker: ConnectionBroker, options: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:

--- a/core/plugins_alpha.py
+++ b/core/plugins_alpha.py
@@ -1,6 +1,5 @@
 from __future__ import annotations
-import importlib
-import pkgutil
+import importlib, pkgutil
 from typing import List
 from core.contracts.plugin_v2 import PluginV2
 
@@ -8,10 +7,15 @@ from core.contracts.plugin_v2 import PluginV2
 def discover_alpha_plugins() -> List[PluginV2]:
     plugins: List[PluginV2] = []
     for _, name, _ in pkgutil.iter_modules(['plugins_alpha']):
-        try:
-            mod = importlib.import_module(f"plugins_alpha.{name}")
-        except Exception:
+        if name.startswith("_"):
             continue
+        try:
+            mod = importlib.import_module(f"plugins_alpha.{name}.plugin")
+        except Exception:
+            try:
+                mod = importlib.import_module(f"plugins_alpha.{name}")
+            except Exception:
+                continue
         cls = getattr(mod, "Plugin", None)
         if cls and issubclass(cls, PluginV2):
             plugins.append(cls())

--- a/plugins_alpha/_template/__init__.py
+++ b/plugins_alpha/_template/__init__.py
@@ -1,0 +1,1 @@
+"""Template plugin package."""

--- a/plugins_alpha/_template/plugin.py
+++ b/plugins_alpha/_template/plugin.py
@@ -1,0 +1,19 @@
+from core.contracts.plugin_v2 import PluginV2
+from core.conn_broker import ConnectionBroker, ClientHandle
+
+
+class Plugin(PluginV2):
+    id = "your_plugin_id"
+    name = "Your Plugin Name"
+    version = "0.1"
+    api_version = "2"
+
+    def describe(self):
+        return {"services": [], "scopes": ["read_base"]}
+
+    def register_broker(self, broker: ConnectionBroker):
+        # broker.register("service_name", provider=..., probe=...)
+        pass
+
+    def run(self, broker: ConnectionBroker, options=None):
+        return {"ok": True}

--- a/plugins_alpha/echo/__init__.py
+++ b/plugins_alpha/echo/__init__.py
@@ -1,0 +1,1 @@
+"""Echo development plugin."""

--- a/plugins_alpha/echo/plugin.py
+++ b/plugins_alpha/echo/plugin.py
@@ -1,0 +1,21 @@
+from core.contracts.plugin_v2 import PluginV2
+from core.conn_broker import ConnectionBroker, ClientHandle
+
+
+class Plugin(PluginV2):
+    id = "echo"
+    name = "Echo Service"
+    version = "0.1"
+    api_version = "2"
+
+    def describe(self):
+        return {"services": ["echo"], "scopes": ["read_base"]}
+
+    def register_broker(self, broker: ConnectionBroker):
+        def provider(scope: str):
+            return ClientHandle(service="echo", scope=scope, handle={"scope": scope})
+
+        def probe(handle):
+            return {"ok": True, "detail": "echo_ready"}
+
+        broker.register("echo", provider=provider, probe=probe)

--- a/plugins_alpha/google_drive/plugin.py
+++ b/plugins_alpha/google_drive/plugin.py
@@ -1,48 +1,17 @@
 from __future__ import annotations
-import os
-from pathlib import Path
-from typing import Dict, Any, Optional
-from google.oauth2.service_account import Credentials
-from googleapiclient.discovery import build
+
+from core.conn_broker import ConnectionBroker
 from core.contracts.plugin_v2 import PluginV2
-from core.conn_broker import ConnectionBroker, ClientHandle
 
 
 class Plugin(PluginV2):
     id = "google_drive"
-    name = "Google Drive Provider"
-    version = "0.1"
+    name = "Google Drive Provider (disabled)"
+    version = "0.0"
+    api_version = "2"
 
-    def describe(self) -> Dict[str, Any]:
-        return {"services": ["drive"], "scopes": ["read_base", "read_crawl"]}
+    def describe(self):
+        return {"services": [], "scopes": []}
 
-    def register_broker(self, broker: ConnectionBroker) -> None:
-        def provider(scope: str) -> Optional[ClientHandle]:
-            creds_path = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
-            if creds_path and not Path(creds_path).is_absolute():
-                creds_path = str((Path(__file__).resolve().parents[2] / creds_path).resolve())
-            if not creds_path or not Path(creds_path).exists():
-                return None
-            scopes = ["https://www.googleapis.com/auth/drive.readonly"]
-            creds = Credentials.from_service_account_file(creds_path, scopes=scopes)
-            service = build("drive", "v3", credentials=creds, cache_discovery=False)
-            return ClientHandle(service="drive", scope=scope, handle=service, metadata={})
-
-        def probe(handle: Optional[ClientHandle]) -> Dict[str, Any]:
-            if handle is None:
-                cp = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
-                if cp and not Path(cp).is_absolute():
-                    cp = str((Path(__file__).resolve().parents[2] / cp).resolve())
-                if not cp:
-                    return {"ok": False, "detail": "missing_credentials", "hint": "Set GOOGLE_APPLICATION_CREDENTIALS or edit .env"}
-                if not Path(cp).exists():
-                    return {"ok": False, "detail": "creds_path_missing", "hint": f"File not found: {cp}"}
-                return {"ok": False, "detail": "client_unavailable"}
-            try:
-                svc = handle.handle
-                svc.files().list(pageSize=1, q="trashed=false", supportsAllDrives=True, includeItemsFromAllDrives=True).execute()
-                return {"ok": True}
-            except Exception as e:
-                return {"ok": False, "detail": "probe_error", "error": str(e)}
-
-        broker.register("drive", provider=provider, probe=probe)
+    def register_broker(self, broker: ConnectionBroker):
+        return None

--- a/tgc/cli_main.py
+++ b/tgc/cli_main.py
@@ -187,6 +187,10 @@ def alpha_boot(args):
         output("\nStarting full crawl/index...")
         _start_full_crawl(context, effective)
 
+    if getattr(args, "serve", False):
+        serve_cmd(args)
+        return
+
 
 def _wire_alpha(subparsers):
     alpha = subparsers.add_parser("alpha", help="Alpha boot: setup, probe, list plugins; crawl only when requested")
@@ -198,6 +202,8 @@ def _wire_alpha(subparsers):
     alpha.add_argument("--page-size", type=int, default=None)
     alpha.add_argument("--dry-run", action="store_true")
     alpha.add_argument("--json", action="store_true")
+    alpha.add_argument("--serve", action="store_true", help="After boot, start HTTP server on localhost")
+    alpha.add_argument("--port", type=int, default=8765)
     alpha.set_defaults(func=alpha_boot)
 
 


### PR DESCRIPTION
## Summary
- replace the connection broker with a pluggable service that relies on plugins for providers and probes
- add a FastAPI-based localhost HTTP server, bootstrap helpers, and CLI flags to serve alpha core with v2 plugin discovery only
- document the HTTP workflow and ship template/echo plugins while neutralizing built-in Google Drive wiring

## Testing
- python app.py serve *(fails: ModuleNotFoundError: No module named 'fastapi'; fastapi/uvicorn are not preinstalled in the environment)*

------
https://chatgpt.com/codex/tasks/task_e_68ed9f4695e483228b18158bdb3731e3