### PR TITLE
Add Google Drive settings tab and secure endpoints

### DIFF
--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -3,6 +3,7 @@
   const panels = {};
   let currentToken = "";
   let googleRowInitialized = false;
+  let settingsInitialized = false;
 
   const tokenInput = document.getElementById("token-input");
   const saveTokenBtn = document.getElementById("save-token");
@@ -11,9 +12,16 @@
   const logsAutoscroll = document.getElementById("logs-autoscroll");
   const probeServices = document.getElementById("probe-services");
   const runProbeBtn = document.getElementById("run-probe");
+  const tabDashboardBtn = document.getElementById("tab-btn-dashboard");
+  const tabSettingsBtn = document.getElementById("tab-btn-settings");
+  const tabDashboard = document.getElementById("tab-dashboard");
+  const tabSettings = document.getElementById("tab-settings");
 
-  document.querySelectorAll(".panel").forEach((section) => {
+  document.querySelectorAll(".panel[data-panel]").forEach((section) => {
     const panelName = section.dataset.panel;
+    if (!panelName) {
+      return;
+    }
     panels[panelName] = {
       section,
       content: section.querySelector('[data-role="content"]'),
@@ -42,7 +50,18 @@
       refreshAll();
       initGoogleRow();
     } else {
-      renderGdUI(false);
+      renderGoogleHealthState("Missing token", false);
+      renderGsStatus("Not configured");
+      const clientIdInput = document.getElementById("gs-client-id");
+      const clientSecretInput = document.getElementById("gs-client-secret");
+      if (clientIdInput) {
+        clientIdInput.placeholder = "";
+        clientIdInput.value = "";
+      }
+      if (clientSecretInput) {
+        clientSecretInput.placeholder = "";
+        clientSecretInput.value = "";
+      }
     }
   }
 
@@ -55,6 +74,214 @@
       throw new Error("Session token required");
     }
     return { "X-Session-Token": currentToken };
+  }
+
+  function renderGsStatus(state) {
+    const el = document.getElementById("gs-status");
+    if (!el) {
+      return;
+    }
+    const variant = state === "Connected" ? "ok" : state === "Ready" ? "warn" : state === "Error" ? "bad" : "bad";
+    el.textContent = state;
+    el.className = variant ? `status-pill ${variant}` : "status-pill";
+  }
+
+  function renderGoogleHealthState(state, connected) {
+    const statusEl = document.getElementById("google-status");
+    const disconnectBtn = document.getElementById("google-disconnect");
+    const checkEl = document.getElementById("google-check");
+    if (!statusEl || !disconnectBtn || !checkEl) {
+      return;
+    }
+    let variant = "bad";
+    if (state === "Connected") {
+      variant = "ok";
+    } else if (state === "Ready") {
+      variant = "warn";
+    } else if (state === "Error") {
+      variant = "bad";
+    }
+    statusEl.textContent = state;
+    statusEl.className = variant ? `status-pill ${variant}` : "status-pill";
+    if (connected) {
+      disconnectBtn.style.display = "inline-block";
+      checkEl.style.display = "inline-block";
+    } else {
+      disconnectBtn.style.display = "none";
+      checkEl.style.display = "none";
+    }
+  }
+
+  function applyGoogleSettingsState(data) {
+    if (!data || typeof data !== "object") {
+      renderGsStatus("Not configured");
+      renderGoogleHealthState("Missing info", false);
+      return;
+    }
+    const ready = Boolean(data.has_client_id && data.has_client_secret);
+    const connected = Boolean(data.connected);
+    renderGsStatus(connected ? "Connected" : ready ? "Ready" : "Not configured");
+    renderGoogleHealthState(connected ? "Connected" : ready ? "Ready" : "Missing info", connected);
+  }
+
+  async function gsFetch(method, path, body) {
+    const headers = { ...tokenHeader(), "Content-Type": "application/json" };
+    const response = await fetch(path, {
+      method,
+      headers,
+      body: body ? JSON.stringify(body) : undefined,
+      cache: "no-store",
+    });
+    if (!response.ok) {
+      const text = await response.text();
+      throw new Error(text || `${response.status}`);
+    }
+    return response.json();
+  }
+
+  async function gsLoad() {
+    const payload = await gsFetch("GET", "/settings/google");
+    const clientIdInput = document.getElementById("gs-client-id");
+    const clientSecretInput = document.getElementById("gs-client-secret");
+    if (clientIdInput) {
+      clientIdInput.placeholder = payload.has_client_id ? payload.client_id_mask || "••••" : "";
+      clientIdInput.value = "";
+    }
+    if (clientSecretInput) {
+      clientSecretInput.placeholder = payload.has_client_secret ? "••••" : "";
+      clientSecretInput.value = "";
+    }
+    applyGoogleSettingsState(payload);
+  }
+
+  async function gsSave() {
+    const cidEl = document.getElementById("gs-client-id");
+    const secEl = document.getElementById("gs-client-secret");
+    const cid = cidEl ? cidEl.value.trim() : "";
+    const sec = secEl ? secEl.value.trim() : "";
+    const payload = {};
+    if (cid) {
+      payload.client_id = cid;
+    }
+    if (sec) {
+      payload.client_secret = sec;
+    }
+    if (!payload.client_id && !payload.client_secret) {
+      window.alert("Nothing to save.");
+      return;
+    }
+    await gsFetch("POST", "/settings/google", payload);
+    if (cidEl) {
+      cidEl.value = "";
+    }
+    if (secEl) {
+      secEl.value = "";
+    }
+    await gsLoad();
+    window.alert("Saved.");
+  }
+
+  async function gsRemove() {
+    if (!window.confirm("Remove Google OAuth client and disconnect?")) {
+      return;
+    }
+    await gsFetch("DELETE", "/settings/google");
+    await gsLoad();
+  }
+
+  async function gsTest() {
+    try {
+      const status = await gsFetch("GET", "/oauth/google/status");
+      if (status && status.connected) {
+        window.alert("Already connected.");
+        return;
+      }
+      const response = await fetch("/oauth/google/start", {
+        method: "POST",
+        headers: tokenHeader(),
+        body: "{}",
+        cache: "no-store",
+      });
+      if (response.status === 200) {
+        window.alert("Client configured. Use your OAuth flow to authorize in the browser.");
+      } else {
+        const text = await response.text();
+        window.alert(text || "Failed to start OAuth.");
+      }
+    } catch (error) {
+      const message = error instanceof Error ? error.message : String(error);
+      window.alert("Error: " + message);
+    }
+  }
+
+  function initSettingsTab() {
+    const saveBtn = document.getElementById("gs-save");
+    const removeBtn = document.getElementById("gs-remove");
+    const testBtn = document.getElementById("gs-test");
+    if (!settingsInitialized) {
+      if (saveBtn) {
+        saveBtn.onclick = () => {
+          gsSave().catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            window.alert(message);
+          });
+        };
+      }
+      if (removeBtn) {
+        removeBtn.onclick = () => {
+          gsRemove().catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            window.alert(message);
+          });
+        };
+      }
+      if (testBtn) {
+        testBtn.onclick = () => {
+          gsTest().catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            window.alert(message);
+          });
+        };
+      }
+      settingsInitialized = true;
+    }
+    gsLoad().catch(() => {
+      renderGsStatus("Not configured");
+      renderGoogleHealthState("Missing info", false);
+    });
+  }
+
+  async function refreshGoogleStatus() {
+    if (!hasToken()) {
+      renderGoogleHealthState("Missing token", false);
+      renderGsStatus("Not configured");
+      return;
+    }
+    try {
+      const payload = await gsFetch("GET", "/settings/google");
+      applyGoogleSettingsState(payload);
+    } catch (error) {
+      renderGsStatus("Error");
+      renderGoogleHealthState("Error", false);
+    }
+  }
+
+  function showTab(name) {
+    if (tabDashboardBtn) {
+      tabDashboardBtn.classList.toggle("active", name === "dashboard");
+    }
+    if (tabSettingsBtn) {
+      tabSettingsBtn.classList.toggle("active", name === "settings");
+    }
+    if (tabDashboard) {
+      tabDashboard.style.display = name === "dashboard" ? "block" : "none";
+    }
+    if (tabSettings) {
+      tabSettings.style.display = name === "settings" ? "block" : "none";
+    }
+    if (name === "settings") {
+      initSettingsTab();
+    }
   }
 
   function updateTokenBanner(show) {
@@ -234,103 +461,37 @@
     refreshLogs();
   }
 
