### PR TITLE
Refactor capability manifest emission to be async-safe

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -173,7 +173,8 @@ def _bootstrap_capabilities() -> None:
         if capability.status == "pending":
             registry.upsert(cap, provider=capability.provider, status="ready", policy={"allowed": True})
 
-    registry.emit_manifest()
+    registry.emit_manifest_async()
+    log("[capabilities] async manifest write requested after probe")
 
 
 def _start_crawl_async(run_id: str, limits: Dict[str, Any]) -> None:
@@ -296,7 +297,9 @@ def get_capabilities(
     x_session_token: Optional[str] = Header(default=None, alias="X-Session-Token")
 ) -> Dict[str, Any]:
     _require_token(x_session_token)
-    return registry.emit_manifest()
+    out = registry.emit_manifest_async()
+    log("[capabilities] served manifest to client; async write started")
+    return out
 
 
 @APP.get("/capabilities/stream")

--- a/core/capabilities/__init__.py
+++ b/core/capabilities/__init__.py
@@ -5,6 +5,7 @@ from .api import (
     list_caps,
     resolve,
     emit_manifest,
+    emit_manifest_async,
     meta,
 )
 
@@ -15,5 +16,6 @@ __all__ = [
     "list_caps",
     "resolve",
     "emit_manifest",
+    "emit_manifest_async",
     "meta",
 ]

--- a/core/capabilities/api.py
+++ b/core/capabilities/api.py
@@ -53,3 +53,7 @@ def meta(name: str) -> Dict[str, Any]:
 
 def emit_manifest() -> Dict[str, Any]:
     return registry.emit_manifest()
+
+
+def emit_manifest_async() -> Dict[str, Any]:
+    return registry.emit_manifest_async()


### PR DESCRIPTION
## Summary
- add manifest helpers for building/siging manifests in-memory with atomic writes
- expose async manifest emission and update HTTP capabilities endpoint to use it
- log asynchronous manifest writes during capability bootstrap

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68eefabbdf7083229b220bdea72b2c56