### PR TITLE
Implement BUS Core Alpha runtime and transparency surface

### DIFF
--- a/config/policy.json
+++ b/config/policy.json
@@ -1,0 +1,16 @@
+{
+  "version": "alpha-2024-08-01",
+  "mode": "enforce",
+  "rules": [
+    {
+      "id": "allow-echo-noop",
+      "intent": "transform",
+      "conditions": {
+        "plugin": "echo",
+        "fn": "noop"
+      },
+      "decision": "allow",
+      "reason": "builtin_echo"
+    }
+  ]
+}

--- a/core/capabilities/registry.py
+++ b/core/capabilities/registry.py
@@ -120,3 +120,13 @@ class CapabilityRegistry:
         t = threading.Thread(target=_writer, daemon=True)
         t.start()
         return out
+
+    def validate_signature(self, manifest: Dict[str, Any]) -> bool:
+        signature = manifest.get("signature")
+        if not isinstance(signature, str):
+            return False
+        base = dict(manifest)
+        base.pop("signature", None)
+        payload = json.dumps(base, separators=(",", ":"), ensure_ascii=False).encode("utf-8")
+        expected = self._sign(payload)
+        return hmac.compare_digest(signature, expected)

--- a/core/contracts/plugin_v2.py
+++ b/core/contracts/plugin_v2.py
@@ -27,3 +27,17 @@ class PluginV2:
             "trust_tier": 1,
             "stages": ["service"],
         }
+
+    def plan_transform(self, fn: str, payload: Dict[str, Any], *, limits: Optional[Dict[str, Any]] = None) -> Dict[str, Any]:
+        raise NotImplementedError("transform planning not implemented")
+
+    def manifest(self) -> Dict[str, Any]:
+        block = self.capabilities() or {}
+        return {
+            "id": getattr(self, "id", self.__class__.__name__),
+            "version": getattr(self, "version", "0"),
+            "provides": list(block.get("provides", [])),
+            "requires": list(block.get("requires", [])),
+            "stages": list(block.get("stages", [])),
+            "trust_tier": block.get("trust_tier", 1),
+        }

--- a/core/public_api.py
+++ b/core/public_api.py
@@ -4,4 +4,5 @@ PUBLIC_IMPORTS_ALLOWLIST = {
     "core.contracts.plugin_v2",
     "core.conn_broker",
     "core.capabilities",
+    "core.secrets",
 }

--- a/core/runtime/__init__.py
+++ b/core/runtime/__init__.py
@@ -1,0 +1,1 @@
+"""Runtime utilities for BUS Core Alpha."""

