### PR TITLE
Add index status persistence and refresh indexing UI

### DIFF
--- a/core/adapters/drive/provider.py
+++ b/core/adapters/drive/provider.py
@@ -98,6 +98,21 @@ class GoogleDriveProvider:
             return {"drives": []}
         return {"drives": data.get("drives", [])}
 
+    def get_start_page_token(self) -> Dict[str, Any]:
+        url = "https://www.googleapis.com/drive/v3/changes/startPageToken?supportsAllDrives=true"
+        try:
+            r, code = self._auth_get(url)
+            if code != 200 or r is None:
+                raise ValueError("token request failed")
+            payload = r.json()
+            token = payload.get("startPageToken") if isinstance(payload, dict) else None
+            if not token:
+                raise ValueError("missing token")
+            return {"ok": True, "token": token}
+        except Exception:
+            self._log.exception("drive.get_start_page_token failed")
+            return {"ok": False, "error": "token_failed"}
+
     # ----- basic status/children (for UI tree) -----
     def status(self) -> Dict[str, Any]:
         cid, cs, rt = self._get_client()

--- a/core/domain/broker.py
+++ b/core/domain/broker.py
@@ -45,6 +45,8 @@ class Broker(ConnectionBroker):
                 return p.list_children(**params)
             if op == "list_drives" and hasattr(p, "list_drives"):
                 return p.list_drives()
+            if op == "get_start_page_token" and hasattr(p, "get_start_page_token"):
+                return p.get_start_page_token()
             if op == "search" and hasattr(p, "search"):
                 return p.search(**params)
             return {"error": "unknown_op"}

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -92,8 +92,7 @@
                 <option value="drive">Drive (Built-in)</option>
                 <option value="local">Local (Built-in)</option>
               </select>
-              <button id="out-index-all" class="btn">Index All</button>
-              <button id="out-fullpull" class="btn">Start Full Pull</button>
+              <button id="out-index" class="btn">Index</button>
             </div>
             <input id="out-search" placeholder="Search…" style="width:100%;margin-bottom:6px;" />
             <div id="out-list" class="list" style="min-height:220px;"></div>


### PR DESCRIPTION
## Summary
- expose a Google Drive start page token helper through the provider and broker
- add index state persistence plus status endpoints that compute Drive token and local root signatures
- refresh the Outputs UI with a single Index button, auto-disable logic, and a settings shortcut to add drive subfolders

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68f80a87fb848322aac5bf8a56f81ad1