### PR TITLE
Remove legacy provider modules and wire bootstrap broker

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -28,6 +28,7 @@ from tgc.bootstrap_fs import DATA, LOGS
 
 from pydantic import BaseModel
 
+from core.domain.bootstrap import get_broker
 from core.settings.reader import load_reader_settings, save_reader_settings
 
 
@@ -155,8 +156,6 @@ oauth = APIRouter()
 
 
 def _broker():
-    from core.runtime import get_broker
-
     return get_broker()
 
 
@@ -666,6 +665,7 @@ def build_app():
     DATA.mkdir(parents=True, exist_ok=True)
     (DATA / "session_token.txt").write_text(SESSION_TOKEN, encoding="utf-8")
     CORE.configure_session_token(SESSION_TOKEN)
+    APP.state.broker = get_broker()
     LOG_FILE = LOGS / f"core_{RUN_ID}.log"
     LOG_FILE.parent.mkdir(parents=True, exist_ok=True)
     banner = f"[trust] mode={CORE.policy.mode} telemetry=off data={DATA} logs={LOGS}"

--- a/core/broker/__init__.py
+++ b/core/broker/__init__.py
@@ -1,5 +1,0 @@
-"""Runtime broker helpers."""
-
-from .runtime import Broker
-
-__all__ = ["Broker"]

--- a/core/catalog/__init__.py
+++ b/core/catalog/__init__.py
@@ -1,5 +1,0 @@
-"""Catalog streaming helpers."""
-
-from .manager import CatalogManager
-
-__all__ = ["CatalogManager"]

--- a/core/domain/bootstrap.py
+++ b/core/domain/bootstrap.py
@@ -1,0 +1,63 @@
+from __future__ import annotations
+
+import json
+import logging
+import os
+from typing import Any, Dict
+
+from core.domain.broker import Broker
+from core.capabilities import registry
+from core.secrets import Secrets
+from core.settings.reader import load_reader_settings
+
+_DEFAULT_SETTINGS: Dict[str, Any] = {
+    "enabled": {"drive": True, "local": True, "notion": False, "smb": False},
+    "local_roots": [],
+}
+
+_broker_singleton: Broker | None = None
+
+
+def _logger_factory(name: str):
+    base = f"core.{name}" if name else "core"
+    return logging.getLogger(base)
+
+
+def _load_reader_settings() -> Dict[str, Any]:
+    try:
+        settings = load_reader_settings()
+        if isinstance(settings, dict):
+            return settings
+    except Exception:
+        pass
+    path = os.path.join("data", "settings_reader.json")
+    if os.path.exists(path):
+        try:
+            with open(path, "r", encoding="utf-8") as handle:
+                data = json.load(handle)
+                if isinstance(data, dict):
+                    return data
+        except Exception:
+            pass
+    return dict(_DEFAULT_SETTINGS)
+
+
+def set_broker(broker: Broker) -> None:
+    global _broker_singleton
+    _broker_singleton = broker
+
+
+def get_broker() -> Broker:
+    global _broker_singleton
+    if _broker_singleton is not None:
+        return _broker_singleton
+    _broker_singleton = Broker(
+        secrets_manager=Secrets,
+        logger_factory=_logger_factory,
+        capabilities=registry,
+        settings_reader_loader=_load_reader_settings,
+    )
+    return _broker_singleton
+
+
+__all__ = ["get_broker", "set_broker"]

--- a/core/providers/__init__.py
+++ b/core/providers/__init__.py
@@ -1,3 +1,0 @@
-"""Core-owned data providers."""
-
-__all__ = []

--- a/core/runtime/__init__.py
+++ b/core/runtime/__init__.py
@@ -1,25 +1,7 @@
 """Runtime utilities for BUS Core Alpha."""
 
-from __future__ import annotations
+from .core_alpha import CoreAlpha
+from .policy import PolicyDecision
+from .probe import PROBE_TIMEOUT_SEC
 