--- a/core/runtime/core_alpha.py
+++ b/core/runtime/core_alpha.py
@@ -1,0 +1,258 @@
+from __future__ import annotations
+
+import hashlib
+import json
+import threading
+import time
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+from core.auth.google_sa import validate_google_service_account
+from core.capabilities import registry
+from core.capabilities.registry import MANIFEST_PATH
+from core.conn_broker import ConnectionBroker
+from core.contracts.plugin_v2 import PluginV2
+from core.runtime.crypto import decrypt, encrypt
+from core.runtime.journal import JournalManager
+from core.runtime.policy import PolicyEngine
+from core.runtime.sandbox import SandboxError, run_transform
+from core.version import VERSION
+from tgc.bootstrap_fs import DATA, LOGS, ensure_first_run
+
+
+@dataclass
+class PluginRecord:
+    id: str
+    name: str
+    version: str
+    services: List[str]
+    scopes: List[str]
+    manifest: Dict[str, Any]
+    configured: bool
+    instance: PluginV2 = field(repr=False)
+
+
+class CoreAlpha:
+    def __init__(self, *, policy_path: Path) -> None:
+        self.run_id = time.strftime("%Y%m%dT%H%M%SZ", time.gmtime())
+        self.bootstrap = ensure_first_run()
+        self.policy = PolicyEngine(policy_path)
+        self.journal = JournalManager(DATA)
+        self.broker = ConnectionBroker(controller=None)
+        self._lock = threading.Lock()
+        self._plugins: List[PluginRecord] = []
+        self.session_token: Optional[str] = None
+        self._load_plugins()
+        self._register_core_capabilities()
+
+    @property
+    def plugins(self) -> List[PluginRecord]:
+        return list(self._plugins)
+
+    def _load_plugins(self) -> None:
+        from core.plugins_alpha import discover_alpha_plugins
+
+        plugins: List[PluginRecord] = []
+        for plugin in discover_alpha_plugins():
+            manifest = plugin.manifest()
+            try:
+                desc = plugin.describe() or {}
+            except Exception:
+                desc = {}
+            services = [str(s) for s in desc.get("services", []) if isinstance(s, str)]
+            scopes = [str(s) for s in desc.get("scopes", []) if isinstance(s, str)]
+            configured = bool(services)
+            record = PluginRecord(
+                id=str(getattr(plugin, "id", plugin.__class__.__name__)),
+                name=str(getattr(plugin, "name", plugin.__class__.__name__)),
+                version=str(getattr(plugin, "version", "0")),
+                services=services,
+                scopes=scopes,
+                manifest=manifest,
+                configured=configured,
+                instance=plugin,
+            )
+            plugins.append(record)
+            self._register_capabilities(record)
+            if configured and hasattr(plugin, "register_broker"):
+                try:
+                    plugin.register_broker(self.broker)
+                except Exception:
+                    pass
+        self._plugins = plugins
+        registry.emit_manifest_async()
+
+    def _register_capabilities(self, record: PluginRecord) -> None:
+        provides = record.manifest.get("provides", [])
+        requires = record.manifest.get("requires", [])
+        if not isinstance(provides, list):
+            provides = []
+        status = "pending" if record.configured else "blocked"
+        reason = None if record.configured else "plugin_not_configured"
+        for cap in provides:
+            policy_block = {"allowed": record.configured, "reason": reason}
+            if requires:
+                policy_block["requires"] = requires
+            registry.upsert(cap, provider=record.id, status=status, policy=policy_block)
+
+    def _register_core_capabilities(self) -> None:
+        ok, meta = validate_google_service_account()
+        registry.upsert(
+            "auth.google.service_account",
+            provider="core",
+            status="ready" if ok else "blocked",
+            policy={"allowed": ok, "reason": None if ok else meta.get("detail", "missing")},
+            meta={k: v for k, v in meta.items() if k in {"project_id", "client_email", "path_exists"}},
+        )
+
+    def configure_session_token(self, token: str) -> None:
+        self.session_token = token
+
+    # ---- primitives ----
+    def read(self, source: str, selector: Dict[str, Any], limits: Optional[Dict[str, Any]]) -> Dict[str, Any]:
+        decision = self.policy.evaluate("read", {"source": source, **(selector or {})})
+        return {
+            "source": source,
+            "selector": selector or {},
+            "limits": limits or {},
+            "allowed": decision.allowed,
+            "reasons": list(decision.reasons),
+        }
+
+    def transform(
+        self,
+        *,
+        plugin_id: str,
+        fn: str,
+        input_payload: Dict[str, Any],
+        limits: Optional[Dict[str, Any]],
+        idempotency_key: str,
+    ) -> Dict[str, Any]:
+        metadata = {"plugin": plugin_id, "fn": fn}
+        policy_decision = self.policy.evaluate("transform", metadata)
+        if not policy_decision.allowed:
+            return {"proposal": None, "policy": policy_decision}
+        payload = {"input": input_payload, "limits": limits or {}}
+        try:
+            result = run_transform(plugin_id, fn, payload)
+        except SandboxError as exc:
+            return {"proposal": {"error": str(exc)}, "policy": policy_decision}
+        proposal = result.get("proposal") or {}
+        inputs_hash = hashlib.sha256(json.dumps(input_payload, sort_keys=True).encode("utf-8")).hexdigest()
+        proposal_hash = hashlib.sha256(json.dumps(proposal, sort_keys=True).encode("utf-8")).hexdigest()
+        try:
+            self.journal.prepare(
+                run_id=self.run_id,
+                actor=plugin_id,
+                intent="transform",
+                idempotency_key=idempotency_key,
+                inputs_hash=inputs_hash,
+                proposal_hash=proposal_hash,
+                policy_version=self.policy.version,
+            )
+        except ValueError as exc:
+            return {"proposal": {"error": str(exc)}, "policy": policy_decision}
+        for record in self._plugins:
+            if record.id == plugin_id:
+                for cap in record.manifest.get("provides", []):
+                    registry.upsert(
+                        cap,
+                        provider=plugin_id,
+                        status="ready",
+                        policy={"allowed": True},
+                    )
+        registry.emit_manifest_async()
+        return {"proposal": proposal, "policy": policy_decision}
+
+    def write(self, target: str, proposal: Dict[str, Any], idempotency_key: str) -> Dict[str, Any]:
+        metadata = {"target": target}
+        decision = self.policy.evaluate("write", metadata)
+        if not decision.allowed:
+            return {"status": "denied", "policy": decision}
+        inputs_hash = hashlib.sha256(json.dumps({"target": target}, sort_keys=True).encode("utf-8")).hexdigest()
+        proposal_hash = hashlib.sha256(json.dumps(proposal, sort_keys=True).encode("utf-8")).hexdigest()
+        try:
+            journal_entry = self.journal.prepare(
+                run_id=self.run_id,
+                actor="core",
+                intent="write",
+                idempotency_key=idempotency_key,
+                inputs_hash=inputs_hash,
+                proposal_hash=proposal_hash,
+                policy_version=self.policy.version,
+            )
+        except ValueError as exc:
+            return {"status": "error", "policy": decision, "error": str(exc)}
+        self.journal.commit(journal_entry["journal_id"], result="commit")
+        return {"status": "committed", "policy": decision, "journal_id": journal_entry["journal_id"]}
+
+    def encrypt(self, dek_id: str, chunks: List[Any]) -> List[str]:
+        return encrypt(dek_id, chunks)
+
+    def decrypt(self, dek_id: str, chunks: List[str]) -> List[str]:
+        return decrypt(dek_id, chunks)
+
+    # ---- transparency ----
+    def transparency_report(self) -> Dict[str, Any]:
+        enabled = [p.id for p in self._plugins if p.configured]
+        caps = [
+            {
+                "cap": cap.cap,
+                "provider": cap.provider,
+                "status": cap.status,
+                "policy": cap.policy,
+            }
+            for cap in registry.list()
+        ]
+        return {
+            "version": VERSION,
+            "policy_mode": self.policy.mode,
+            "telemetry": "off",
+            "enabled_plugins": enabled,
+            "capability_summary": caps,
+            "journal_path": str(self.journal.journal_path),
+            "audit_path": str(self.journal.audit_path),
+            "manifest_path": str(MANIFEST_PATH),
+            "data_paths": [str(DATA), str(LOGS)],
+            "retention_policy": {"journal": "manual", "logs": "manual"},
+        }
+
+    def plugin_list(self) -> List[Dict[str, Any]]:
+        out: List[Dict[str, Any]] = []
+        for record in self._plugins:
+            if not record.configured:
+                continue
+            out.append(
+                {
+                    "id": record.id,
+                    "name": record.name,
+                    "services": record.services,
+                    "scopes": record.scopes,
+                    "version": record.version,
+                }
+            )
+        return out
+
+    def update_capabilities_after_probe(self, results: Dict[str, Dict[str, Any]]) -> None:
+        for record in self._plugins:
+            if not record.configured:
+                continue
+            service_ok = any(results.get(svc, {}).get("ok") for svc in record.services)
+            status = "ready" if service_ok else "blocked"
+            policy = {"allowed": service_ok}
+            if not service_ok:
+                policy["reason"] = "probe_failed"
+            for cap in record.manifest.get("provides", []):
+                registry.upsert(cap, provider=record.id, status=status, policy=policy)
+        registry.emit_manifest_async()
+
+    def probe_services(self, services: List[str]) -> Dict[str, Any]:
+        from core.runtime.probe import probe_services
+
+        results = probe_services(self.broker, services)
+        self.update_capabilities_after_probe(results)
+        return results
+
+
+__all__ = ["CoreAlpha", "PluginRecord"]

