### PR TITLE
Add built-in Drive and Local read plugins with toggles

### DIFF
--- a/core/plugins/loader.py
+++ b/core/plugins/loader.py
@@ -1,23 +1,194 @@
-"""Lightweight plugin module registry."""
+"""Lightweight plugin module registry with discovery helpers."""
 
 from __future__ import annotations
 
+import importlib
+import json
+import os
+from pathlib import Path
 from types import ModuleType
-from typing import Dict
+from typing import Dict, Iterable, List, Optional
+
+
+MODULE_DIR = Path(__file__).resolve().parent
+CORE_DIR = MODULE_DIR.parent
+ROOT_DIR = CORE_DIR.parent
+
+BUILTIN_PLUGIN_ROOT = os.path.abspath(CORE_DIR / "plugins_builtin")
+ALPHA_PLUGIN_ROOT = os.path.abspath(ROOT_DIR / "plugins_alpha")
+USER_PLUGIN_ROOT = os.path.abspath(ROOT_DIR / "plugins_user")
+
+_PLUGIN_ROOTS: List[tuple[str, str]] = [
+    (BUILTIN_PLUGIN_ROOT, "core.plugins_builtin"),
+    (ALPHA_PLUGIN_ROOT, "plugins_alpha"),
+    (USER_PLUGIN_ROOT, "plugins_user"),
+]
 
 _PLUGINS: Dict[str, ModuleType] = {}
+_PLUGIN_INFO: Dict[str, Dict[str, object]] = {}
+_LOADED = False
+
+_SETTINGS_PATH = Path("data/settings_plugins.json")
+
+
+def _ensure_loaded() -> None:
+    global _LOADED
+    if _LOADED:
+        return
+    for root, base_module in _PLUGIN_ROOTS:
+        if not root or not os.path.isdir(root):
+            continue
+        root_path = Path(root)
+        for plugin_file in sorted(root_path.rglob("plugin.py")):
+            if plugin_file.name != "plugin.py":
+                continue
+            try:
+                relative = plugin_file.relative_to(root_path)
+            except ValueError:
+                continue
+            parts = list(relative.parts[:-1])
+            if not parts:
+                continue
+            if any(part.startswith("_") for part in parts):
+                continue
+            module_name = ".".join([base_module, *parts, "plugin"])
+            try:
+                module = importlib.import_module(module_name)
+            except Exception:
+                continue
+            register(module)
+    _LOADED = True
+
+
+def _collect_metadata(service_id: str, module: ModuleType) -> Dict[str, object]:
+    plugin_path = Path(getattr(module, "__file__", "") or "").resolve()
+    plugin_dir = plugin_path.parent if plugin_path.exists() else None
+    plugin_dir_str = str(plugin_dir) if plugin_dir else ""
+    builtin = False
+    if plugin_dir_str:
+        try:
+            builtin = os.path.commonpath([plugin_dir_str, BUILTIN_PLUGIN_ROOT]) == BUILTIN_PLUGIN_ROOT
+        except Exception:
+            builtin = False
+
+    describe_data: Dict[str, object] = {}
+    describe_fn = getattr(module, "describe", None)
+    if callable(describe_fn):
+        try:
+            data = describe_fn() or {}
+            if isinstance(data, dict):
+                describe_data = data
+        except Exception:
+            describe_data = {}
+
+    def _list_from(value: Optional[Iterable[object]]) -> List[str]:
+        if not value:
+            return []
+        return [str(item) for item in value if isinstance(item, str)]
+
+    name = str(
+        describe_data.get("name")
+        or getattr(module, "NAME", "")
+        or service_id
+    )
+    version = str(
+        describe_data.get("version")
+        or getattr(module, "VERSION", "")
+        or ""
+    )
+
+    return {
+        "id": service_id,
+        "name": name,
+        "version": version,
+        "services": _list_from(describe_data.get("services")),
+        "scopes": _list_from(describe_data.get("scopes")),
+        "capabilities": _list_from(describe_data.get("capabilities")),
+        "builtin": builtin,
+        "plugin_dir": plugin_dir_str,
+    }
+
+
+def _load_plugin_settings() -> Dict[str, object]:
+    try:
+        data = json.loads(_SETTINGS_PATH.read_text(encoding="utf-8"))
+    except FileNotFoundError:
+        return {}
+    except json.JSONDecodeError:
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def _save_plugin_settings(data: Dict[str, object]) -> None:
+    _SETTINGS_PATH.parent.mkdir(parents=True, exist_ok=True)
+    _SETTINGS_PATH.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
+
+
+def _is_plugin_enabled(pid: str, default: bool = True) -> bool:
+    settings = _load_plugin_settings() or {}
+    enabled = settings.get("enabled")
+    if isinstance(enabled, dict) and pid in enabled:
+        return bool(enabled.get(pid))
+    return bool(default)
+
+
+def set_plugin_enabled(pid: str, enabled: bool) -> None:
+    settings = _load_plugin_settings() or {}
+    enabled_block = settings.get("enabled")
+    if not isinstance(enabled_block, dict):
+        enabled_block = {}
+    enabled_block[pid] = bool(enabled)
+    settings["enabled"] = enabled_block
+    _save_plugin_settings(settings)
 
 
 def register(module: ModuleType) -> None:
     service_id = getattr(module, "SERVICE_ID", None)
     if not service_id:
         return
