### PR TITLE
Add Google Drive OAuth integration

### DIFF
--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -36,6 +36,20 @@
             <button type="button" data-action="refresh">Refresh</button>
           </div>
         </div>
+        <div id="google-auth-row" class="row">
+          <span class="label">Google Drive</span>
+          <span id="google-status" class="status-pill">Unknown</span>
+          <button id="google-connect" class="btn" type="button">Connect</button>
+          <button
+            id="google-disconnect"
+            class="btn btn-danger"
+            type="button"
+            style="display: none;"
+          >
+            ✕ Disconnect
+          </button>
+          <span id="google-check" class="check" style="display: none;">✓ Connected</span>
+        </div>
         <pre class="panel-content" data-role="content"></pre>
         <div class="panel-error" data-role="error"></div>
       </section>

--- a/core/ui/styles.css
+++ b/core/ui/styles.css
@@ -198,6 +198,45 @@ button:disabled {
   margin: 0 clamp(1rem, 3vw, 2.5rem) 1.5rem;
 }
 
+.row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  flex-wrap: wrap;
+}
+
+.row .label {
+  font-weight: 600;
+}
+
+.status-pill {
+  display: inline-flex;
+  align-items: center;
+  padding: 0.15rem 0.6rem;
+  border-radius: 999px;
+  background: rgba(0, 0, 0, 0.08);
+  font-weight: 600;
+  color: rgba(60, 60, 60, 0.85);
+}
+
+.status-pill.ok {
+  color: #0a8754;
+  background: rgba(10, 135, 84, 0.12);
+}
+
+.btn {
+  font-weight: 600;
+}
+
+.btn-danger {
+  background: var(--error);
+}
+
+.check {
+  font-weight: 600;
+  color: #0a8754;
+}
+
 .panel.logs .panel-content {
   max-height: 260px;
   white-space: pre-wrap;


### PR DESCRIPTION
## Summary
- add backend OAuth endpoints for Google Drive state, token exchange, status, and revocation
- expose Health panel controls to connect and disconnect Google Drive via new UI row
- style Google Drive controls and wire them to OAuth endpoints using session tokens

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f41852479c83228ca79160ca6848fd