### PR TITLE
Add local dashboard UI served at /ui

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -7,6 +7,8 @@ from pathlib import Path
 from typing import Any, Dict, List, Optional
 
 from fastapi import Body, FastAPI, Header, HTTPException, Request
+from fastapi.responses import FileResponse
+from fastapi.staticfiles import StaticFiles
 
 from core.capabilities import registry
 from core.capabilities.registry import MANIFEST_PATH
@@ -17,6 +19,7 @@ from core.version import VERSION
 from tgc.bootstrap_fs import DATA, LOGS
 
 APP = FastAPI(title="BUS Core Alpha", version=VERSION)
+APP.mount("/ui/static", StaticFiles(directory="core/ui"), name="ui-static")
 LICENSE_NAME = "PolyForm-Noncommercial-1.0.0"
 LICENSE_URL = "https://polyformproject.org/licenses/noncommercial/1.0.0/"
 
@@ -73,6 +76,11 @@ def _with_run_id(payload: Dict[str, Any]) -> Dict[str, Any]:
     payload = dict(payload)
     payload.setdefault("run_id", RUN_ID)
     return payload
+
+
+@APP.get("/ui")
+def ui_index() -> FileResponse:
+    return FileResponse("core/ui/index.html")
 
 
 @APP.get("/health")

