### PR TITLE
Fix Send2Trash dependency handling

### DIFF
--- a/core/plans/commit.py
+++ b/core/plans/commit.py
@@ -1,10 +1,13 @@
-import os
-import shutil
-from typing import Any, Dict, List
+import os, shutil
+from typing import Dict, Any, List
 
-from send2trash import send2trash
+try:
+    from send2trash import send2trash
+except Exception as _e:
+    def send2trash(_path: str):
+        raise RuntimeError("Send2Trash is not installed. Install with: python -m pip install Send2Trash==1.8.2") from _e
 
-from .model import ActionKind, Plan
+from .model import Plan, ActionKind
 
 
 def _ensure_parent(path: str):

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,5 @@ cryptography>=42.0.0
 fastapi
 uvicorn[standard]
 pydantic
-Send2Trash>=1.8.2
-pywin32>=306
+Send2Trash==1.8.2
+pywin32>=306; platform_system == "Windows"


### PR DESCRIPTION
## Summary
- pin Send2Trash dependency and conditionally install pywin32 on Windows
- guard send2trash import so commit actions fail with a helpful message when missing

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68f94fdeaacc8322be1c92c31b2f4cdc