-    _PLUGINS[str(service_id)] = module
+    sid = str(service_id)
+    _PLUGINS[sid] = module
+    _PLUGIN_INFO[sid] = _collect_metadata(sid, module)
 
 
 def get_plugin(service_id: str):
+    _ensure_loaded()
     return _PLUGINS.get(service_id)
 
 
 def all_plugins() -> Dict[str, ModuleType]:
+    _ensure_loaded()
     return dict(_PLUGINS)
+
+
+def plugin_descriptor(service_id: str) -> Optional[Dict[str, object]]:
+    _ensure_loaded()
+    info = _PLUGIN_INFO.get(service_id)
+    if not info:
+        return None
+    record = dict(info)
+    builtin = bool(record.get("builtin"))
+    record["enabled"] = _is_plugin_enabled(service_id, default=True if builtin else True)
+    return record
+
+
+def iter_descriptors() -> List[Dict[str, object]]:
+    _ensure_loaded()
+    out: List[Dict[str, object]] = []
+    for service_id, info in _PLUGIN_INFO.items():
+        record = plugin_descriptor(service_id)
+        if record is None:
+            continue
+        out.append(record)
+    return out
+
+
+__all__ = [
+    "BUILTIN_PLUGIN_ROOT",
+    "all_plugins",
+    "get_plugin",
+    "iter_descriptors",
+    "plugin_descriptor",
+    "register",
+    "set_plugin_enabled",
+]

--- a/core/plugins_builtin/__init__.py
+++ b/core/plugins_builtin/__init__.py
@@ -1,0 +1,3 @@
+"""Built-in plugins shipped with the controller core."""
+
+__all__ = []

--- a/core/plugins_builtin/google_drive/__init__.py
+++ b/core/plugins_builtin/google_drive/__init__.py
@@ -1,0 +1,3 @@
+from . import plugin
+
+__all__ = ["plugin"]