--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -1,0 +1,262 @@
+(function () {
+  const TOKEN_STORAGE_KEY = "tgc_token";
+  const panels = {};
+  let currentToken = "";
+
+  const tokenInput = document.getElementById("token-input");
+  const saveTokenBtn = document.getElementById("save-token");
+  const refreshAllBtn = document.getElementById("refresh-all");
+  const tokenBanner = document.getElementById("token-banner");
+  const logsAutoscroll = document.getElementById("logs-autoscroll");
+  const probeServices = document.getElementById("probe-services");
+  const runProbeBtn = document.getElementById("run-probe");
+
+  document.querySelectorAll(".panel").forEach((section) => {
+    const panelName = section.dataset.panel;
+    panels[panelName] = {
+      section,
+      content: section.querySelector('[data-role="content"]'),
+      error: section.querySelector('[data-role="error"]'),
+      timing: section.querySelector('[data-role="timing"]'),
+      timestamp: section.querySelector('[data-role="timestamp"]'),
+      refreshBtn: section.querySelector('button[data-action="refresh"]'),
+    };
+  });
+
+  function loadToken() {
+    const stored = window.localStorage.getItem(TOKEN_STORAGE_KEY) || "";
+    currentToken = stored;
+    if (tokenInput) {
+      tokenInput.value = stored;
+    }
+    updateTokenBanner(!currentToken);
+  }
+
+  function saveToken() {
+    const nextToken = (tokenInput ? tokenInput.value.trim() : "");
+    window.localStorage.setItem(TOKEN_STORAGE_KEY, nextToken);
+    currentToken = nextToken;
+    updateTokenBanner(!currentToken);
+    if (currentToken) {
+      refreshAll();
+    }
+  }
+
+  function updateTokenBanner(show) {
+    if (!tokenBanner) {
+      return;
+    }
+    if (show) {
+      tokenBanner.classList.remove("hidden");
+    } else {
+      tokenBanner.classList.add("hidden");
+    }
+  }
+
+  function updatePanelMeta(panel, elapsedMs) {
+    if (!panel) {
+      return;
+    }
+    panel.timing.textContent = typeof elapsedMs === "number" ? `${elapsedMs} ms` : "—";
+    panel.timestamp.textContent = new Date().toLocaleTimeString();
+  }
+
+  function setPanelError(panel, message) {
+    if (!panel) {
+      return;
+    }
+    panel.error.textContent = message || "";
+  }
+
+  function setPanelContent(panel, text) {
+    if (!panel) {
+      return;
+    }
+    panel.content.textContent = text;
+  }
+
+  function ensureToken(panel) {
+    if (!currentToken) {
+      updateTokenBanner(true);
+      setPanelError(panel, "Session token required.");
+      panel.timing.textContent = "—";
+      panel.timestamp.textContent = "—";
+      return false;
+    }
+    return true;
+  }
+
+  async function requestJSON(path, options, panelName) {
+    const panel = panels[panelName];
+    if (!panel) {
+      return;
+    }
+    if (!ensureToken(panel)) {
+      return;
+    }
+
+    const requestOptions = Object.assign({ method: "GET" }, options || {});
+    const headers = Object.assign({}, requestOptions.headers || {}, {
+      "X-Session-Token": currentToken,
+    });
+    if (requestOptions.body && !headers["Content-Type"]) {
+      headers["Content-Type"] = "application/json";
+    }
+    requestOptions.headers = headers;
+
+    setPanelError(panel, "");
+    setPanelContent(panel, "Loading…");
+
+    const start = performance.now();
+    try {
+      const response = await fetch(path, requestOptions);
+      const elapsed = Math.round(performance.now() - start);
+      if (!response.ok) {
+        updatePanelMeta(panel, elapsed);
+        let errorText = `${response.status} ${response.statusText}`;
+        try {
+          const payload = await response.clone().json();
+          if (payload && payload.detail) {
+            errorText += ` – ${payload.detail}`;
+          }
+        } catch (err) {
+          // ignore JSON parsing failure for error body
+        }
+        if (response.status === 401) {
+          updateTokenBanner(true);
+        }
+        setPanelError(panel, errorText);
+        setPanelContent(panel, "");
+        return;
+      }
+
+      const data = await response.json();
+      updatePanelMeta(panel, Math.round(performance.now() - start));
+      updateTokenBanner(false);
+      renderPanel(panelName, data);
+    } catch (error) {
+      panel.timing.textContent = "—";
+      panel.timestamp.textContent = "—";
+      setPanelError(panel, error instanceof Error ? error.message : String(error));
+      setPanelContent(panel, "");
+    }
+  }
+
+  function renderPanel(panelName, data) {
+    const panel = panels[panelName];
+    if (!panel) {
+      return;
+    }
+    setPanelError(panel, "");
+    if (panelName === "logs") {
+      const lines = Array.isArray(data.logs) ? data.logs : [];
+      const text = lines.join("\n");
+      setPanelContent(panel, text);
+      if (logsAutoscroll && logsAutoscroll.checked) {
+        panel.content.scrollTop = panel.content.scrollHeight;
+      }
+      return;
+    }
+    setPanelContent(panel, JSON.stringify(data, null, 2));
+  }
+
+  function getProbeServices() {
+    try {
+      const source = probeServices ? probeServices.value : "[]";
+      const parsed = JSON.parse(source || "[]");
+      if (Array.isArray(parsed)) {
+        return parsed.map((item) => String(item));
+      }
+    } catch (error) {
+      // handled by caller
+    }
+    return null;
+  }
+
+  async function refreshHealth() {
+    await requestJSON("/health", { method: "GET" }, "health");
+  }
+
+  async function refreshPlugins() {
+    await requestJSON("/plugins", { method: "GET" }, "plugins");
+  }
+
+  async function refreshCapabilities() {
+    await requestJSON("/capabilities", { method: "GET" }, "capabilities");
+  }
+
+  async function refreshLogs() {
+    await requestJSON("/logs", { method: "GET" }, "logs");
+  }
+
+  async function runProbe() {
+    const panel = panels.probe;
+    if (!panel) {
+      return;
+    }
+    if (!ensureToken(panel)) {
+      return;
+    }
+    const services = getProbeServices();
+    if (!services) {
+      setPanelError(panel, "Services must be a JSON array.");
+      return;
+    }
+    await requestJSON(
+      "/probe",
+      {
+        method: "POST",
+        body: JSON.stringify({ services }),
+      },
+      "probe"
+    );
+  }
+
+  function refreshAll() {
+    refreshHealth();
+    refreshPlugins();
+    refreshCapabilities();
+    refreshLogs();
+  }
+
+  function attachEvents() {
+    if (saveTokenBtn) {
+      saveTokenBtn.addEventListener("click", saveToken);
+    }
+    if (tokenInput) {
+      tokenInput.addEventListener("keydown", (event) => {
+        if (event.key === "Enter") {
+          event.preventDefault();
+          saveToken();
+        }
+      });
+    }
+    if (refreshAllBtn) {
+      refreshAllBtn.addEventListener("click", refreshAll);
+    }
+    if (panels.health?.refreshBtn) {
+      panels.health.refreshBtn.addEventListener("click", refreshHealth);
+    }
+    if (panels.plugins?.refreshBtn) {
+      panels.plugins.refreshBtn.addEventListener("click", refreshPlugins);
+    }
+    if (panels.capabilities?.refreshBtn) {
+      panels.capabilities.refreshBtn.addEventListener("click", refreshCapabilities);
+    }
+    if (panels.logs?.refreshBtn) {
+      panels.logs.refreshBtn.addEventListener("click", refreshLogs);
+    }
+    if (panels.probe?.refreshBtn) {
+      panels.probe.refreshBtn.addEventListener("click", runProbe);
+    }
+    if (runProbeBtn) {
+      runProbeBtn.addEventListener("click", runProbe);
+    }
+  }
+
+  loadToken();
+  attachEvents();
+  if (currentToken) {
+    refreshAll();
+  }
+})();

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -1,0 +1,106 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Core Dashboard</title>
+    <link rel="stylesheet" href="/ui/static/styles.css" />
+  </head>
+  <body>
+    <header class="page-header">
+      <div class="header-main">
+        <h1>Core Dashboard</h1>
+        <button id="refresh-all" type="button">Refresh All</button>
+      </div>
+      <div class="token-controls">
+        <label for="token-input">Session Token</label>
+        <input type="password" id="token-input" autocomplete="off" />
+        <button id="save-token" type="button">Save Token</button>
+      </div>
+    </header>
+
+    <div class="banner info" id="local-banner">
+      <strong>Local &amp; Transparent:</strong> data never leaves your machine. HTTP is
+      localhost-only. Telemetry is off.
+    </div>
+
+    <div class="banner error hidden" id="token-banner">Invalid or missing token</div>
+
+    <main class="panels">
+      <section class="panel" data-panel="health">
+        <div class="panel-header">
+          <h2>Health</h2>
+          <div class="panel-actions">
+            <span class="panel-meta" data-role="timing">&mdash;</span>
+            <span class="panel-meta" data-role="timestamp">&mdash;</span>
+            <button type="button" data-action="refresh">Refresh</button>
+          </div>
+        </div>
+        <pre class="panel-content" data-role="content"></pre>
+        <div class="panel-error" data-role="error"></div>
+      </section>
+
+      <section class="panel" data-panel="plugins">
+        <div class="panel-header">
+          <h2>Plugins</h2>
+          <div class="panel-actions">
+            <span class="panel-meta" data-role="timing">&mdash;</span>
+            <span class="panel-meta" data-role="timestamp">&mdash;</span>
+            <button type="button" data-action="refresh">Refresh</button>
+          </div>
+        </div>
+        <pre class="panel-content" data-role="content"></pre>
+        <div class="panel-error" data-role="error"></div>
+      </section>
+
+      <section class="panel" data-panel="capabilities">
+        <div class="panel-header">
+          <h2>Capabilities</h2>
+          <div class="panel-actions">
+            <span class="panel-meta" data-role="timing">&mdash;</span>
+            <span class="panel-meta" data-role="timestamp">&mdash;</span>
+            <button type="button" data-action="refresh">Refresh</button>
+          </div>
+        </div>
+        <pre class="panel-content" data-role="content"></pre>
+        <div class="panel-error" data-role="error"></div>
+      </section>
+
+      <section class="panel" data-panel="probe">
+        <div class="panel-header">
+          <h2>Probe</h2>
+          <div class="panel-actions">
+            <span class="panel-meta" data-role="timing">&mdash;</span>
+            <span class="panel-meta" data-role="timestamp">&mdash;</span>
+            <button type="button" data-action="refresh">Run Probe</button>
+          </div>
+        </div>
+        <div class="probe-controls">
+          <label for="probe-services">Services (JSON array)</label>
+          <textarea id="probe-services" rows="3">["echo"]</textarea>
+          <button id="run-probe" type="button">Run Probe</button>
+        </div>
+        <pre class="panel-content" data-role="content"></pre>
+        <div class="panel-error" data-role="error"></div>
+      </section>
+    </main>
+
+    <section class="panel logs" data-panel="logs">
+      <div class="panel-header">
+        <h2>Logs</h2>
+        <div class="panel-actions">
+          <span class="panel-meta" data-role="timing">&mdash;</span>
+          <span class="panel-meta" data-role="timestamp">&mdash;</span>
+          <label class="autoscale">
+            <input type="checkbox" id="logs-autoscroll" /> Auto-scroll
+          </label>
+          <button type="button" data-action="refresh">Refresh</button>
+        </div>
+      </div>
+      <pre class="panel-content" data-role="content" id="logs-content"></pre>
+      <div class="panel-error" data-role="error"></div>
+    </section>
+
+    <script src="/ui/static/app.js" defer></script>
+  </body>
+</html>