-  async function gdStatus() {
-    const headers = tokenHeader();
-    const response = await fetch(`/oauth/google/status`, { headers });
-    if (!response.ok) {
-      throw new Error("status failed");
-    }
-    return response.json();
-  }
-
-  async function gdStart() {
-    const headers = { ...tokenHeader(), "Content-Type": "application/json" };
-    const redirect = `${window.location.origin}/oauth/google/callback`;
-    const response = await fetch(`/oauth/google/start`, {
-      method: "POST",
-      headers,
-      body: JSON.stringify({ redirect }),
-    });
-    const payload = await response.json();
-    if (!response.ok || !payload.auth_url) {
-      throw new Error(payload.error || "auth failed");
-    }
-    window.open(payload.auth_url, "_blank");
-  }
-
   async function gdRevoke() {
     const headers = tokenHeader();
     const response = await fetch(`/oauth/google/revoke`, {
       method: "POST",
       headers,
+      cache: "no-store",
     });
     if (!response.ok) {
       throw new Error("revoke failed");
     }
   }
 
-  function renderGdUI(connected) {
-    const statusEl = document.getElementById("google-status");
-    const connectBtn = document.getElementById("google-connect");
-    const disconnectBtn = document.getElementById("google-disconnect");
-    const checkEl = document.getElementById("google-check");
-    if (!statusEl || !connectBtn || !disconnectBtn || !checkEl) {
-      return;
-    }
-    if (connected) {
-      statusEl.textContent = "Connected";
-      statusEl.classList.add("ok");
-      connectBtn.style.display = "none";
-      disconnectBtn.style.display = "inline-block";
-      checkEl.style.display = "inline-block";
-    } else {
-      statusEl.textContent = "Not connected";
-      statusEl.classList.remove("ok");
-      connectBtn.style.display = "inline-block";
-      disconnectBtn.style.display = "none";
-      checkEl.style.display = "none";
-    }
-  }
-
   async function initGoogleRow() {
-    const connectBtn = document.getElementById("google-connect");
     const disconnectBtn = document.getElementById("google-disconnect");
-    if (!connectBtn || !disconnectBtn) {
+    if (!disconnectBtn) {
       return;
     }
 
     if (!googleRowInitialized) {
-      connectBtn.onclick = async () => {
-        try {
-          await gdStart();
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          window.alert(message);
-        }
-      };
-      disconnectBtn.onclick = async () => {
-        try {
-          await gdRevoke();
-          renderGdUI(false);
-        } catch (error) {
-          const message = error instanceof Error ? error.message : String(error);
-          window.alert(message);
-        }
+      disconnectBtn.onclick = () => {
+        gdRevoke()
+          .then(() => refreshGoogleStatus())
+          .catch((error) => {
+            const message = error instanceof Error ? error.message : String(error);
+            window.alert(message);
+          });
       };
       googleRowInitialized = true;
     }
 
-    if (!hasToken()) {
-      renderGdUI(false);
-      return;
-    }
-
-    try {
-      const status = await gdStatus();
-      renderGdUI(Boolean(status?.connected));
-    } catch (error) {
-      renderGdUI(false);
-    }
+    await refreshGoogleStatus();
   }
 
   function attachEvents() {
@@ -366,6 +527,12 @@
     if (runProbeBtn) {
       runProbeBtn.addEventListener("click", runProbe);
     }
+    if (tabDashboardBtn) {
+      tabDashboardBtn.addEventListener("click", () => showTab("dashboard"));
+    }
+    if (tabSettingsBtn) {
+      tabSettingsBtn.addEventListener("click", () => showTab("settings"));
+    }
   }
 
   loadToken();
@@ -378,7 +545,8 @@
     if (hasToken()) {
       initGoogleRow();
     } else {
-      renderGdUI(false);
+      renderGoogleHealthState("Missing token", false);
+      renderGsStatus("Not configured");
     }
   });
 })();

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -26,93 +26,128 @@
 
     <div class="banner error hidden" id="token-banner">Invalid or missing token</div>
 
