### PR TITLE
Use shared capability registry singleton

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -12,7 +12,7 @@ from pydantic import BaseModel
 from starlette.responses import StreamingResponse
 
 from core.auth.google_sa import validate_google_service_account
-from core.capabilities.registry import CapabilityRegistry
+from core.capabilities import REGISTRY
 from core.conn_broker import ConnectionBroker
 from core.version import VERSION
 from tgc.bootstrap_fs import DATA, LOGS, ensure_first_run
@@ -24,7 +24,6 @@ SESSION_TOKEN = secrets.token_urlsafe(24)
 
 LOG_FILE = LOGS / f"core_{RUN_ID}.log"
 
-REGISTRY = CapabilityRegistry(plugin_api_version="2")
 _SUBSCRIBERS: set[Any] = set()
 
 

--- a/core/capabilities/__init__.py
+++ b/core/capabilities/__init__.py
@@ -1,1 +1,7 @@
-# makes core.capabilities a package
+from __future__ import annotations
+from .registry import CapabilityRegistry
+
+# Single global registry instance for the whole process
+REGISTRY = CapabilityRegistry(plugin_api_version="2")
+
+__all__ = ["REGISTRY", "CapabilityRegistry"]


### PR DESCRIPTION
## Summary
- expose a shared capability registry singleton from core.capabilities
- update the HTTP API to import and use the shared registry instead of instantiating a new one

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68eecafcc02483228616fa3d693698d2