### PR TITLE
Add packaged launcher and UI dev workflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,46 @@ irm http://127.0.0.1:8765/plugins -Headers @{ 'X-Session-Token'=$token }
 irm http://127.0.0.1:8765/probe   -Method Post -Headers @{ 'X-Session-Token'=$token } -ContentType application/json -Body "{}"
 ```
 
+## Packaged Dev App (TGC Controller)
+
+Build the development-friendly ONEDIR bundle (PowerShell):
+
+```
+py -3.11 -m venv .venv
+.\\.venv\\Scripts\\Activate.ps1
+python -m pip install --upgrade pip
+pip install -r requirements.txt
+pip install pyinstaller
+
+pyinstaller launcher.py ^
+  --name "TGC Controller" ^
+  --noconsole ^
+  --onedir ^
+  --add-data "core/ui;core/ui" ^
+  --add-data "LICENSE;." ^
+  --hidden-import uvicorn ^
+  --hidden-import fastapi
+```
+
+Launch the packaged controller:
+
+```
+.\\dist\\TGC-Controller\\TGC Controller.exe
+```
+
+On startup it will:
+
+* create (or reuse) `data\\` and `logs\\` beside the executable and save the current session token to `data\\session_token.txt`.
+* print the token path and the resolved UI directory (`core\\ui`) so you can see where files are being served from.
+* wait for the core to report healthy and open `http://127.0.0.1:8765/ui` (or the fallback port if 8765 is busy).
+
+Live UI editing while the app runs:
+
+* Edit the static assets under `.\\dist\\TGC-Controller\\core\\ui\\` (for example `index.html`, `app.js`, or `styles.css`).
+* Refresh the browser tab — changes are served immediately because the ONEDIR layout keeps those files on disk.
+
+To stop the app, close the window or press `Ctrl+C` in the console; the embedded uvicorn server will shut down cleanly.
+
 Plugins:
 
 * Put plugins under `plugins_alpha/<your_plugin>/plugin.py`