-    <main class="panels">
-      <section class="panel" data-panel="health">
+    <nav class="tab-bar">
+      <button id="tab-btn-dashboard" class="tab-button active" type="button">Dashboard</button>
+      <button id="tab-btn-settings" class="tab-button" type="button">Settings</button>
+    </nav>
+
+    <section id="tab-dashboard" class="tab-section">
+      <main class="panels">
+        <section class="panel" data-panel="health">
+          <div class="panel-header">
+            <h2>Health</h2>
+            <div class="panel-actions">
+              <span class="panel-meta" data-role="timing">&mdash;</span>
+              <span class="panel-meta" data-role="timestamp">&mdash;</span>
+              <button type="button" data-action="refresh">Refresh</button>
+            </div>
+          </div>
+          <div id="google-auth-row" class="row">
+            <span class="label">Google Drive</span>
+            <span id="google-status" class="status-pill bad">Missing info</span>
+            <button
+              id="google-disconnect"
+              class="btn btn-danger"
+              type="button"
+              style="display: none;"
+            >
+              ✕ Disconnect
+            </button>
+            <span id="google-check" class="check" style="display: none;">✓ Connected</span>
+          </div>
+          <pre class="panel-content" data-role="content"></pre>
+          <div class="panel-error" data-role="error"></div>
+        </section>
+
+        <section class="panel" data-panel="plugins">
+          <div class="panel-header">
+            <h2>Plugins</h2>
+            <div class="panel-actions">
+              <span class="panel-meta" data-role="timing">&mdash;</span>
+              <span class="panel-meta" data-role="timestamp">&mdash;</span>
+              <button type="button" data-action="refresh">Refresh</button>
+            </div>
+          </div>
+          <pre class="panel-content" data-role="content"></pre>
+          <div class="panel-error" data-role="error"></div>
+        </section>
+
+        <section class="panel" data-panel="capabilities">
+          <div class="panel-header">
+            <h2>Capabilities</h2>
+            <div class="panel-actions">
+              <span class="panel-meta" data-role="timing">&mdash;</span>
+              <span class="panel-meta" data-role="timestamp">&mdash;</span>
+              <button type="button" data-action="refresh">Refresh</button>
+            </div>
+          </div>
+          <pre class="panel-content" data-role="content"></pre>
+          <div class="panel-error" data-role="error"></div>
+        </section>
+
+        <section class="panel" data-panel="probe">
+          <div class="panel-header">
+            <h2>Probe</h2>
+            <div class="panel-actions">
+              <span class="panel-meta" data-role="timing">&mdash;</span>
+              <span class="panel-meta" data-role="timestamp">&mdash;</span>
+              <button type="button" data-action="refresh">Run Probe</button>
+            </div>
+          </div>
+          <div class="probe-controls">
+            <label for="probe-services">Services (JSON array)</label>
+            <textarea id="probe-services" rows="3">["echo"]</textarea>
+            <button id="run-probe" type="button">Run Probe</button>
+          </div>
+          <pre class="panel-content" data-role="content"></pre>
+          <div class="panel-error" data-role="error"></div>
+        </section>
+      </main>
+
+      <section class="panel logs" data-panel="logs">
         <div class="panel-header">
