### PR TITLE
Add capability registry and expose capability endpoints

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # 🤖 TGC Alpha Core
 
-**Version: v.a0.01.2**
+**Version: v.a0.01.3**
 
 > A small, opinionated controller that boots, checks connections, shows status — and only digs deeper when you ask.
 
@@ -24,7 +24,7 @@ Google Drive, Sheets, Notion, and any other integrations live entirely in plugin
 
 ---
 
-## Alpha Core (HTTP) — v.a0.01.2
+## Alpha Core (HTTP) — v.a0.01.3
 
 Install deps:
 
@@ -54,6 +54,19 @@ Plugins:
 * Put plugins under `plugins_alpha/<your_plugin>/plugin.py`
 * Implement `Plugin(PluginV2)` with `describe()` and `register_broker()`
 * Core remains silent until a plugin declares services.
+
+## Capability Registry & System Manifest
+
+- Core validates capabilities and writes a signed manifest:
+  - Windows: `%LOCALAPPDATA%\TGC\state\system_manifest.json`
+  - macOS/Linux: `~/.tgc/state/system_manifest.json`
+- Endpoints:
+  - `GET /capabilities`
+  - `GET /capabilities/stream`  (SSE events: `CAPABILITY_UPDATE`)
+- Plugins declare capabilities via `PluginV2.capabilities()`:
+  - `provides`: `["namespace.capability"]`
+  - `requires`: `["other.capability"]`
+- Core is the only writer. No secrets in the manifest. HMAC-SHA256 signature prevents tampering.
 
 ---
 

--- a/core/auth/google_sa.py
+++ b/core/auth/google_sa.py
@@ -1,0 +1,50 @@
+from __future__ import annotations
+
+import json
+import os
+from pathlib import Path
+from typing import Any, Dict, Optional, Tuple
+
+
+def _project_root() -> Path:
+    return Path(__file__).resolve().parents[2]
+
+
+def _resolve_creds_path() -> Path:
+    envp = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
+    if envp:
+        p = Path(os.path.expandvars(os.path.expanduser(envp)))
+        if not p.is_absolute():
+            p = (_project_root() / p).resolve()
+        return p
+    return (_project_root() / "credentials" / "service-account.json").resolve()
+
+
+def validate_google_service_account() -> Tuple[bool, Dict[str, Any]]:
+    """
+    Validate presence & basic structure of service-account JSON.
+    Returns (ready, meta) where meta has no secrets.
+    """
+
+    p = _resolve_creds_path()
+    meta: Dict[str, Any] = {"path_exists": p.exists(), "path": str(p)}
+    if not p.exists():
+        return False, {
+            **meta,
+            "detail": "missing_credentials",
+            "hint": "Place service-account.json under credentials/ or set GOOGLE_APPLICATION_CREDENTIALS",
+        }
+    try:
+        obj = json.loads(p.read_text(encoding="utf-8"))
+        if obj.get("type") != "service_account":
+            return False, {**meta, "detail": "not_service_account"}
+        meta.update({
+            "project_id": obj.get("project_id"),
+            "client_email": obj.get("client_email"),
+        })
+        return True, meta
+    except Exception as e:  # pragma: no cover - defensive
+        return False, {**meta, "detail": "invalid_json", "error": str(e)}
+
+
+__all__ = ["validate_google_service_account"]

