### PR TITLE
Enforce plugin import boundaries and hide core internals

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ class Plugin(PluginV2):
 
 Drop your plugin under `plugins_alpha/<name>/` and restart the core. Core discovers packages automatically and keeps Google/Notion details outside of the main runtime.
 
+## Public API Contract (for plugins)
+
+Plugins may only import:
+- `core.contracts.plugin_v2`          (plugin base class & interface)
+- `core.conn_broker`                  (broker types & client handle)
+- `core.capabilities`                 (facade: publish/resolve/list_caps/emit_manifest/meta)
+
+Plugins that import any other `core.*` modules are rejected at load time by the import guard.
+Core internals live under `core/_internal/*` and are private.
+HTTP endpoints are stable; do not rely on undocumented fields.
+
 ---
 
 ## Commands

--- a/config/backups/20251013T194031Z/app.py
+++ b/config/backups/20251013T194031Z/app.py
@@ -28,14 +28,14 @@ from tgc.util.serialization import safe_serialize
 
 from core import brand, policy_engine, retention
 from core.audit import write_audit
-from core.capabilities import REGISTRY, meta, resolve
+from core.capabilities import list_caps, meta, resolve
 from core.config import load_core_config, plugin_env_whitelist
 from core.isolate import run_isolated
 from core.permissions import require
 from core.plugin_api import Context
 from core.policy_log import log_policy
 from core.menu_render import render_root
-from core.runtime import get_runtime_limits, set_runtime_limits
+from core._internal.runtime import get_runtime_limits, set_runtime_limits
 from core.runtime_state import boot_sequence
 from core.safelog import logger
 from core.system_check import system_check as _system_check
@@ -61,8 +61,9 @@ def _limits() -> Dict[str, object]:
 def _format_capabilities_table() -> str:
     headers = ("Capability", "Plugin", "Scopes", "Network")
     rows = []
-    for name in sorted(REGISTRY.keys()):
-        info = REGISTRY[name]
+    caps = list_caps()
+    for name in sorted(caps.keys()):
+        info = caps[name]
         scopes = ", ".join(info.get("scopes") or [])
         network = str(bool(info.get("network", False))).lower()
         rows.append((name, info.get("plugin", ""), scopes, network))

--- a/core/_internal/__init__.py
+++ b/core/_internal/__init__.py
@@ -1,0 +1,3 @@
+"""Private core internals. Do not import from plugins."""
+
+__all__ = []

--- a/core/_internal/runtime.py
+++ b/core/_internal/runtime.py
@@ -1,3 +1,5 @@
+"""Internal runtime helpers for capability execution."""
+
 import time
 import uuid
 from typing import Any, Dict, Optional

--- a/core/capabilities/__init__.py
+++ b/core/capabilities/__init__.py
@@ -1,7 +1,19 @@
-from __future__ import annotations
-from .registry import CapabilityRegistry
+from .api import (
+    registry,
+    publish,
+    unpublish,
+    list_caps,
+    resolve,
+    emit_manifest,
+    meta,
+)
 
-# Single global registry instance for the whole process
-REGISTRY = CapabilityRegistry(plugin_api_version="2")
-
-__all__ = ["REGISTRY", "CapabilityRegistry"]
+__all__ = [
+    "registry",
+    "publish",
+    "unpublish",
+    "list_caps",
+    "resolve",
+    "emit_manifest",
+    "meta",
+]

--- a/core/capabilities/api.py
+++ b/core/capabilities/api.py
@@ -1,0 +1,55 @@
+"""Public capabilities facade."""
+
+from __future__ import annotations
+
+from typing import Any, Callable, Dict
+
+from core.capabilities.registry import CapabilityRegistry
+from core._internal.capabilities_runtime import (
+    capability_meta,
+    list_published_capabilities,
+    publish_capability,
+    resolve_capability,
+    unpublish_capability,
+)
+
+registry = CapabilityRegistry(plugin_api_version="2")
+
+
+def publish(
+    name: str,
+    *,
+    plugin: str,
+    version: str,
+    scopes: list[str],
+    func: Callable[..., Any],
+    network: bool = False,
+) -> None:
+    publish_capability(
+        name,
+        plugin=plugin,
+        version=version,
+        scopes=scopes,
+        func=func,
+        network=network,
+    )
+
+
+def unpublish(name: str) -> None:
+    unpublish_capability(name)
+
+
+def list_caps() -> Dict[str, Dict[str, Any]]:
+    return list_published_capabilities()
+
+
+def resolve(name: str):
+    return resolve_capability(name)
+
+
+def meta(name: str) -> Dict[str, Any]:
+    return capability_meta(name)
+
+
+def emit_manifest() -> Dict[str, Any]:
+    return registry.emit_manifest()

--- a/core/consent_cli.py
+++ b/core/consent_cli.py
@@ -6,7 +6,7 @@ import json
 from pathlib import Path
 from typing import Dict, Iterable, List
 
-from core.capabilities import REGISTRY
+from core.capabilities import list_caps
 from core.permissions import grant as grant_scopes
 import core.permissions as _permissions
 