--- a/core/runtime/crypto.py
+++ b/core/runtime/crypto.py
@@ -1,0 +1,48 @@
+from __future__ import annotations
+
+from typing import Iterable, List
+
+from cryptography.fernet import Fernet
+
+
+class _DekPool:
+    def __init__(self) -> None:
+        self._keys: dict[str, bytes] = {}
+
+    def get(self, dek_id: str) -> bytes:
+        if dek_id not in self._keys:
+            self._keys[dek_id] = Fernet.generate_key()
+        return self._keys[dek_id]
+
+
+def _ensure_bytes(data) -> bytes:
+    if isinstance(data, bytes):
+        return data
+    if isinstance(data, str):
+        return data.encode("utf-8")
+    raise TypeError("chunk must be bytes or str")
+
+
+def _to_text(data: bytes) -> str:
+    return data.decode("utf-8")
+
+
+_pool = _DekPool()
+
+
+def encrypt(dek_id: str, chunks: Iterable) -> List[str]:
+    key = _pool.get(dek_id)
+    f = Fernet(key)
+    out: List[str] = []
+    for chunk in chunks:
+        out.append(_to_text(f.encrypt(_ensure_bytes(chunk))))
+    return out
+
+
+def decrypt(dek_id: str, chunks: Iterable[str]) -> List[str]:
+    key = _pool.get(dek_id)
+    f = Fernet(key)
+    out: List[str] = []
+    for chunk in chunks:
+        out.append(_to_text(f.decrypt(_ensure_bytes(chunk))))
+    return out