--- a/core/capabilities/registry.py
+++ b/core/capabilities/registry.py
@@ -1,0 +1,103 @@
+from __future__ import annotations
+
+import hashlib
+import hmac
+import json
+import os
+import threading
+import time
+from dataclasses import asdict, dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.version import VERSION
+
+
+def _state_dir() -> Path:
+    if os.name == "nt":
+        base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
+        return Path(base) / "TGC" / "state"
+    return Path.home() / ".tgc" / "state"
+
+
+MANIFEST_PATH = _state_dir() / "system_manifest.json"
+KEY_PATH = _state_dir() / "capabilities_hmac.key"
+
+
+@dataclass
+class Capability:
+    cap: str
+    provider: str
+    status: str = "blocked"
+    policy: Dict[str, Any] = field(default_factory=dict)
+    meta: Dict[str, Any] = field(default_factory=dict)
+
+
+@dataclass
+class Manifest:
+    core_version: str
+    plugin_api_version: str
+    schema_version: str
+    generated_at: str
+    capabilities: List[Capability]
+    signature: Optional[str] = None
+
+
+class CapabilityRegistry:
+    def __init__(self, plugin_api_version: str = "2") -> None:
+        self._lock = threading.Lock()
+        self._caps: Dict[str, Capability] = {}
+        self._plugin_api_version = plugin_api_version
+        _state_dir().mkdir(parents=True, exist_ok=True)
+        if not KEY_PATH.exists():
+            KEY_PATH.write_bytes(os.urandom(32))
+
+    def upsert(
+        self,
+        cap: str,
+        *,
+        provider: str,
+        status: str = "ready",
+        policy: Optional[Dict[str, Any]] = None,
+        meta: Optional[Dict[str, Any]] = None,
+    ) -> None:
+        with self._lock:
+            c = Capability(cap=cap, provider=provider, status=status, policy=policy or {}, meta=meta or {})
+            self._caps[cap] = c
+
+    def delete(self, cap: str) -> None:
+        with self._lock:
+            self._caps.pop(cap, None)
+
+    def list(self) -> List[Capability]:
+        with self._lock:
+            return list(self._caps.values())
+
+    def _sign(self, payload: bytes) -> str:
+        key = KEY_PATH.read_bytes()
+        return hmac.new(key, payload, hashlib.sha256).hexdigest()
+
+    def emit_manifest(self) -> Dict[str, Any]:
+        with self._lock:
+            manifest = Manifest(
+                core_version=VERSION,
+                plugin_api_version=self._plugin_api_version,
+                schema_version="1",
+                generated_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                capabilities=self.list(),
+            )
+        base = asdict(manifest)
+        base_no_sig = {k: v for k, v in base.items() if k != "signature"}
+        payload = json.dumps(base_no_sig, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        sig = self._sign(payload)
+        base_no_sig["signature"] = sig
+        MANIFEST_PATH.write_text(json.dumps(base_no_sig, indent=2), encoding="utf-8")
+        return base_no_sig
+
+
+__all__ = [
+    "Capability",
+    "CapabilityRegistry",
+    "MANIFEST_PATH",
+    "KEY_PATH",
+]

--- a/core/contracts/plugin_v2.py
+++ b/core/contracts/plugin_v2.py
@@ -17,3 +17,13 @@ class PluginV2:
 
     def run(self, broker: ConnectionBroker, options: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
         return {"ok": True}
+
+    def capabilities(self) -> Dict[str, Any]:
+        """Return a declarative capability manifest block."""
+
+        return {
+            "provides": [],
+            "requires": [],
+            "trust_tier": 1,
+            "stages": ["service"],
+        }

--- a/core/version.py
+++ b/core/version.py
@@ -1,5 +1,5 @@
 """Version information for TGC Alpha Core."""
 
-VERSION = "v.a0.01.2"
+VERSION = "v.a0.01.3"
 
 __all__ = ["VERSION"]

--- a/plugins_alpha/_template/plugin.py
+++ b/plugins_alpha/_template/plugin.py
@@ -17,3 +17,11 @@ class Plugin(PluginV2):
 
     def run(self, broker: ConnectionBroker, options=None):
         return {"ok": True}
+
+    def capabilities(self):
+        return {
+            "provides": [],
+            "requires": [],
+            "trust_tier": 1,
+            "stages": ["service"],
+        }

--- a/plugins_alpha/echo/plugin.py
+++ b/plugins_alpha/echo/plugin.py
@@ -19,3 +19,11 @@ class Plugin(PluginV2):
             return {"ok": True, "detail": "echo_ready"}
 
         broker.register("echo", provider=provider, probe=probe)
+
+    def capabilities(self):
+        return {
+            "provides": ["echo.service"],
+            "requires": [],
+            "trust_tier": 1,
+            "stages": ["service"],
+        }

--- a/plugins_alpha/google_drive/plugin.py
+++ b/plugins_alpha/google_drive/plugin.py
@@ -15,3 +15,11 @@ class Plugin(PluginV2):
 
     def register_broker(self, broker: ConnectionBroker):
         return None
+
+    def capabilities(self):
+        return {
+            "provides": ["drive.files.read"],
+            "requires": ["auth.google.service_account"],
+            "trust_tier": 1,
+            "stages": ["service"],
+        }


### PR DESCRIPTION
## Summary
- add Google service account validation helper and capability registry with signed manifest emission
- bootstrap core and plugin capabilities at HTTP startup, expose `/capabilities` + SSE stream, and update probes to publish status
- extend PluginV2 + templates/plugins to declare capabilities and document the registry while bumping the core version

## Testing
- python -m compileall core/auth/google_sa.py core/capabilities/registry.py

------
https://chatgpt.com/codex/tasks/task_e_68eec54504a883228fd7d86b0deead0c