### PR TITLE
Add licensing docs, SPDX tooling, and runtime license signals

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,49 @@
+name: CI
+
+on:
+  push:
+    branches: [ "**" ]
+  pull_request:
+    branches: [ "**" ]
+
+jobs:
+  build-test:
+    runs-on: ubuntu-latest
+    timeout-minutes: 15
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+
+      - name: Set up Python
+        uses: actions/setup-python@v5
+        with:
+          python-version: "3.11"
+
+      - name: Install dependencies (best-effort)
+        run: |
+          python -m pip install --upgrade pip
+          if [ -f requirements.txt ]; then pip install -r requirements.txt || true; fi
+          pip install pytest
+
+      - name: Stamp SPDX headers (idempotent)
+        run: python tools/add_spdx_headers.py
+
+      - name: Check SPDX headers
+        run: python tools/check_spdx_headers.py
+
+      - name: Check plugin LICENSE files
+        run: python tools/check_licenses.py
+
+      - name: Run tests (if any)
+        run: |
+          if [ -d tests ]; then pytest -q; else echo "No tests/ directory"; fi
+
+      - name: Upload artifacts (logs/data)
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: tgc-artifacts
+          path: |
+            logs/**
+            data/**
+          if-no-files-found: ignore

--- a/COMMERCIAL-LICENSE.md
+++ b/COMMERCIAL-LICENSE.md
@@ -1,0 +1,14 @@
+# Commercial License for TGC Core (BUS)
+
+To use the BUS core for commercial or production purposes, please obtain a commercial license from True Good Craft.
+
+**Contact:** Truegoodcraft@gmail.com
+
+**Scope:** usage in production, SaaS, internal business processes, or monetized products/services.
+
+We offer:
+- Per-seat or per-server licensing
+- OEM redistribution
+- Support & SLAs
+
+> Plugins under Apache-2.0 remain open and usable independently under their own terms.

--- a/LICENSE-THIRD-PARTY.md
+++ b/LICENSE-THIRD-PARTY.md
@@ -1,0 +1,4 @@
+# Third-party Licenses
+
+This project uses third-party libraries. Refer to each dependency’s license for terms.
+(You can generate a deps list with: `pip-licenses --format=markdown` if desired.)

--- a/README.md
+++ b/README.md
@@ -128,11 +128,24 @@ HTTP endpoints are stable; do not rely on undocumented fields.
 
 ---
 
-## License & Ownership
+## Licensing
 
-* 🧿 **Core Ownership**: The core is proprietary to True Good Craft (TGC). All rights reserved.
-* 🔌 **Plugins**: You may create and add plugins for use within this software’s access scope. Your plugins remain yours; the core remains mine.
-* ✅ **Permitted**: Build plugins, use the broker, run crawls.
-* ❌ **Not Permitted**: Extracting or relicensing the core, or bypassing the broker/safety model.
+- **Core (BUS)**: Source-available **Polyform Noncommercial 1.0.0**. Commercial/production use requires a separate license. See `/core/LICENSE` and `COMMERCIAL-LICENSE.md`. Contact: **Truegoodcraft@gmail.com**.
+- **Plugins**: **Apache-2.0** unless otherwise noted in their plugin folders.
 
-If this helps you, buy your software a coffee. ☕️
+| Component        | Path               | License                          |
+|------------------|--------------------|----------------------------------|
+| Core (BUS)       | `/core`            | Polyform Noncommercial 1.0.0     |
+| Example plugins  | `/plugins_alpha/*` | Apache-2.0                       |
+
+### Continuous Integration (CI)
+CI stamps and enforces SPDX headers and runs tests.
+
+Local helpers:
+```bash
+python tools/add_spdx_headers.py   # stamp headers
+python tools/check_spdx_headers.py # verify headers
+python tools/check_licenses.py     # verify plugin LICENSE files
+```
+
+---

--- a/TRADEMARKS.md
+++ b/TRADEMARKS.md
@@ -1,0 +1,4 @@
+# Trademarks
+
+“TGC”, “True Good Craft”, and related logos are trademarks of True Good Craft.
+You may not use our marks in a way that suggests endorsement or affiliation without written permission.

--- a/core/LICENSE
+++ b/core/LICENSE
@@ -1,0 +1,12 @@
+Polyform Noncommercial License 1.0.0
+
+Licensor: True Good Craft
+Licensed Work: TGC Controller Core (“BUS”), the source code located in /core
+
+You may use, copy, modify, and distribute the Licensed Work for any noncommercial purpose, subject to the terms of the Polyform Noncommercial License 1.0.0.
+
+Commercial use requires a separate commercial license from the Licensor.
+
+Full text: https://polyformproject.org/licenses/noncommercial/1.0.0/
+
+Copyright (c) True Good Craft

--- a/core/NOTICE
+++ b/core/NOTICE
@@ -1,0 +1,3 @@
+TGC Controller Core (“BUS”)
+Copyright (c) True Good Craft
+Contains third-party components under their respective licenses. See LICENSE-THIRD-PARTY.md at repo root.

--- a/core/__init__.py
+++ b/core/__init__.py
@@ -1,0 +1,2 @@
+# SPDX-License-Identifier: PolyForm-Noncommercial-1.0.0
+# Core is source-available for noncommercial use; see /core/LICENSE and COMMERCIAL-LICENSE.md

--- a/core/capabilities/registry.py
+++ b/core/capabilities/registry.py
@@ -83,6 +83,13 @@ class CapabilityRegistry:
     def emit_manifest(self) -> Dict[str, Any]:
         """Synchronous write (kept for compatibility)."""
         out = self.build_manifest()
+        out.setdefault(
+            "license",
+            {
+                "core": "PolyForm-Noncommercial-1.0.0",
+                "core_url": "https://polyformproject.org/licenses/noncommercial/1.0.0/",
+            },
+        )
         try:
             self._atomic_write(MANIFEST_PATH, json.dumps(out, indent=2))
         except Exception as e:
@@ -96,6 +103,13 @@ class CapabilityRegistry:
         Never blocks the caller longer than building JSON/signing.
         """
         out = self.build_manifest()
+        out.setdefault(
+            "license",
+            {
+                "core": "PolyForm-Noncommercial-1.0.0",
+                "core_url": "https://polyformproject.org/licenses/noncommercial/1.0.0/",
+            },
+        )
 
         def _writer() -> None:
             try:

--- a/plugins_alpha/echo/LICENSE
+++ b/plugins_alpha/echo/LICENSE
@@ -1,0 +1,3 @@
+Apache License
+Version 2.0, January 2004
+https://www.apache.org/licenses/LICENSE-2.0

--- a/plugins_alpha/google_drive/LICENSE
+++ b/plugins_alpha/google_drive/LICENSE
@@ -1,0 +1,3 @@
+Apache License
+Version 2.0, January 2004
+https://www.apache.org/licenses/LICENSE-2.0

--- a/plugins_alpha/notion/LICENSE
+++ b/plugins_alpha/notion/LICENSE
@@ -1,0 +1,3 @@
+Apache License
+Version 2.0, January 2004
+https://www.apache.org/licenses/LICENSE-2.0

--- a/tgc/cli_main.py
+++ b/tgc/cli_main.py
@@ -59,7 +59,7 @@ def _start_full_crawl(context: CommandContext, effective_options: Dict[str, obje
 
 
 def serve_cmd(args):
-    from core.api.http import build_app
+    from core.api.http import LICENSE_NAME, LICENSE_URL, build_app
     import uvicorn
 
     app, token = build_app()
@@ -67,6 +67,9 @@ def serve_cmd(args):
     port = int(getattr(args, "port", 8765) or 8765)
     print(f"Serving on http://{host}:{port}")
     print(f"Session token (also saved to data/session_token.txt): {token}")
+    print(
+        f"License: {LICENSE_NAME} — {LICENSE_URL} — commercial use requires permission (Truegoodcraft@gmail.com)"
+    )
     uvicorn.run(app, host=host, port=port, log_level="warning")
 
 

--- a/tools/add_spdx_headers.py
+++ b/tools/add_spdx_headers.py
@@ -1,0 +1,41 @@
+from __future__ import annotations
+import os
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE = ROOT / "core"
+PLUGS = ROOT / "plugins_alpha"
+
+CORE_ID = "PolyForm-Noncommercial-1.0.0"
+PLUG_ID = "Apache-2.0"
+
+SKIP_DIRS = {".git", ".github", ".venv", "venv", "__pycache__", "dist", "build"}
+
+HEADER = "# SPDX-License-Identifier: {spdx}\n# Copyright (c) True Good Craft\n"
+
+def needs_header(text: str) -> bool:
+    head = text.splitlines()[:5]
+    return not any("SPDX-License-Identifier" in line for line in head)
+
+def apply_headers(base: Path, spdx: str):
+    if not base.exists(): return
+    for p in base.rglob("*.py"):
+        if any(part in SKIP_DIRS or part.startswith(".") for part in p.parts):
+            continue
+        try:
+            t = p.read_text(encoding="utf-8")
+        except Exception:
+            continue
+        if needs_header(t):
+            p.write_text(HEADER.format(spdx=spdx) + "\n" + t, encoding="utf-8")
+
+def main():
+    apply_headers(CORE, CORE_ID)
+    if PLUGS.exists():
+        for sub in PLUGS.iterdir():
+            if sub.is_dir() and not sub.name.startswith("_"):
+                apply_headers(sub, PLUG_ID)
+    print("SPDX headers applied.")
+
+if __name__ == "__main__":
+    main()

--- a/tools/check_licenses.py
+++ b/tools/check_licenses.py
@@ -1,0 +1,27 @@
+from __future__ import annotations
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+PLUGS = ROOT / "plugins_alpha"
+SKIP = {"_"}  # skip folders starting with _
+
+def missing_plugin_licenses()->list[str]:
+    out=[]
+    if not PLUGS.exists(): return out
+    for sub in PLUGS.iterdir():
+        if sub.is_dir() and not sub.name.startswith(tuple(SKIP)):
+            if not (sub/"LICENSE").exists():
+                out.append(str(sub.relative_to(ROOT)))
+    return out
+
+def main()->int:
+    miss = missing_plugin_licenses()
+    if miss:
+        print("Plugins missing LICENSE (Apache-2.0):")
+        for p in miss: print(" -", p + "/LICENSE")
+        return 1
+    print("All plugins have LICENSE files.")
+    return 0
+
+if __name__=="__main__":
+    raise SystemExit(main())

--- a/tools/check_spdx_headers.py
+++ b/tools/check_spdx_headers.py
@@ -1,0 +1,39 @@
+from __future__ import annotations
+from pathlib import Path
+
+ROOT = Path(__file__).resolve().parents[1]
+CORE = ROOT / "core"
+PLUGS = ROOT / "plugins_alpha"
+
+REQ = {"core": "PolyForm-Noncommercial-1.0.0", "plugins": "Apache-2.0"}
+SKIP_DIRS = {".git", ".github", ".venv", "venv", "__pycache__", "dist", "build"}
+
+def head(p: Path, n=6) -> str:
+    try: return "".join(p.read_text(encoding="utf-8").splitlines(True)[:n])
+    except Exception: return ""
+
+def check_tree(base: Path, expect: str) -> list[str]:
+    miss=[]
+    for p in base.rglob("*.py"):
+        if any(part in SKIP_DIRS or part.startswith(".") for part in p.parts): continue
+        if f"SPDX-License-Identifier: {expect}" not in head(p):
+            miss.append(str(p.relative_to(ROOT)))
+    return miss
+
+def main()->int:
+    probs=[]
+    if CORE.exists(): probs += [f"[core] {p}" for p in check_tree(CORE, REQ["core"])]
+    if PLUGS.exists():
+        for sub in PLUGS.iterdir():
+            if sub.is_dir() and not sub.name.startswith("_"):
+                probs += [f"[plugins] {p}" for p in check_tree(sub, REQ["plugins"])]
+    if probs:
+        print("Missing/incorrect SPDX headers in:")
+        for p in probs: print(" -", p)
+        print("\nFix: run `python tools/add_spdx_headers.py` and commit.")
+        return 1
+    print("All SPDX headers OK.")
+    return 0
+
+if __name__ == "__main__":
+    raise SystemExit(main())


### PR DESCRIPTION
## Summary
- document the Polyform Noncommercial license for the core alongside Apache-2.0 plugin notices and supporting top-level files
- add tooling and GitHub Actions CI to stamp and verify SPDX headers and plugin LICENSE coverage
- surface runtime license information via HTTP headers, a `/license` endpoint, manifest metadata, and CLI startup output

## Testing
- pytest -q

------
https://chatgpt.com/codex/tasks/task_e_68eff0c6b7f08322b8e1809aa50c1487