--- a/core/runtime/journal.py
+++ b/core/runtime/journal.py
@@ -1,0 +1,171 @@
+from __future__ import annotations
+
+import json
+import threading
+import time
+import uuid
+import hashlib
+import tempfile
+from pathlib import Path
+from typing import Any, Dict, List, Optional
+
+
+def _atomic_append(path: Path, lines: List[str]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    existing = ""
+    if path.exists():
+        existing = path.read_text(encoding="utf-8")
+    with tempfile.NamedTemporaryFile("w", delete=False, encoding="utf-8", dir=str(path.parent)) as tf:
+        if existing:
+            tf.write(existing)
+            if not existing.endswith("\n"):
+                tf.write("\n")
+        for line in lines:
+            tf.write(line.rstrip("\n") + "\n")
+        tmp_name = tf.name
+    Path(tmp_name).replace(path)
+
+
+def _json_hash(obj: Dict[str, Any]) -> str:
+    payload = json.dumps(obj, sort_keys=True, separators=(",", ":")).encode("utf-8")
+    return hashlib.sha256(payload).hexdigest()
+
+
+class JournalManager:
+    """Append-only journal + audit chain."""
+
+    def __init__(self, data_dir: Path) -> None:
+        self._data_dir = data_dir
+        self._journal_path = data_dir / "journal.log"
+        self._audit_path = data_dir / "audit.log"
+        self._lock = threading.Lock()
+        self._last_journal_hash = ""
+        self._last_audit_hash = ""
+        self._idempotency: Dict[str, str] = {}
+        self._journal_index: Dict[str, Dict[str, Any]] = {}
+        self._recover()
+
+    @property
+    def journal_path(self) -> Path:
+        return self._journal_path
+
+    @property
+    def audit_path(self) -> Path:
+        return self._audit_path
+
+    def _load_lines(self, path: Path) -> List[Dict[str, Any]]:
+        if not path.exists():
+            return []
+        out: List[Dict[str, Any]] = []
+        for line in path.read_text(encoding="utf-8").splitlines():
+            line = line.strip()
+            if not line:
+                continue
+            try:
+                out.append(json.loads(line))
+            except json.JSONDecodeError:
+                continue
+        return out
+
+    def _recover(self) -> None:
+        with self._lock:
+            journal_entries = self._load_lines(self._journal_path)
+            audit_entries = self._load_lines(self._audit_path)
+            committed = {a.get("journal_id") for a in audit_entries if a.get("result") == "commit"}
+            rolled_back = {a.get("journal_id") for a in audit_entries if a.get("result") in {"rollback", "replay"}}
+            self._journal_index = {}
+            self._idempotency = {}
+            self._last_journal_hash = ""
+            for entry in journal_entries:
+                jid = str(entry.get("journal_id"))
+                if not jid:
+                    continue
+                self._journal_index[jid] = entry
+                self._last_journal_hash = _json_hash(entry)
+                self._idempotency[str(entry.get("idempotency_key"))] = "pending"
+            self._last_audit_hash = ""
+            for entry in audit_entries:
+                self._last_audit_hash = entry.get("hash", "")
+                jid = str(entry.get("journal_id"))
+                if jid and entry.get("result") == "commit":
+                    self._idempotency[str(self._journal_index.get(jid, {}).get("idempotency_key"))] = "committed"
+                elif jid:
+                    self._idempotency[str(self._journal_index.get(jid, {}).get("idempotency_key"))] = "rolled_back"
+            pending = {
+                jid: entry
+                for jid, entry in self._journal_index.items()
+                if jid not in committed and jid not in rolled_back
+            }
+            for jid, entry in pending.items():
+                self._record_audit_locked(jid, "rollback", detail="recovered_pending")
+                self._idempotency[str(entry.get("idempotency_key"))] = "rolled_back"
+
+    def prepare(
+        self,
+        *,
+        run_id: str,
+        actor: str,
+        intent: str,
+        idempotency_key: str,
+        inputs_hash: str,
+        proposal_hash: str,
+        policy_version: str,
+    ) -> Dict[str, Any]:
+        with self._lock:
+            existing_status = self._idempotency.get(idempotency_key)
+            if existing_status == "committed":
+                raise ValueError("idempotency_key_already_committed")
+            journal_id = str(uuid.uuid4())
+            entry = {
+                "journal_id": journal_id,
+                "run_id": run_id,
+                "actor": actor,
+                "intent": intent,
+                "inputs_hash": inputs_hash,
+                "proposal_hash": proposal_hash,
+                "policy_version": policy_version,
+                "idempotency_key": idempotency_key,
+                "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+                "prev_hash": self._last_journal_hash,
+            }
+            digest = _json_hash(entry)
+            _atomic_append(self._journal_path, [json.dumps(entry, separators=(",", ":"))])
+            self._last_journal_hash = digest
+            self._journal_index[journal_id] = entry
+            self._idempotency[idempotency_key] = "pending"
+            return entry
+
+    def commit(self, journal_id: str, *, result: str = "commit") -> Dict[str, Any]:
+        if result not in {"commit", "rollback", "replay"}:
+            raise ValueError("invalid_result")
+        with self._lock:
+            return self._record_audit_locked(journal_id, result)
+
+    def _record_audit_locked(self, journal_id: str, result: str, detail: Optional[str] = None) -> Dict[str, Any]:
+        record = {
+            "journal_id": journal_id,
+            "result": result,
+            "ts": time.strftime("%Y-%m-%dT%H:%M:%SZ", time.gmtime()),
+            "prev_hash": self._last_audit_hash,
+        }
+        if detail:
+            record["detail"] = detail
+        record_hash = _json_hash(record)
+        record["hash"] = record_hash
+        _atomic_append(self._audit_path, [json.dumps(record, separators=(",", ":"))])
+        self._last_audit_hash = record_hash
+        entry = self._journal_index.get(journal_id)
+        if entry:
+            self._idempotency[str(entry.get("idempotency_key"))] = "committed" if result == "commit" else "rolled_back"
+        return record
+
+    def status_for_idempotency(self, key: str) -> Optional[str]:
+        return self._idempotency.get(key)
+
+    def as_dict(self) -> Dict[str, Any]:
+        with self._lock:
+            return {
+                "journal_path": str(self._journal_path),
+                "audit_path": str(self._audit_path),
+                "idempotency": dict(self._idempotency),
+            }

--- a/core/runtime/policy.py
+++ b/core/runtime/policy.py
@@ -1,0 +1,93 @@
+from __future__ import annotations
+
+import json
+import threading
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Tuple
+
+
+@dataclass(frozen=True)
+class PolicyDecision:
+    decision: str
+    reasons: Tuple[str, ...]
+    version: str
+
+    @property
+    def allowed(self) -> bool:
+        return self.decision.lower() == "allow"
+
+
+class PolicyEngine:
+    """Simple deny-by-default policy engine."""
+
+    def __init__(self, policy_path: Path) -> None:
+        self._path = policy_path
+        self._lock = threading.Lock()
+        self._mode = "enforce"
+        self._version = "default"
+        self._rules: List[Dict[str, Any]] = []
+        self._load()
+
+    @property
+    def mode(self) -> str:
+        return self._mode
+
+    @property
+    def version(self) -> str:
+        return self._version
+
+    def _load(self) -> None:
+        with self._lock:
+            try:
+                data = json.loads(self._path.read_text(encoding="utf-8"))
+            except FileNotFoundError:
+                data = {}
+            except json.JSONDecodeError as exc:
+                data = {"_error": str(exc)}
+            self._mode = str(data.get("mode") or "enforce").lower()
+            self._version = str(data.get("version") or "default")
+            rules = data.get("rules")
+            if isinstance(rules, list):
+                self._rules = [r for r in rules if isinstance(r, dict)]
+            else:
+                self._rules = []
+
+    def reload(self) -> None:
+        self._load()
+
+    def evaluate(self, intent: str, metadata: Dict[str, Any]) -> PolicyDecision:
+        intent = (intent or "").lower().strip()
+        reasons: List[str] = []
+        decision = "deny"
+        for rule in list(self._rules):
+            if rule.get("intent") != intent:
+                continue
+            conditions = rule.get("conditions")
+            if not self._conditions_match(conditions, metadata):
+                continue
+            decision = str(rule.get("decision") or "deny").lower()
+            reason = str(rule.get("reason") or rule.get("id") or "policy_rule")
+            reasons.append(reason)
+            break
+        if not reasons:
+            reasons.append("no_matching_rule")
+        return PolicyDecision(decision=decision, reasons=tuple(reasons), version=self._version)
+
+    def simulate(self, intent: str, metadata: Dict[str, Any]) -> PolicyDecision:
+        return self.evaluate(intent, metadata)
+
+    @staticmethod
+    def _conditions_match(conditions: Any, metadata: Dict[str, Any]) -> bool:
+        if not conditions:
+            return True
+        if isinstance(conditions, dict):
+            for key, expected in conditions.items():
+                if isinstance(expected, Iterable) and not isinstance(expected, (str, bytes, dict)):
+                    if str(metadata.get(key)) not in {str(v) for v in expected}:
+                        return False
+                else:
+                    if str(metadata.get(key)) != str(expected):
+                        return False
+            return True
+        return False

--- a/core/runtime/probe.py
+++ b/core/runtime/probe.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import concurrent.futures
+import time
+from typing import Dict, List
+
+from core.conn_broker import ConnectionBroker
+
+PROBE_TIMEOUT_SEC = 5
+
+
+def _probe_one(broker: ConnectionBroker, svc: str) -> dict:
+    t0 = time.time()
+    try:
+        res = broker.probe(svc)
+        if not isinstance(res, dict):
+            res = {"ok": bool(res)}
+        res.setdefault("elapsed_ms", int((time.time() - t0) * 1000))
+        return res
+    except Exception as exc:
+        return {
+            "ok": False,
+            "detail": "probe_exception",
+            "error": str(exc),
+            "elapsed_ms": int((time.time() - t0) * 1000),
+        }
+
+
+def probe_services(broker: ConnectionBroker, services: List[str]) -> Dict[str, dict]:
+    results: Dict[str, dict] = {}
+    if not services:
+        return results
+    max_workers = min(8, max(1, len(services)))
+    wall_timeout = PROBE_TIMEOUT_SEC * max(1, len(services))
+    with concurrent.futures.ThreadPoolExecutor(max_workers=max_workers) as pool:
+        futs = {pool.submit(_probe_one, broker, svc): svc for svc in services}
+        try:
+            for fut in concurrent.futures.as_completed(futs, timeout=wall_timeout):
+                svc = futs[fut]
+                try:
+                    results[svc] = fut.result(timeout=0)
+                except concurrent.futures.TimeoutError:
+                    results[svc] = {
+                        "ok": False,
+                        "detail": "probe_timeout",
+                        "timeout_sec": PROBE_TIMEOUT_SEC,
+                    }
+                except Exception as exc:
+                    results[svc] = {
+                        "ok": False,
+                        "detail": "probe_exception",
+                        "error": str(exc),
+                    }
+        except concurrent.futures.TimeoutError:
+            pass
+    for fut, svc in futs.items():
+        if svc not in results:
+            results[svc] = {
+                "ok": False,
+                "detail": "probe_timeout",
+                "timeout_sec": PROBE_TIMEOUT_SEC,
+            }
+    return results

--- a/core/runtime/sandbox.py
+++ b/core/runtime/sandbox.py
@@ -1,0 +1,52 @@
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+import sys
+import tempfile
+from typing import Any, Dict
+
+
+class SandboxError(RuntimeError):
+    ...
+
+
+def run_transform(plugin_id: str, fn: str, payload: Dict[str, Any], *, timeout: float = 5.0) -> Dict[str, Any]:
+    """Execute plugin transform in a sandboxed subprocess."""
+
+    with tempfile.TemporaryDirectory(prefix="bus_sandbox_") as tmp:
+        env = os.environ.copy()
+        env["BUS_SANDBOX_DIR"] = tmp
+        cmd = [
+            sys.executable,
+            "-m",
+            "core.runtime.sandbox_runner",
+            "--plugin",
+            plugin_id,
+            "--fn",
+            fn,
+        ]
+        try:
+            proc = subprocess.run(
+                cmd,
+                input=json.dumps(payload).encode("utf-8"),
+                capture_output=True,
+                timeout=max(timeout, 0.5),
+                check=False,
+                cwd=tmp,
+                env=env,
+            )
+        except subprocess.TimeoutExpired as exc:
+            raise SandboxError(f"sandbox_timeout:{plugin_id}:{fn}") from exc
+        if proc.returncode != 0:
+            detail = proc.stderr.decode("utf-8", errors="ignore").strip()
+            raise SandboxError(
+                f"sandbox_error:{plugin_id}:{fn}:{proc.returncode}:{detail}",
+            )
+        stdout = proc.stdout.decode("utf-8")
+        try:
+            result = json.loads(stdout or "{}")
+        except json.JSONDecodeError as exc:
+            raise SandboxError("sandbox_invalid_json") from exc
+        return result

--- a/core/runtime/sandbox_runner.py
+++ b/core/runtime/sandbox_runner.py
@@ -1,0 +1,44 @@
+from __future__ import annotations
+
+import argparse
+import importlib
+import json
+import sys
+from typing import Any, Dict
+
+from core.contracts.plugin_v2 import PluginV2
+
+
+def _load_plugin(plugin_id: str) -> PluginV2:
+    module_names = [f"plugins_alpha.{plugin_id}.plugin", f"plugins_alpha.{plugin_id}"]
+    last_exc: Exception | None = None
+    for name in module_names:
+        try:
+            module = importlib.import_module(name)
+        except Exception as exc:  # pragma: no cover - defensive
+            last_exc = exc
+            continue
+        plugin_cls = getattr(module, "Plugin", None)
+        if plugin_cls and issubclass(plugin_cls, PluginV2):
+            return plugin_cls()
+    raise RuntimeError(f"plugin_not_found:{plugin_id}:{last_exc}")
+
+
+def main(argv: list[str] | None = None) -> int:
+    parser = argparse.ArgumentParser(description="Sandbox runner")
+    parser.add_argument("--plugin", required=True)
+    parser.add_argument("--fn", required=True)
+    args = parser.parse_args(argv)
+
+    payload = json.loads(sys.stdin.read() or "{}")
+    plugin = _load_plugin(args.plugin)
+    input_data: Dict[str, Any] = payload.get("input") or {}
+    limits = payload.get("limits") or {}
+    proposal = plugin.plan_transform(args.fn, input_data, limits=limits)
+    output = {"proposal": proposal}
+    sys.stdout.write(json.dumps(output))
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())

