### PR TITLE
Fix local FS root validation and drive token resilience

### DIFF
--- a/core/adapters/fs/test_provider_paths.py
+++ b/core/adapters/fs/test_provider_paths.py
@@ -1,0 +1,17 @@
+from core.adapters.fs.provider import _is_under_root
+
+
+def test_is_under_root_same_drive():
+    assert _is_under_root(r"D:\\root\\child\\file.txt", r"D:\\root")
+
+
+def test_is_under_root_different_drive():
+    assert not _is_under_root(r"C:\\other\\file.txt", r"D:\\root")
+
+
+def test_is_under_root_unc_share():
+    assert _is_under_root(r"\\srv\share\root\dir", r"\\srv\share\root")
+
+
+def test_is_under_root_boundary():
+    assert not _is_under_root(r"D:\\root2", r"D:\\root")

--- a/core/domain/broker.py
+++ b/core/domain/broker.py
@@ -63,3 +63,11 @@ class Broker(ConnectionBroker):
 
     def catalog_close(self, stream_id: str) -> Dict[str, Any]:
         return self._catalog.close(stream_id)
+
+    def clear_provider_cache(self, provider: str) -> None:
+        p = self._providers.get(provider)
+        if p and hasattr(p, "clear_cache"):
+            try:
+                p.clear_cache()
+            except Exception:
+                pass


### PR DESCRIPTION
## Summary
- normalize and validate local filesystem roots with a robust helper to avoid cross-drive crashes
- make the Google Drive token fetch resilient to disconnects and clear cached clients on revoke
- expose a broker cache clearing hook and add unit coverage for the new path helper

## Testing
- pytest core/adapters/fs/test_provider_paths.py

------
https://chatgpt.com/codex/tasks/task_e_68f8129808a883228577cb2f87e06cfb