### PR TITLE
Update Reader plugin Google OAuth secrets

### DIFF
--- a/plugins_alpha/reader/plugin.py
+++ b/plugins_alpha/reader/plugin.py
@@ -13,7 +13,7 @@ from typing import Any, Dict, List, Optional, Tuple
 import requests  # assumed available; if not, please `pip install requests`
 
 SERVICE_ID = "reader"
-VERSION = "0.1.1"  # bumped
+VERSION = "0.1.2"  # bumped
 
 _broker = None
 _log = None
@@ -58,15 +58,27 @@ def _settings() -> Dict[str, Any]:
 # ---------------- Google helpers ----------------
 
 def _google_client() -> Tuple[Optional[str], Optional[str], Optional[str]]:
-    # Try a few common namespaces for compatibility
-    cid = (_get_secret("google_oauth", "client_id")
-           or _get_secret("google", "client_id")
-           or _get_secret("oauth.google", "client_id"))
-    cs = (_get_secret("google_oauth", "client_secret")
-          or _get_secret("google", "client_secret")
-          or _get_secret("oauth.google", "client_secret"))
-    rt = (_get_secret("google_drive", "refresh_token")
-          or _get_secret("google", "refresh_token"))
+    get = getattr(_broker, "get_secret", lambda *_: None)
+    # client id / secret across common namespaces
+    cid = (
+        get("google_oauth", "client_id")
+        or get("oauth.google", "client_id")
+        or get("google", "client_id")
+        or get("google_drive", "client_id")
+    )
+    cs = (
+        get("google_oauth", "client_secret")
+        or get("oauth.google", "client_secret")
+        or get("google", "client_secret")
+        or get("google_drive", "client_secret")
+    )
+    # refresh token across common namespaces (drive keeps it most often)
+    rt = (
+        get("google_drive", "refresh_token")
+        or get("oauth.google", "refresh_token")
+        or get("google_oauth", "refresh_token")
+        or get("google", "refresh_token")
+    )
     return cid, cs, rt
 
 def _google_access_token() -> Optional[str]:


### PR DESCRIPTION
## Summary
- expand Google OAuth client credential lookup to cover multiple namespaces for Drive
- retain local requests session use and bump the plugin version to 0.1.2

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f56277f07c8322a93700035950eb1b