--- a/docs/DATA_LIFECYCLE.md
+++ b/docs/DATA_LIFECYCLE.md
@@ -1,0 +1,44 @@
+# BUS Core Alpha Data Lifecycle
+
+This document explains how BUS Core Alpha handles data, where it is stored, and how operators can clear or rotate it.
+
+## Storage Locations
+
+| Path | Purpose | Notes |
+| ---- | ------- | ----- |
+| `data/journal.log` | Write-ahead log (JSONL) | Append-only; records prepare phase details. |
+| `data/audit.log` | Audit chain (JSONL) | Hash chained; records commit/rollback/replay events. |
+| `logs/` | Runtime logs | Per-run file named `core_<run_id>.log`; `/logs` endpoint tails last 200 lines. |
+| `data/session_token.txt` | Current session token | Regenerated on each boot; can be cleared via `config clear --what data`. |
+| `~/.tgc/secrets` or `%LOCALAPPDATA%\TGC\secrets` | Encrypted secrets store | Managed by `core.secrets`; populated through `python app.py secrets set ...`. |
+| `plugins_alpha/<id>/settings.json` | Optional read-only plugin settings | Never written by plugins; toggle read-only via `python app.py config settings-ro`. |
+| `~/.tgc/state/system_manifest.json` | Last capability manifest | Written asynchronously by `/capabilities`. |
+
+## Lifecycle Principles
+
+1. **Core-owned writes only** – Plugins never write to disk. All stateful writes go through Core primitives.
+2. **Two-phase writes** – `write()` and successful `transform()` calls record a journal entry before committing. Audit entries follow once commits/rollbacks resolve.
+3. **Crash safety** – On startup, the journal manager rolls back any entry without an audit record and appends a `rollback` event.
+4. **No telemetry** – Logs are local only; no remote upload or background diagnostics.
+5. **Secrets in RAM** – Encryption keys are held in-memory; decrypted payloads are never written to disk.
+
+## Retention & Rotation
+
+* Journals and audits are retained until an operator deletes them. Suggested practice: archive after review, then remove with `python app.py config clear --what data`.
+* Logs follow the same manual retention policy. Each boot creates a new file.
+* Session tokens are regenerated automatically and stored in `data/session_token.txt` for CLI convenience.
+
+## Operator Controls
+
+* **Secrets** – Run `python app.py secrets set --plugin <id> --key <name>` to write secrets. Remove them with `python app.py config clear --what secrets`.
+* **Data** – Run `python app.py config clear --what data` to clear journals, logs, and session tokens. This does not touch plugin settings.
+* **Transparency** – `/transparency.report` summarises active paths, retention mode, and plugin state. `/policy.simulate` lets operators inspect policy outcomes without performing an action.
+
+## Data Flow Overview
+
+1. **Read**: Requests go through the policy engine; allowed reads return structured data and never write to disk.
+2. **Transform**: Input is packaged into a sandboxed subprocess. The subprocess can only propose operations; it does not persist results. The Core records the proposal in the journal and surfaces it back to the caller.
+3. **Write**: Not exposed over HTTP in Core Alpha, but the primitive is available internally. It records to the journal, re-evaluates policy, and then commits with an audit record.
+4. **Secrets**: Plugins retrieve secrets via `core.secrets.Secrets.get` on demand. They never cache or persist them.
+
+For additional context, review `docs/TRANSPARENCY.md` and inspect the live transparency endpoints.