--- a/launcher.py
+++ b/launcher.py
@@ -1,0 +1,187 @@
+from __future__ import annotations
+
+import argparse
+import atexit
+import os
+import signal
+import socket
+import sys
+import threading
+import time
+import webbrowser
+from pathlib import Path
+from typing import Optional, Tuple
+from urllib import error, request
+
+import uvicorn
+
+from core.api.http import UI_STATIC_DIR, build_app
+from tgc.bootstrap_fs import DATA, LOGS, TOKEN_FILE
+
+DEFAULT_PORT = 8765
+FALLBACK_PORT = 8777
+HEALTH_PATH = "/health"
+
+
+def _base_directory() -> Path:
+    if getattr(sys, "frozen", False):  # PyInstaller
+        return Path(sys.executable).resolve().parent
+    return Path(__file__).resolve().parent
+
+
+def _ensure_runtime_dirs() -> None:
+    for path in (DATA, LOGS):
+        path.mkdir(parents=True, exist_ok=True)
+
+
+def _is_port_free(port: int) -> bool:
+    with socket.socket(socket.AF_INET, socket.SOCK_STREAM) as sock:
+        sock.setsockopt(socket.SOL_SOCKET, socket.SO_REUSEADDR, 1)
+        try:
+            sock.bind(("127.0.0.1", port))
+        except OSError:
+            return False
+    return True
+
+
+def _parse_port(value: Optional[str]) -> Optional[int]:
+    if not value:
+        return None
+    try:
+        port = int(value)
+    except ValueError:
+        return None
+    if 0 < port < 65536:
+        return port
+    return None
+
+
+def _select_port(args_port: Optional[int], data_dir: Path) -> Tuple[int, bool, Optional[int]]:
+    env_port = _parse_port(os.environ.get("TGC_PORT") or os.environ.get("PORT"))
+    last_port_path = data_dir / "last_port.txt"
+    explicit = args_port is not None or env_port is not None
+
+    if args_port is not None:
+        port = args_port
+    elif env_port is not None:
+        port = env_port
+    else:
+        port = DEFAULT_PORT
+        if last_port_path.exists():
+            previous = _parse_port(last_port_path.read_text(encoding="utf-8").strip())
+            if previous:
+                port = previous
+
+    if _is_port_free(port):
+        return port, explicit, None
+
+    if explicit:
+        raise RuntimeError(f"Port {port} is not available")
+
+    fallback_candidates = []
+    if port != DEFAULT_PORT:
+        fallback_candidates.append(DEFAULT_PORT)
+    if FALLBACK_PORT not in fallback_candidates and FALLBACK_PORT != port:
+        fallback_candidates.append(FALLBACK_PORT)
+
+    for candidate in fallback_candidates:
+        if _is_port_free(candidate):
+            return candidate, False, port
+
+    raise RuntimeError("No available port found")
+
+
+def _write_last_port(port: int, data_dir: Path) -> None:
+    try:
+        (data_dir / "last_port.txt").write_text(str(port), encoding="utf-8")
+    except OSError:
+        pass
+
+
+def _wait_for_health(port: int, token: str, retries: int = 40, delay: float = 0.5) -> bool:
+    url = f"http://127.0.0.1:{port}{HEALTH_PATH}"
+    headers = {"X-Session-Token": token}
+    for _ in range(retries):
+        try:
+            req = request.Request(url, headers=headers)
+            with request.urlopen(req, timeout=2.0) as resp:
+                if resp.status == 200:
+                    return True
+        except error.URLError:
+            time.sleep(delay)
+        except Exception:
+            time.sleep(delay)
+    return False
+
+
+def main(argv: Optional[list[str]] = None) -> int:
+    parser = argparse.ArgumentParser(description="TGC Controller launcher")
+    parser.add_argument("--port", type=int, help="Override listen port", default=None)
+    args = parser.parse_args(argv)
+
+    base_dir = _base_directory()
+    os.chdir(base_dir)
+
+    _ensure_runtime_dirs()
+
+    try:
+        port, explicit, previous = _select_port(args.port, DATA)
+    except RuntimeError as exc:
+        print(f"Error: {exc}")
+        return 1
+
+    if previous is not None:
+        print(f"Port {previous} unavailable, using {port}")
+    elif port != DEFAULT_PORT and not explicit:
+        print(f"Selected port {port}")
+
+    app, session_token = build_app()
+
+    print(f"Session token saved at: {TOKEN_FILE.resolve()}")
+    print(f"Served UI from: {UI_STATIC_DIR.resolve()}")
+
+    config = uvicorn.Config(app, host="127.0.0.1", port=port, log_level="info")
+    server = uvicorn.Server(config)
+
+    def _shutdown_server() -> None:
+        if not server.should_exit:
+            server.should_exit = True
+
+    atexit.register(_shutdown_server)
+
+    server_thread = threading.Thread(target=server.run, name="uvicorn-server", daemon=True)
+    server_thread.start()
+
+    if not server.started.wait(timeout=10):
+        print("Error: server failed to start")
+        server.should_exit = True
+        server_thread.join(timeout=5)
+        return 1
+
+    _write_last_port(port, DATA)
+    print(f"TGC Controller running at http://127.0.0.1:{port}")
+
+    if _wait_for_health(port, session_token):
+        webbrowser.open(f"http://127.0.0.1:{port}/ui")
+    else:
+        print("Warning: core health check failed; UI will not auto-open.")
+
+    def _signal_handler(signum, frame):  # noqa: ARG001
+        server.should_exit = True
+
+    for signame in (signal.SIGINT, signal.SIGTERM):
+        signal.signal(signame, _signal_handler)
+
+    try:
+        while server_thread.is_alive():
+            time.sleep(0.2)
+    except KeyboardInterrupt:
+        server.should_exit = True
+    finally:
+        server_thread.join()
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tgc_controller.spec
+++ b/tgc_controller.spec
@@ -1,0 +1,53 @@
+# -*- mode: python ; coding: utf-8 -*-
+
+block_cipher = None
+
+
+a = Analysis(
+    ['launcher.py'],
+    pathex=[],
+    binaries=[],
+    datas=[
+        ('core/ui', 'core/ui'),
+        ('LICENSE', '.'),
+    ],
+    hiddenimports=['uvicorn', 'fastapi'],
+    hookspath=[],
+    hooksconfig={},
+    runtime_hooks=[],
+    excludes=[],
+    win_no_prefer_redirects=False,
+    win_private_assemblies=False,
+    cipher=block_cipher,
+    noarchive=False,
+)
+pyz = PYZ(a.pure, a.zipped_data, cipher=block_cipher)
+
+exe = EXE(
+    pyz,
+    a.scripts,
+    [],
+    exclude_binaries=True,
+    name='TGC Controller',
+    debug=False,
+    bootloader_ignore_signals=False,
+    strip=False,
+    upx=True,
+    console=False,
+    disable_windowed_traceback=False,
+    target_arch=None,
+    codesign_identity=None,
+    entitlements_file=None,
+)
+
+coll = COLLECT(
+    exe,
+    a.binaries,
+    a.zipfiles,
+    a.datas,
+    strip=False,
+    upx=True,
+    upx_exclude=[],
+    name='TGC Controller',
+    distpath='dist/TGC-Controller',
+)


### PR DESCRIPTION
## Summary
- add a Windows-friendly launcher that boots uvicorn in-process, ensures runtime folders, reuses session tokens, and opens the UI once healthy
- make the FastAPI app resolve its static UI directory for source, onedir, and onefile layouts while logging the chosen path
- provide a PyInstaller spec and README guidance for building and editing the packaged ONEDIR distribution

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f4fab080408322865575cea1d9c09a