-          <h2>Health</h2>
+          <h2>Logs</h2>
           <div class="panel-actions">
             <span class="panel-meta" data-role="timing">&mdash;</span>
             <span class="panel-meta" data-role="timestamp">&mdash;</span>
+            <label class="autoscale">
+              <input type="checkbox" id="logs-autoscroll" /> Auto-scroll
+            </label>
             <button type="button" data-action="refresh">Refresh</button>
           </div>
         </div>
-        <div id="google-auth-row" class="row">
-          <span class="label">Google Drive</span>
-          <span id="google-status" class="status-pill">Unknown</span>
-          <button id="google-connect" class="btn" type="button">Connect</button>
-          <button
-            id="google-disconnect"
-            class="btn btn-danger"
-            type="button"
-            style="display: none;"
-          >
-            ✕ Disconnect
-          </button>
-          <span id="google-check" class="check" style="display: none;">✓ Connected</span>
-        </div>
-        <pre class="panel-content" data-role="content"></pre>
+        <pre class="panel-content" data-role="content" id="logs-content"></pre>
         <div class="panel-error" data-role="error"></div>
       </section>
+    </section>
 
-      <section class="panel" data-panel="plugins">
-        <div class="panel-header">
-          <h2>Plugins</h2>
-          <div class="panel-actions">
-            <span class="panel-meta" data-role="timing">&mdash;</span>
-            <span class="panel-meta" data-role="timestamp">&mdash;</span>
-            <button type="button" data-action="refresh">Refresh</button>
+    <section id="tab-settings" class="tab-section" style="display: none;">
+      <div class="panels settings-panels">
+        <section class="panel settings-card">
+          <div class="settings-card-header">
+            <div>
+              <h2>Integrations</h2>
+              <p class="settings-subtitle">Google Drive (Read-only)</p>
+            </div>
+            <span id="gs-status" class="status-pill bad">Not configured</span>
           </div>