--- a/core/plugins_builtin/google_drive/plugin.py
+++ b/core/plugins_builtin/google_drive/plugin.py
@@ -1,0 +1,61 @@
+SERVICE_ID = "google_drive"
+VERSION = "1.0.0"
+_b = None
+
+
+def describe():
+    return {
+        "id": SERVICE_ID,
+        "name": "Google Drive (built-in, read)",
+        "version": VERSION,
+        "services": ["drive.read"],
+        "scopes": ["read"],
+        "builtin": True,
+        "capabilities": ["drive.files.read"],
+    }
+
+
+def register_broker(broker):
+    global _b
+    _b = broker
+
+
+def probe(timeout_s=0.9):
+    try:
+        status = _b.service_call("google_drive", "status", {})
+        ok = bool(status.get("configured") and status.get("can_exchange_token"))
+        return {
+            "ok": ok,
+            "status": "ready" if ok else "blocked",
+            "details": {"configured": status.get("configured", False)},
+        }
+    except Exception:
+        return {"ok": False, "status": "blocked"}
+
+
+def read(op, params):
+    if op == "children":
+        return _b.service_call(
+            "google_drive",
+            "list_children",
+            {
+                "parent_id": params.get("parent_id", "drive:root"),
+                "page_size": int(params.get("page_size", 200)),
+                "page_token": params.get("page_token"),
+            },
+        )
+    if op == "catalog_open":
+        return _b.catalog_open(
+            "google_drive",
+            params.get("scope", "allDrives"),
+            {
+                "recursive": bool(params.get("recursive", True)),
+                "page_size": int(params.get("page_size", 500)),
+                "fingerprint": bool(params.get("fingerprint", False)),
+            },
+        )
+    if op == "catalog_next":
+        return _b.catalog_next(params["stream_id"], int(params.get("max_items", 500)))
+    if op == "catalog_close":
+        return _b.catalog_close(params["stream_id"])
+    return {"error": "unknown_op"}

--- a/core/plugins_builtin/local/__init__.py
+++ b/core/plugins_builtin/local/__init__.py
@@ -1,0 +1,3 @@
+from . import plugin
+
+__all__ = ["plugin"]

--- a/core/plugins_builtin/local/plugin.py
+++ b/core/plugins_builtin/local/plugin.py
@@ -1,0 +1,57 @@
+SERVICE_ID = "local"
+VERSION = "1.0.0"
+_b = None
+
+
+def describe():
+    return {
+        "id": SERVICE_ID,
+        "name": "Local Files (built-in, read)",
+        "version": VERSION,
+        "services": ["local.read"],
+        "scopes": ["read"],
+        "builtin": True,
+        "capabilities": ["local.files.read"],
+    }
+
+
+def register_broker(broker):
+    global _b
+    _b = broker
+
+
+def probe(timeout_s=0.9):
+    try:
+        status = _b.service_call("local_fs", "status", {})
+        ok = bool(status.get("configured"))
+        return {
+            "ok": ok,
+            "status": "ready" if ok else "blocked",
+            "details": {"roots": status.get("roots", [])},
+        }
+    except Exception:
+        return {"ok": False, "status": "blocked"}
+
+
+def read(op, params):
+    if op == "children":
+        return _b.service_call(
+            "local_fs",
+            "list_children",
+            {"parent_id": params.get("parent_id", "local:root")},
+        )
+    if op == "catalog_open":
+        return _b.catalog_open(
+            "local_fs",
+            params.get("scope", "local_roots"),
+            {
+                "recursive": bool(params.get("recursive", True)),
+                "page_size": int(params.get("page_size", 500)),
+                "fingerprint": bool(params.get("fingerprint", False)),
+            },
+        )
+    if op == "catalog_next":
+        return _b.catalog_next(params["stream_id"], int(params.get("max_items", 500)))
+    if op == "catalog_close":
+        return _b.catalog_close(params["stream_id"])
+    return {"error": "unknown_op"}

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -85,11 +85,12 @@
           <div class="panel-body">
             <div style="display:flex;align-items:center;gap:8px;margin-bottom:6px;">
               <button id="out-back" class="btn btn-secondary" title="Back">←</button>
-              <span id="out-breadcrumb" class="muted">Drive</span>
+              <span id="out-breadcrumb" class="muted">Reader</span>
               <span style="flex:1;"></span>
               <select id="out-source">
-                <option value="drive">Drive</option>
-                <option value="local">Local</option>
+                <option value="reader">Reader (Unified)</option>
+                <option value="drive">Drive (Built-in)</option>
+                <option value="local">Local (Built-in)</option>
               </select>
               <button id="out-index-all" class="btn">Index All</button>
               <button id="out-fullpull" class="btn">Start Full Pull</button>


### PR DESCRIPTION
## Summary
- add plugin loader discovery for built-in plugins and persist plugin enable states
- add built-in google_drive and local read wrappers and expose toggleable enable endpoint
- surface built-in sources and enable flags in core, capabilities, and UI including the Outputs explorer

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f7ff8271308322bbe1f1f4fce8bbf0