-from typing import Optional, TYPE_CHECKING
-
-if TYPE_CHECKING:  # pragma: no cover
-    from core.domain.broker import Broker
-
-
-_BROKER: Optional["Broker"] = None
-
-
-def set_broker(broker: "Broker") -> None:
-    global _BROKER
-    _BROKER = broker
-
-
-def get_broker() -> "Broker":
-    if _BROKER is None:
-        raise RuntimeError("broker_not_initialized")
-    return _BROKER
-
-
-__all__ = ["get_broker", "set_broker"]
+__all__ = ["CoreAlpha", "PolicyDecision", "PROBE_TIMEOUT_SEC"]

--- a/core/runtime/core_alpha.py
+++ b/core/runtime/core_alpha.py
@@ -12,13 +12,13 @@ from typing import Any, Dict, List, Optional
 from core.auth.google_sa import validate_google_service_account
 from core.capabilities import registry
 from core.capabilities.registry import MANIFEST_PATH
+from core.domain.bootstrap import set_broker
 from core.domain.broker import Broker
 from core.contracts.plugin_v2 import PluginV2
 from core.runtime.crypto import decrypt, encrypt
 from core.runtime.journal import JournalManager
 from core.runtime.policy import PolicyEngine
 from core.runtime.sandbox import SandboxError, run_transform
-from core.runtime import set_broker
 from core.secrets import Secrets
 from core.settings.reader import load_reader_settings
 from core.version import VERSION

--- a/tgc/cli_main.py
+++ b/tgc/cli_main.py
@@ -9,11 +9,9 @@ from datetime import UTC, datetime
 from typing import Dict, List, Optional
 
 from core.bus.models import CommandContext
-from core.domain.broker import Broker
-from core.capabilities import registry
+from core.domain.bootstrap import get_broker
 from core.plugins_alpha import discover_alpha_plugins as _discover_alpha_plugins
 from core.secrets import Secrets
-from core.settings.reader import load_reader_settings
 from tgc.bootstrap import bootstrap_controller
 from tgc.bootstrap_fs import ensure_first_run
 
@@ -174,13 +172,8 @@ def alpha_boot(args):
     controller = bootstrap_controller()
     run_id = datetime.now(UTC).strftime("%Y%m%dT%H%M%SZ")
     context = _mk_context(controller, run_id, dry_run=bool(getattr(args, "dry_run", False)))
-    broker = Broker(
-        Secrets,
-        lambda name: logging.getLogger(f"plugins.{name}" if name else "plugins"),
-        registry,
-        load_reader_settings,
-    )
-    context.extras["conn_broker"] = broker
+    context.extras["conn_broker"] = get_broker()
+    broker = context.extras["conn_broker"]
 
     plugins_instances = _discover_alpha_plugins()
     plugin_names: List[str] = []


### PR DESCRIPTION
## Summary
- remove the legacy provider, broker, and catalog packages that were replaced by the alpha refactor
- add a core.domain.bootstrap module to own broker construction and expose a reusable get_broker
- update FastAPI, runtime, and CLI entrypoints to resolve the broker through the new bootstrap

## Testing
- `python -c "from core.adapters.drive.provider import GoogleDriveProvider; from core.domain.broker import Broker; print('ok')"`
- `python app.py serve --port 8765`
- `curl -s -H "X-Session-Token: $TOKEN" http://127.0.0.1:8765/health`
- `curl -s -H "X-Session-Token: $TOKEN" -H "Content-Type: application/json" -d '{"op":"autocheck"}' http://127.0.0.1:8765/plugins/reader/read`
- `curl -s -H "X-Session-Token: $TOKEN" -H "Content-Type: application/json" -d '{"source":"local_fs","scope":"local_roots","options":{}}' http://127.0.0.1:8765/catalog/open`
- `curl -s -H "X-Session-Token: $TOKEN" -H "Content-Type: application/json" -d '{"stream_id":"$SID","max_items":10}' http://127.0.0.1:8765/catalog/next`

------
https://chatgpt.com/codex/tasks/task_e_68f58def5c6c8322922d2d4c0ac6be0e