-        </div>
-        <pre class="panel-content" data-role="content"></pre>
-        <div class="panel-error" data-role="error"></div>
-      </section>
-
-      <section class="panel" data-panel="capabilities">
-        <div class="panel-header">
-          <h2>Capabilities</h2>
-          <div class="panel-actions">
-            <span class="panel-meta" data-role="timing">&mdash;</span>
-            <span class="panel-meta" data-role="timestamp">&mdash;</span>
-            <button type="button" data-action="refresh">Refresh</button>
+          <div class="form-field">
+            <label for="gs-client-id">Client ID</label>
+            <input id="gs-client-id" type="text" autocomplete="off" />
+            <small class="field-note">Shown masked on load; leave blank to keep existing.</small>
           </div>
-        </div>
-        <pre class="panel-content" data-role="content"></pre>
-        <div class="panel-error" data-role="error"></div>
-      </section>
-
-      <section class="panel" data-panel="probe">
-        <div class="panel-header">
-          <h2>Probe</h2>
-          <div class="panel-actions">
-            <span class="panel-meta" data-role="timing">&mdash;</span>
-            <span class="panel-meta" data-role="timestamp">&mdash;</span>
-            <button type="button" data-action="refresh">Run Probe</button>
+          <div class="form-field">
+            <label for="gs-client-secret">Client Secret</label>
+            <input id="gs-client-secret" type="password" autocomplete="off" />
+            <small class="field-note">Shown masked on load; leave blank to keep existing.</small>
           </div>
-        </div>
-        <div class="probe-controls">
-          <label for="probe-services">Services (JSON array)</label>
-          <textarea id="probe-services" rows="3">["echo"]</textarea>
-          <button id="run-probe" type="button">Run Probe</button>
-        </div>
-        <pre class="panel-content" data-role="content"></pre>
-        <div class="panel-error" data-role="error"></div>
-      </section>
-    </main>
-
-    <section class="panel logs" data-panel="logs">
-      <div class="panel-header">
-        <h2>Logs</h2>
-        <div class="panel-actions">
-          <span class="panel-meta" data-role="timing">&mdash;</span>
-          <span class="panel-meta" data-role="timestamp">&mdash;</span>
-          <label class="autoscale">
-            <input type="checkbox" id="logs-autoscroll" /> Auto-scroll
-          </label>
-          <button type="button" data-action="refresh">Refresh</button>
-        </div>
+          <div class="settings-actions">
+            <button id="gs-save" class="btn" type="button">Save</button>
+            <button id="gs-test" class="btn" type="button">Test Connection</button>
+            <button id="gs-remove" class="btn btn-danger" type="button">Remove / Disconnect</button>
+          </div>
+        </section>
       </div>
-      <pre class="panel-content" data-role="content" id="logs-content"></pre>
-      <div class="panel-error" data-role="error"></div>
     </section>
 
     <script src="/ui/static/app.js" defer></script>