@@ -43,7 +43,7 @@ def current_consents() -> Dict[str, List[str]]:
 
 def list_scopes() -> Dict[str, List[str]]:
     plugins: Dict[str, set[str]] = {}
-    for metadata in REGISTRY.values():
+    for metadata in list_caps().values():
         plugin = metadata.get("plugin")
         scopes = metadata.get("scopes") or []
         if not plugin:

--- a/core/menu_render.py
+++ b/core/menu_render.py
@@ -5,7 +5,7 @@ from __future__ import annotations
 from typing import Any, Dict, Iterable
 
 from core.brand import NAME, VENDOR
-from core.capabilities import REGISTRY
+from core.capabilities import list_caps
 from core.menu_spec import (
     CONTROLLER_CONFIG_MENU,
     MAIN_MENU,
@@ -126,7 +126,7 @@ def render_status_plugins_overview(payload: Dict[str, Any]) -> None:
 
     index_caps = []
     print(f"{caps_label}:")
-    for capability, meta in sorted(REGISTRY.items()):
+    for capability, meta in sorted(list_caps().items()):
         if ".index" not in capability:
             continue
         index_caps.append(capability)

--- a/core/plugins_alpha.py
+++ b/core/plugins_alpha.py
@@ -1,22 +1,109 @@
 from __future__ import annotations
-import importlib, pkgutil
-from typing import List
+
+import builtins
+import importlib
+import importlib.util
+import pkgutil
+import sys
+from contextlib import contextmanager
+from typing import Iterator, List, Set
+
 from core.contracts.plugin_v2 import PluginV2
+from core.public_api import PUBLIC_IMPORTS_ALLOWLIST
+
+
+def _is_allowed_core_module(module_name: str) -> bool:
+    if module_name == "core":
+        return False
+    for allowed in PUBLIC_IMPORTS_ALLOWLIST:
+        if module_name == allowed or module_name.startswith(f"{allowed}."):
+            return True
+    return False
+
+
+def _disallowed_new_core_imports(before: Set[str], after: Set[str]) -> Set[str]:
+    newly = {name for name in after - before if name.startswith("core.")}
+    return {name for name in newly if not _is_allowed_core_module(name)}
+
+
+@contextmanager
+def _capture_plugin_imports(prefix: str) -> Iterator[Set[str]]:
+    captured: Set[str] = set()
+    original_import = builtins.__import__
+
+    def guarded_import(name, globals=None, locals=None, fromlist=(), level=0):  # type: ignore[override]
+        importer = None
+        if isinstance(globals, dict):
+            importer = globals.get("__name__")
+        if importer and importer.startswith(prefix):
+            resolved = name
+            if level and isinstance(globals, dict):
+                package = globals.get("__package__") or importer
+                try:
+                    resolved = importlib.util.resolve_name(name or "", package)
+                except Exception:
+                    resolved = name
+            captured.add(resolved)
+        return original_import(name, globals, locals, fromlist, level)
+
+    builtins.__import__ = guarded_import
+    try:
+        yield captured
+    finally:
+        builtins.__import__ = original_import
+
+
+def _disallowed_captured_imports(prefix: str, captured: Set[str]) -> Set[str]:
+    violations: Set[str] = set()
+    for name in captured:
+        if not name:
+            continue
+        absolute = name if not name.startswith(".") else f"{prefix}{name}"
+        if absolute == "core" or absolute.startswith("core."):
+            if not _is_allowed_core_module(absolute):
+                violations.add(absolute)
+    return violations
 
 
 def discover_alpha_plugins() -> List[PluginV2]:
     plugins: List[PluginV2] = []
-    for _, name, _ in pkgutil.iter_modules(['plugins_alpha']):
+    for _, name, _ in pkgutil.iter_modules(["plugins_alpha"]):
         if name.startswith("_"):
             continue
+        mod = None
+        snap_before = set(sys.modules.keys())
+        prefix = f"plugins_alpha.{name}"
+        captured_names: Set[str] = set()
         try:
-            mod = importlib.import_module(f"plugins_alpha.{name}.plugin")
-        except Exception:
-            try:
-                mod = importlib.import_module(f"plugins_alpha.{name}")
-            except Exception:
+            for candidate in (f"{prefix}.plugin", prefix):
+                with _capture_plugin_imports(prefix) as captured:
+                    try:
+                        mod = importlib.import_module(candidate)
+                        captured_names = set(captured)
+                        break
+                    except Exception:
+                        mod = None
+                        captured_names = set()
+                        continue
+                # context manager ensures restore even on exception
+            if mod is None:
                 continue
-        cls = getattr(mod, "Plugin", None)
-        if cls and issubclass(cls, PluginV2):
-            plugins.append(cls())
+            snap_after = set(sys.modules.keys())
+            captured_violations = _disallowed_captured_imports(prefix, captured_names)
+            module_violations = _disallowed_new_core_imports(snap_before, snap_after)
+            violations = captured_violations | module_violations
+            if violations:
+                newly_loaded = snap_after - snap_before
+                for module_name in newly_loaded:
+                    if module_name.startswith(prefix):
+                        sys.modules.pop(module_name, None)
+                for module_name in newly_loaded:
+                    if module_name.startswith("core."):
+                        sys.modules.pop(module_name, None)
+                continue
+            cls = getattr(mod, "Plugin", None)
+            if cls and issubclass(cls, PluginV2):
+                plugins.append(cls())
+        except Exception:
+            continue
     return plugins

--- a/core/public_api.py
+++ b/core/public_api.py
@@ -1,0 +1,7 @@
+"""Public import allowlist for plugin sandboxing."""
+
+PUBLIC_IMPORTS_ALLOWLIST = {
+    "core.contracts.plugin_v2",
+    "core.conn_broker",
+    "core.capabilities",
+}

--- a/tests/test_plugin_import_guard.py
+++ b/tests/test_plugin_import_guard.py
@@ -1,0 +1,35 @@
+from __future__ import annotations
+
+import importlib
+import shutil
+import sys
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGDIR = ROOT / "plugins_alpha" / "violator"
+PLUGDIR.mkdir(parents=True, exist_ok=True)
+(PLUGDIR / "__init__.py").write_text("", encoding="utf-8")
+
+(PLUGDIR / "plugin.py").write_text(
+    "from core.contracts.plugin_v2 import PluginV2\n"
+    "from core._internal import runtime  # forbidden\n"
+    "class Plugin(PluginV2):\n"
+    "    id='violator'; name='Violator'; version='0.0'; api_version='2'\n"
+    "    def describe(self): return {'services':[], 'scopes':['read_base']}\n"
+    "    def register_broker(self, b): pass\n",
+    encoding="utf-8",
+)
+
+
+def test_discovery_rejects_internal_imports() -> None:
+    if "core.plugins_alpha" in sys.modules:
+        del sys.modules["core.plugins_alpha"]
+    mod = importlib.import_module("core.plugins_alpha")
+    plugs = mod.discover_alpha_plugins()
+    ids = [getattr(p, "id", "unknown") for p in plugs]
+    assert "violator" not in ids
+
+
+def teardown_module(module) -> None:  # type: ignore[override]
+    if PLUGDIR.exists():
+        shutil.rmtree(PLUGDIR)

--- a/tests/test_public_api_only.py
+++ b/tests/test_public_api_only.py
@@ -1,0 +1,8 @@
+from core.public_api import PUBLIC_IMPORTS_ALLOWLIST
+
+
+def test_allowlist_is_minimal_and_stable() -> None:
+    assert "core.conn_broker" in PUBLIC_IMPORTS_ALLOWLIST
+    assert "core.contracts.plugin_v2" in PUBLIC_IMPORTS_ALLOWLIST
+    assert "core.capabilities" in PUBLIC_IMPORTS_ALLOWLIST
+    assert "core._internal.runtime" not in PUBLIC_IMPORTS_ALLOWLIST

--- a/tgc/actions/master_index.py
+++ b/tgc/actions/master_index.py
@@ -7,10 +7,10 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
-from core.capabilities import REGISTRY
+from core.capabilities import list_caps
 from core import retention
 from core.plugin_api import Result
-from core.runtime import run_capability
+from core._internal.runtime import run_capability
 from core.unilog import write as uni_write
 
 from ..controller import Controller
@@ -190,7 +190,7 @@ class MasterIndexAction(SimpleAction):
 
             used_capability = False
             if root_ids:
-                if "google.sheets_index" in REGISTRY:
+                if "google.sheets_index" in list_caps():
                     try:
                         payload = run_capability(
                             "google.sheets_index",

--- a/tgc/master_index_controller.py
+++ b/tgc/master_index_controller.py
@@ -12,9 +12,9 @@ from pathlib import Path
 from typing import TYPE_CHECKING, Callable, Dict, Iterable, List, Optional, Sequence, Tuple
 
 from core.bus.models import CommandContext
-from core.capabilities import REGISTRY
+from core.capabilities import list_caps
 from core.plugin_api import Result
-from core.runtime import run_capability
+from core._internal.runtime import run_capability
 
 from .integration_support import (
     format_drive_share_message,
@@ -198,7 +198,7 @@ class MasterIndexController:
         fallback_args: Tuple[object, ...],
         fallback_kwargs: Optional[Dict[str, object]] = None,
     ) -> "TraversalResult":
-        if capability in REGISTRY:
+        if capability in list_caps():
             try:
                 result = run_capability(capability, **plugin_kwargs)
             except PermissionError as exc:


### PR DESCRIPTION
## Summary
- add an explicit public import allowlist and tighten plugin discovery with import tracing so plugins that touch core internals are rejected
- move runtime and capability registries into the new core._internal package while exposing a thin core.capabilities facade for public use
- update documentation and internal modules to the new APIs and add regression tests covering the allowlist and discovery guard

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eed47aea088322b2575771bc7b3b11