### PR TITLE
Add settings toggle for local writes

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -37,7 +37,7 @@ from core.capabilities import registry
 from core.capabilities.registry import MANIFEST_PATH
 from core.policy.guard import require_owner_commit
 from core.policy.model import Policy
-from core.policy.store import load_policy, save_policy
+from core.policy.store import load_policy, save_policy, get_writes_enabled, set_writes_enabled
 from core.plans.commit import commit_local
 from core.plans.model import Plan, PlanStatus
 from core.plans.preview import preview_plan
@@ -223,6 +223,21 @@ oauth = APIRouter()
 
 def _broker():
     return get_broker()
+
+
+class WritesBody(BaseModel):
+    enabled: bool
+
+
+@protected.get("/dev/writes")
+def dev_get_writes():
+    return {"enabled": get_writes_enabled()}
+
+
+@protected.post("/dev/writes")
+def dev_set_writes(body: WritesBody):
+    set_writes_enabled(bool(body.enabled))
+    return {"enabled": get_writes_enabled()}
 
 
 @protected.get("/dev/ping_plugin")

--- a/core/policy/guard.py
+++ b/core/policy/guard.py
@@ -3,14 +3,14 @@ import os
 from fastapi import HTTPException
 
 from .model import Role
-from .store import load_policy
+from .store import load_policy, get_writes_enabled
 
 
 def require_owner_commit() -> None:
-    # Always require explicit opt-in for any local write
-    if os.environ.get("BUS_ALLOW_LOCAL_WRITES") != "1":
-        raise HTTPException(status_code=403, detail="Local writes disabled (set BUS_ALLOW_LOCAL_WRITES=1).")
-    # Optional policy enforcement
+    # Allow if env override or UI toggle is on; otherwise block
+    if not get_writes_enabled():
+        raise HTTPException(status_code=403, detail="Local writes disabled. Enable in Settings.")
+    # Optional strict policy (OFF unless BUS_POLICY_ENFORCE=1)
     if os.environ.get("BUS_POLICY_ENFORCE") == "1":
         p = load_policy()
         if not (p.role == Role.OWNER and p.plan_only is False):

--- a/core/policy/store.py
+++ b/core/policy/store.py
@@ -25,3 +25,31 @@ def load_policy() -> Policy:
 
 def save_policy(policy: Policy) -> None:
     CONFIG_FILE.write_text(policy.model_dump_json(indent=2), encoding="utf-8")
+
+
+def get_writes_enabled() -> bool:
+    # ENV override wins
+    import os, json
+
+    if os.environ.get("BUS_ALLOW_LOCAL_WRITES") == "1":
+        return True
+    if CONFIG_FILE.exists():
+        try:
+            data = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+            return bool(data.get("writes_enabled", False))
+        except Exception:
+            pass
+    return False
+
+
+def set_writes_enabled(enabled: bool) -> None:
+    import json
+
+    data = {}
+    if CONFIG_FILE.exists():
+        try:
+            data = json.loads(CONFIG_FILE.read_text(encoding="utf-8"))
+        except Exception:
+            data = {}
+    data["writes_enabled"] = bool(enabled)
+    CONFIG_FILE.write_text(json.dumps(data, indent=2), encoding="utf-8")

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -201,9 +201,77 @@
             </div>
           </div>
         </div>
+        <div style="margin-top:16px; padding:12px; border:1px solid #333; border-radius:6px;">
+          <h3 style="margin:0 0 8px 0;">Safety</h3>
+          <div style="display:flex; align-items:center; gap:12px;">
+            <div id="writesStatus">Writes: <strong>Loading…</strong></div>
+            <label>
+              <input id="writesToggle" type="checkbox" />
+              Enable writes (dangerous)
+            </label>
+          </div>
+          <div class="muted" style="margin-top:6px;">Env <code>BUS_ALLOW_LOCAL_WRITES=1</code> always forces ON.</div>
+        </div>
+
+        <div style="margin-top:16px; padding:12px; border:1px solid #333; border-radius:6px;">
+          <h3 style="margin:0 0 8px 0;">Dev Tools</h3>
+          <button id="btnPingPlugin" type="button">Ping Plugin</button>
+          <pre id="pingOut" style="margin-top:8px; white-space:pre-wrap;"></pre>
+        </div>
       </div>
     </section>
 
+    <script>
+      (function () {
+        const token = (
+          window.__SESSION_TOKEN || window.__sessionToken || window.BUS_SESSION_TOKEN || ""
+        )
+          .toString();
+        function headers() {
+          const h = {};
+          if (token) h["X-Session-Token"] = token;
+          return h;
+        }
+
+        async function refreshWrites() {
+          try {
+            const r = await fetch("/dev/writes", { headers: headers() });
+            const j = await r.json();
+            const on = !!j.enabled;
+            document.getElementById("writesToggle").checked = on;
+            document.getElementById("writesStatus").innerHTML =
+              "Writes: <strong>" + (on ? "Enabled" : "Disabled") + "</strong>";
+          } catch (e) {
+            document.getElementById("writesStatus").textContent = "Writes: error";
+          }
+        }
+
+        document.getElementById("writesToggle").addEventListener("change", async (ev) => {
+          const enabled = ev.target.checked;
+          await fetch("/dev/writes", {
+            method: "POST",
+            headers: Object.assign({ "Content-Type": "application/json" }, headers()),
+            body: JSON.stringify({ enabled }),
+          });
+          refreshWrites();
+        });
+
+        const pingBtn = document.getElementById("btnPingPlugin");
+        if (pingBtn) {
+          pingBtn.addEventListener("click", async () => {
+            try {
+              const r = await fetch("/dev/ping_plugin", { headers: headers() });
+              const j = await r.json();
+              document.getElementById("pingOut").textContent = JSON.stringify(j, null, 2);
+            } catch (e) {
+              document.getElementById("pingOut").textContent = String(e);
+            }
+          });
+        }
+
+        refreshWrites();
+      })();
+    </script>
     <script src="/ui/static/app.js" defer></script>
   </body>
 </html>


### PR DESCRIPTION
## Summary
- add helpers to persist and read the local writes toggle in the policy store
- consult the persisted toggle in the commit guard before allowing writes
- expose /dev/writes endpoints and wire the settings UI to show and toggle the state, plus ping button

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68f953a838d08322aad25f38f976caad