### PR TITLE
Add core auth and capabilities scaffolding

### DIFF
--- a/core/auth/__init__.py
+++ b/core/auth/__init__.py
@@ -1,0 +1,1 @@
+# makes core.auth a package

--- a/core/auth/google_sa.py
+++ b/core/auth/google_sa.py
@@ -1,14 +1,10 @@
 from __future__ import annotations
-
-import json
-import os
+import os, json
 from pathlib import Path
-from typing import Any, Dict, Optional, Tuple
-
+from typing import Dict, Any, Tuple
 
 def _project_root() -> Path:
-    return Path(__file__).resolve().parents[2]
-
+    return Path(__file__).resolve().parents[2]  # core/auth -> core -> repo
 
 def _resolve_creds_path() -> Path:
     envp = os.environ.get("GOOGLE_APPLICATION_CREDENTIALS", "").strip()
@@ -19,32 +15,21 @@ def _resolve_creds_path() -> Path:
         return p
     return (_project_root() / "credentials" / "service-account.json").resolve()
 
-
 def validate_google_service_account() -> Tuple[bool, Dict[str, Any]]:
     """
     Validate presence & basic structure of service-account JSON.
-    Returns (ready, meta) where meta has no secrets.
+    Returns (ready, meta) with no secrets.
     """
-
     p = _resolve_creds_path()
     meta: Dict[str, Any] = {"path_exists": p.exists(), "path": str(p)}
     if not p.exists():
-        return False, {
-            **meta,
-            "detail": "missing_credentials",
-            "hint": "Place service-account.json under credentials/ or set GOOGLE_APPLICATION_CREDENTIALS",
-        }
+        return False, {**meta, "detail": "missing_credentials",
+                       "hint": "Place service-account.json under credentials/ or set GOOGLE_APPLICATION_CREDENTIALS"}
     try:
         obj = json.loads(p.read_text(encoding="utf-8"))
         if obj.get("type") != "service_account":
             return False, {**meta, "detail": "not_service_account"}
-        meta.update({
-            "project_id": obj.get("project_id"),
-            "client_email": obj.get("client_email"),
-        })
+        meta.update({"project_id": obj.get("project_id"), "client_email": obj.get("client_email")})
         return True, meta
-    except Exception as e:  # pragma: no cover - defensive
+    except Exception as e:
         return False, {**meta, "detail": "invalid_json", "error": str(e)}
-
-
-__all__ = ["validate_google_service_account"]

--- a/core/capabilities/__init__.py
+++ b/core/capabilities/__init__.py
@@ -1,0 +1,1 @@
+# makes core.capabilities a package

--- a/core/capabilities/registry.py
+++ b/core/capabilities/registry.py
@@ -1,37 +1,28 @@
 from __future__ import annotations
-
-import hashlib
-import hmac
-import json
-import os
-import threading
-import time
-from dataclasses import asdict, dataclass, field
+import json, os, hmac, hashlib, time, threading
+from dataclasses import dataclass, asdict, field
 from pathlib import Path
-from typing import Any, Dict, List, Optional
+from typing import Dict, List, Any, Optional
 
 from core.version import VERSION
 
-
 def _state_dir() -> Path:
+    # Windows: %LOCALAPPDATA%\TGC\state ; Others: ~/.tgc/state
     if os.name == "nt":
         base = os.environ.get("LOCALAPPDATA") or str(Path.home() / "AppData" / "Local")
         return Path(base) / "TGC" / "state"
     return Path.home() / ".tgc" / "state"
 
-
 MANIFEST_PATH = _state_dir() / "system_manifest.json"
-KEY_PATH = _state_dir() / "capabilities_hmac.key"
-
+KEY_PATH      = _state_dir() / "capabilities_hmac.key"
 
 @dataclass
 class Capability:
     cap: str
     provider: str
-    status: str = "blocked"
+    status: str = "blocked"           # ready | blocked | pending | deprecated
     policy: Dict[str, Any] = field(default_factory=dict)
-    meta: Dict[str, Any] = field(default_factory=dict)
-
+    meta: Dict[str, Any] = field(default_factory=dict)  # non-secret metadata
 
 @dataclass
 class Manifest:
@@ -40,10 +31,10 @@ class Manifest:
     schema_version: str
     generated_at: str
     capabilities: List[Capability]
-    signature: Optional[str] = None
-
+    signature: Optional[str] = None   # HMAC-SHA256 over JSON (without signature)
 
 class CapabilityRegistry:
+    """Core-owned registry. Single writer. Thread-safe. No secrets."""
     def __init__(self, plugin_api_version: str = "2") -> None:
         self._lock = threading.Lock()
         self._caps: Dict[str, Capability] = {}
@@ -52,18 +43,11 @@ class CapabilityRegistry:
         if not KEY_PATH.exists():
             KEY_PATH.write_bytes(os.urandom(32))
 
-    def upsert(
-        self,
-        cap: str,
-        *,
-        provider: str,
-        status: str = "ready",
-        policy: Optional[Dict[str, Any]] = None,
-        meta: Optional[Dict[str, Any]] = None,
-    ) -> None:
+    def upsert(self, cap: str, *, provider: str, status: str = "ready",
+               policy: Optional[Dict[str, Any]] = None, meta: Optional[Dict[str, Any]] = None) -> None:
         with self._lock:
-            c = Capability(cap=cap, provider=provider, status=status, policy=policy or {}, meta=meta or {})
-            self._caps[cap] = c
+            self._caps[cap] = Capability(cap=cap, provider=provider, status=status,
+                                         policy=policy or {}, meta=meta or {})
 
     def delete(self, cap: str) -> None:
         with self._lock:
@@ -79,25 +63,15 @@ class CapabilityRegistry:
 
     def emit_manifest(self) -> Dict[str, Any]:
         with self._lock:
-            manifest = Manifest(
+            base = asdict(Manifest(
                 core_version=VERSION,
                 plugin_api_version=self._plugin_api_version,
                 schema_version="1",
                 generated_at=time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
                 capabilities=self.list(),
-            )
-        base = asdict(manifest)
+            ))
         base_no_sig = {k: v for k, v in base.items() if k != "signature"}
         payload = json.dumps(base_no_sig, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
-        sig = self._sign(payload)
-        base_no_sig["signature"] = sig
+        base_no_sig["signature"] = self._sign(payload)
         MANIFEST_PATH.write_text(json.dumps(base_no_sig, indent=2), encoding="utf-8")
         return base_no_sig
-
-
-__all__ = [
-    "Capability",
-    "CapabilityRegistry",
-    "MANIFEST_PATH",
-    "KEY_PATH",
-]


### PR DESCRIPTION
## Summary
- add package initializers for core auth and capabilities modules
- update Google service-account validation helper to the new format
- align capability registry implementation with new manifest structure

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68eec85071f083228b4212e081264148