### PR TITLE
Add autocheck and full pull support to Reader plugin and UI

### DIFF
--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -111,11 +111,19 @@
             </div>
           </div>
           <div class="outputs-controls">
-            <label for="reader-source">Source</label>
-            <select id="reader-source">
-              <option value="drive">Drive</option>
-              <option value="local">Local</option>
-            </select>
+            <div style="margin:8px 0;">
+              <div id="reader-status" class="muted" style="margin-bottom:6px;">Checking sources…</div>
+              <div style="display:flex; gap:8px; align-items:center; flex-wrap:wrap;">
+                <label>Source:</label>
+                <select id="reader-source">
+                  <option value="drive">Drive</option>
+                  <option value="local">Local</option>
+                </select>
+                <button id="reader-fullpull" class="btn">Start Full Pull</button>
+                <button id="reader-cancelpull" class="btn btn-secondary" disabled>Cancel</button>
+                <span id="reader-progress" class="muted"></span>
+              </div>
+            </div>
             <button id="reader-index-all" type="button" class="btn">Index All</button>
           </div>
           <div id="reader-tree" class="tree"></div>


### PR DESCRIPTION
## Summary
- add Reader plugin operations for `autocheck` and `start_full_pull` so readiness checks and catalog streams stay inside Core
- extend the Outputs panel with source status messaging plus start/cancel controls for a full pull
- wire the UI to call the new plugin operations, stream catalog pages, and display progress updates

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f5762ffd2c83229b1b940b541b2507