--- a/docs/TRANSPARENCY.md
+++ b/docs/TRANSPARENCY.md
@@ -1,0 +1,49 @@
+# BUS Core Alpha Transparency Report
+
+The BUS Core Alpha runtime is built for transparency and local control. This document summarises what the Core does at runtime, where data flows, and how operators can verify behaviour.
+
+## Identity & Versioning
+
+* **Core version**: `${VERSION}` (reported via `/health`).
+* **Policy mode**: Loaded from `config/policy.json`. Default is `enforce` with deny-by-default rules.
+* **Run identifier**: Every boot emits a unique `run_id` that appears in all API responses and logs.
+
+## Runtime Surfaces
+
+* **HTTP API** (localhost only): `/health`, `/plugins`, `/probe`, `/capabilities`, `/execTransform`, `/policy.simulate`, `/nodes.manifest.sync`, `/transparency.report`, `/logs`.
+* **Plugin imports**: Guarded allowlist (`core.contracts.plugin_v2`, `core.conn_broker`, `core.secrets`, `core.capabilities`). Any other `core.*` import fails at load time.
+* **Sandbox**: Transform executions run in an ephemeral subprocess with a per-run temporary directory and a hard timeout.
+
+## Journaling & Audit
+
+* **Journal path**: `data/journal.log` (append-only JSONL). Each entry records `journal_id`, `intent`, hashes of inputs/proposals, policy version, and `prev_hash` for continuity.
+* **Audit path**: `data/audit.log` (append-only JSONL). Contains hash-chained records of `commit`, `rollback`, and crash-recovery `replay` events.
+* **Crash recovery**: On boot the Core rolls back any uncommitted journal entries and records the rollback in the audit log.
+
+## Capabilities & Manifests
+
+* Core signs capability manifests with an internal HMAC key stored under the local profile directory (`~/.tgc/state` or `%LOCALAPPDATA%\TGC\state`).
+* `/capabilities` builds the manifest in-memory, returns it immediately, and writes to disk asynchronously (never blocks the request path).
+* `/nodes.manifest.sync` validates signatures from remote peers but never writes without verification.
+
+## Telemetry & Diagnostics
+
+* **Telemetry**: Disabled. No network beacons, analytics, or background telemetry are emitted.
+* **Diagnostics**: `logs/` contains per-run append-only logs. `/logs` returns the last 200 lines for local inspection only.
+* **Policy simulator**: `/policy.simulate` offers an explicit alternative to legacy “dry-run” modes.
+
+## Plugins
+
+* Only configured plugins are exposed on `/plugins` and participate in `/probe`.
+* Each plugin manifest declares `id`, `version`, `provides`, `requires`, `stages`, and `trust_tier` for transparency.
+* Plugins never persist secrets. They access credentials through `core.secrets.Secrets`, which in turn prefers the OS keyring and falls back to an encrypted local store.
+
+## Operator Checklist
+
+1. Inspect `docs/DATA_LIFECYCLE.md` for retention and clearing procedures.
+2. Review `config/policy.json` to understand allowed operations.
+3. Start the server (`python -m uvicorn core.api.http:APP ...`) and confirm the startup trust banner.
+4. Call `/transparency.report` and verify paths, telemetry status, and enabled plugins.
+5. Use `python app.py config status` to review local paths.
+
+This document, alongside the live `/transparency.report`, forms the disclosure package shipped with the Core.

--- a/plugins_alpha/echo/plugin.py
+++ b/plugins_alpha/echo/plugin.py
@@ -22,3 +22,9 @@ class Plugin(PluginV2):
             return {"ok": True, "detail": "echo_ready"}  # returns immediately
 
         broker.register("echo", provider=provider, probe=probe)
+
+    def plan_transform(self, fn: str, payload, *, limits=None):
+        if fn != "noop":
+            raise ValueError("unknown_transform")
+        summary = {"echo": payload}
+        return {"operations": [], "summary": summary}


### PR DESCRIPTION
## Summary
- replace the HTTP surface with the BUS Core Alpha endpoints and trust banner logging
- add the sandboxed transform runner, policy engine, journaling/audit primitives, and capability management helpers
- document transparency and data lifecycle details while shipping default policy configuration

## Testing
- `pytest`


------
https://chatgpt.com/codex/tasks/task_e_68f4047514908322b9d31b5ab94ab616