--- a/core/ui/styles.css
+++ b/core/ui/styles.css
@@ -1,0 +1,234 @@
+:root {
+  color-scheme: light dark;
+  --bg-color: #f5f5f7;
+  --bg-color-dark: #1e1e1e;
+  --panel-bg: rgba(255, 255, 255, 0.85);
+  --panel-bg-dark: rgba(40, 40, 40, 0.85);
+  --border-color: rgba(0, 0, 0, 0.12);
+  --border-color-dark: rgba(255, 255, 255, 0.15);
+  --accent: #0066cc;
+  --error: #d14343;
+  --info: #0a8754;
+  font-family: "Inter", system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+}
+
+body {
+  margin: 0;
+  min-height: 100vh;
+  background: var(--bg-color);
+  color: #1a1a1a;
+  line-height: 1.4;
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--bg-color-dark);
+    color: #f1f1f1;
+  }
+}
+
+.page-header {
+  display: flex;
+  flex-wrap: wrap;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+  padding: 1.5rem clamp(1rem, 3vw, 2.5rem) 1rem;
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.header-main {
+  display: flex;
+  align-items: center;
+  gap: 1rem;
+}
+
+.header-main h1 {
+  margin: 0;
+  font-size: clamp(1.4rem, 2vw, 1.9rem);
+}
+
+.token-controls {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.token-controls label {
+  font-weight: 600;
+}
+
+.token-controls input {
+  padding: 0.4rem 0.6rem;
+  border-radius: 6px;
+  border: 1px solid rgba(0, 0, 0, 0.2);
+  min-width: 16rem;
+}
+
+button {
+  padding: 0.45rem 0.9rem;
+  border: 1px solid transparent;
+  border-radius: 6px;
+  background: var(--accent);
+  color: white;
+  cursor: pointer;
+  font-weight: 600;
+}
+
+button:hover {
+  opacity: 0.9;
+}
+
+button:disabled {
+  opacity: 0.5;
+  cursor: not-allowed;
+}
+
+.banner {
+  margin: 0 clamp(1rem, 3vw, 2.5rem);
+  padding: 0.75rem 1rem;
+  border-radius: 8px;
+  border: 1px solid transparent;
+  font-size: 0.95rem;
+}
+
+.banner.info {
+  background: rgba(10, 135, 84, 0.1);
+  border-color: rgba(10, 135, 84, 0.4);
+}
+
+.banner.error {
+  background: rgba(209, 67, 67, 0.12);
+  border-color: rgba(209, 67, 67, 0.45);
+  color: var(--error);
+}
+
+.banner.hidden {
+  display: none;
+}
+
+.panels {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
+  gap: 1.5rem;
+  padding: 1.5rem clamp(1rem, 3vw, 2.5rem);
+}
+
+.panel {
+  background: var(--panel-bg);
+  border-radius: 12px;
+  border: 1px solid var(--border-color);
+  box-shadow: 0 4px 12px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 0.75rem;
+  padding: 1rem;
+}
+
+@media (prefers-color-scheme: dark) {
+  .panel {
+    background: var(--panel-bg-dark);
+    border-color: var(--border-color-dark);
+    box-shadow: 0 6px 16px rgba(0, 0, 0, 0.4);
+  }
+
+  .token-controls input {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.25);
+    color: inherit;
+  }
+}
+
+.panel-header {
+  display: flex;
+  justify-content: space-between;
+  gap: 0.5rem;
+  align-items: flex-start;
+}
+
+.panel-header h2 {
+  margin: 0;
+  font-size: 1.1rem;
+}
+
+.panel-actions {
+  display: flex;
+  align-items: center;
+  gap: 0.6rem;
+  flex-wrap: wrap;
+  font-size: 0.85rem;
+}
+
+.panel-meta {
+  color: rgba(60, 60, 60, 0.85);
+}
+
+@media (prefers-color-scheme: dark) {
+  .panel-meta {
+    color: rgba(220, 220, 220, 0.75);
+  }
+}
+
+.panel-content {
+  flex: 1;
+  background: rgba(0, 0, 0, 0.04);
+  border-radius: 8px;
+  padding: 0.75rem;
+  margin: 0;
+  max-height: 320px;
+  overflow: auto;
+  font-size: 0.9rem;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  .panel-content {
+    background: rgba(255, 255, 255, 0.04);
+  }
+}
+
+.panel-error {
+  min-height: 1.2rem;
+  color: var(--error);
+  font-size: 0.9rem;
+}
+
+.panel.logs {
+  margin: 0 clamp(1rem, 3vw, 2.5rem) 1.5rem;
+}
+
+.panel.logs .panel-content {
+  max-height: 260px;
+  white-space: pre-wrap;
+}
+
+.autoscale {
+  display: flex;
+  align-items: center;
+  gap: 0.3rem;
+  font-weight: 600;
+}
+
+.probe-controls {
+  display: flex;
+  flex-direction: column;
+  gap: 0.5rem;
+}
+
+.probe-controls textarea {
+  resize: vertical;
+  min-height: 3rem;
+  border-radius: 8px;
+  border: 1px solid rgba(0, 0, 0, 0.18);
+  padding: 0.5rem;
+  font-family: "SFMono-Regular", "Consolas", "Liberation Mono", monospace;
+}
+
+@media (prefers-color-scheme: dark) {
+  .probe-controls textarea {
+    background: rgba(255, 255, 255, 0.06);
+    border-color: rgba(255, 255, 255, 0.25);
+    color: inherit;
+  }
+}


### PR DESCRIPTION
## Summary
- mount a static UI bundle in the FastAPI app and expose it at /ui
- build a lightweight vanilla HTML/JS dashboard to inspect health, plugins, capabilities, probes, and logs
- add styling and token-aware client logic with manual refresh controls and error handling

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68f4097e58008322a91044aaf90d8787