--- a/core/ui/styles.css
+++ b/core/ui/styles.css
@@ -108,6 +108,49 @@ button:disabled {
   display: none;
 }
 
+.tab-bar {
+  display: flex;
+  gap: 0.5rem;
+  margin: 1.5rem clamp(1rem, 3vw, 2.5rem) 0;
+  padding: 0 clamp(1rem, 3vw, 2.5rem);
+  border-bottom: 1px solid rgba(0, 0, 0, 0.08);
+}
+
+.tab-button {
+  background: transparent;
+  color: inherit;
+  border: none;
+  border-bottom: 3px solid transparent;
+  border-radius: 6px 6px 0 0;
+  padding: 0.6rem 1rem;
+  font-weight: 600;
+  cursor: pointer;
+}
+
+.tab-button:hover {
+  opacity: 1;
+  background: rgba(0, 0, 0, 0.05);
+}
+
+.tab-button.active {
+  border-bottom-color: var(--accent);
+  background: rgba(0, 0, 0, 0.06);
+  color: var(--accent);
+}
+
+@media (prefers-color-scheme: dark) {
+  .tab-bar {
+    border-bottom-color: rgba(255, 255, 255, 0.12);
+  }
+  .tab-button:hover {
+    background: rgba(255, 255, 255, 0.08);
+  }
+  .tab-button.active {
+    background: rgba(255, 255, 255, 0.1);
+    color: #90c2ff;
+  }
+}
+
 .panels {
   display: grid;
   grid-template-columns: repeat(auto-fit, minmax(260px, 1fr));
@@ -212,16 +255,27 @@ button:disabled {
 .status-pill {
   display: inline-flex;
   align-items: center;
-  padding: 0.15rem 0.6rem;
+  padding: 0.2rem 0.65rem;
   border-radius: 999px;
-  background: rgba(0, 0, 0, 0.08);
   font-weight: 600;
+  font-size: 0.85rem;
+  background: rgba(0, 0, 0, 0.08);
   color: rgba(60, 60, 60, 0.85);
 }
 
 .status-pill.ok {
-  color: #0a8754;
-  background: rgba(10, 135, 84, 0.12);
+  background: #1f9d55;
+  color: #ffffff;
+}
+
+.status-pill.warn {
+  background: #b7791f;
+  color: #ffffff;
+}
+
+.status-pill.bad {
+  background: #c53030;
+  color: #ffffff;
 }
 
 .btn {
@@ -270,4 +324,59 @@ button:disabled {
     border-color: rgba(255, 255, 255, 0.25);
     color: inherit;
   }
+}
+
+.settings-panels {
+  grid-template-columns: minmax(260px, 460px);
+  justify-content: flex-start;
+}
+
+.settings-card {
+  gap: 1rem;
+}
+
+.settings-card-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 1rem;
+}
+
+.settings-subtitle {
+  margin: 0.25rem 0 0;
+  font-size: 0.9rem;
+  color: rgba(60, 60, 60, 0.7);
+}
+
+@media (prefers-color-scheme: dark) {
+  .settings-subtitle {
+    color: rgba(220, 220, 220, 0.7);
+  }
+}
+
+.form-field {
+  display: flex;
+  flex-direction: column;
+  gap: 0.35rem;
+}
+
+.form-field label {
+  font-weight: 600;
+}
+
+.field-note {
+  font-size: 0.8rem;
+  color: rgba(60, 60, 60, 0.7);
+}
+
+@media (prefers-color-scheme: dark) {
+  .field-note {
+    color: rgba(220, 220, 220, 0.6);
+  }
+}
+
+.settings-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 0.75rem;
 }


### PR DESCRIPTION
## Summary
- add secure Google Drive settings models and CRUD endpoints backed by the secrets manager with masked responses
- require configured credentials before starting OAuth and apply no-store caching headers to the integration routes
- introduce a Settings tab UI for managing Google Drive credentials, update the dashboard status row, and wire up supporting JavaScript and styles

## Testing
- python -m compileall core/api/http.py

------
https://chatgpt.com/codex/tasks/task_e_68f422d8cdc48322b9cdf0a7d9805991