### PR TITLE
Implement plan engine with local execution and organizer UI

### DIFF
--- a/core/adapters/fs/executor.py
+++ b/core/adapters/fs/executor.py
@@ -1,0 +1,174 @@
+from __future__ import annotations
+
+import json
+import os
+import shutil
+import uuid
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Dict, Iterable, Optional, Tuple
+
+from .provider import _is_under_root, _norm, _same_drive
+
+
+def _normalize(path: str) -> str:
+    return _norm(path)
+
+
+def _ensure_dir(path: Path) -> None:
+    path.mkdir(parents=True, exist_ok=True)
+
+
+def _append_suffix(path: Path, index: int) -> Path:
+    if index <= 0:
+        return path
+    stem = path.stem
+    suffix = path.suffix
+    return path.with_name(f"{stem}-{index}{suffix}")
+
+
+def resolve_collision_append_1(target: Path) -> Path:
+    candidate = target
+    counter = 0
+    while candidate.exists():
+        counter += 1
+        candidate = _append_suffix(target, counter)
+    return candidate
+
+
+def _quarantine_base(roots: Iterable[str]) -> Optional[Path]:
+    first = next(iter(roots), None)
+    if not first:
+        return None
+    base = Path(first)
+    documents = base if base.name.lower() == "documents" else base / "Documents"
+    return documents / "Quarantine"
+
+
+@dataclass
+class CollisionResult:
+    resolved_path: Path
+    collided: bool
+
+
+class LocalFSExecutor:
+    """Helper responsible for performing file-system mutations under local roots."""
+
+    def __init__(self, allowed_roots: Iterable[str]):
+        self._allowed_roots = [Path(r) for r in allowed_roots]
+        self._allowed_norm = [_normalize(str(r)) for r in self._allowed_roots]
+        base = _quarantine_base(self._allowed_norm)
+        self._quarantine_move = (
+            (base / "MoveSource") if base is not None else Path("data/quarantine/MoveSource")
+        )
+        self._quarantine_duplicates = (
+            (base / "Duplicates") if base is not None else Path("data/quarantine/Duplicates")
+        )
+        self._quarantine_combined = (
+            (base / "Combined") if base is not None else Path("data/quarantine/Combined")
+        )
+
+    # region policies
+    def is_allowed(self, path: Path) -> bool:
+        candidate = _normalize(str(path))
+        for root in self._allowed_norm:
+            if _is_under_root(candidate, root):
+                return True
+        return False
+
+    def ensure_allowed(self, path: Path) -> None:
+        if not self.is_allowed(path):
+            raise PermissionError(f"Path {path} not under allowed roots")
+
+    # endregion
+
+    def collision_resolve(self, path: Path, mode: str = "append-1") -> CollisionResult:
+        if mode != "append-1":
+            return CollisionResult(resolved_path=path, collided=False)
+        if not path.exists():
+            return CollisionResult(resolved_path=path, collided=False)
+        resolved = resolve_collision_append_1(path)
+        return CollisionResult(resolved_path=resolved, collided=True)
+
+    def _same_drive(self, a: Path, b: Path) -> bool:
+        return _same_drive(str(a), str(b))
+
+    def same_drive(self, a: Path, b: Path) -> bool:
+        return self._same_drive(a, b)
+
+    # rename/move helpers
+    def _prepare_target(self, target: Path) -> None:
+        _ensure_dir(target.parent)
+
+    def _copy(self, src: Path, dest: Path) -> None:
+        if src.is_dir():
+            if dest.exists():
+                raise FileExistsError(dest)
+            shutil.copytree(src, dest)
+        else:
+            shutil.copy2(src, dest)
+
+    def _move(self, src: Path, dest: Path) -> None:
+        if src.is_dir():
+            shutil.move(str(src), str(dest))
+        else:
+            os.replace(src, dest)
+
+    def rename_or_move(
+        self,
+        src: Path,
+        dest: Path,
+        *,
+        collision_mode: str = "append-1",
+        quarantine: bool = True,
+    ) -> Tuple[Path, Dict[str, str]]:
+        self.ensure_allowed(src)
+        self.ensure_allowed(dest)
+        if not src.exists():
+            raise FileNotFoundError(src)
+
+        collision = self.collision_resolve(dest, collision_mode)
+        final_dest = collision.resolved_path
+        self._prepare_target(final_dest)
+
+        metadata: Dict[str, str] = {}
+        if self._same_drive(src, final_dest):
+            if src.is_dir():
+                shutil.move(str(src), str(final_dest))
+            else:
+                os.replace(src, final_dest)
+            rollback_src = final_dest
+            rollback_dest = src
+            metadata["rollback"] = json.dumps({
+                "op": "move",
+                "src": str(rollback_src),
+                "dest": str(rollback_dest),
+            })
+            return final_dest, metadata
+
+        # cross-drive move: copy then quarantine original
+        temp_name = final_dest.parent / f".__tgc_tmp_{uuid.uuid4().hex}{final_dest.suffix}"
+        self._copy(src, temp_name)
+        if final_dest.exists():
+            os.replace(temp_name, final_dest)
+        else:
+            os.replace(temp_name, final_dest)
+        rollback_steps = [
+            {"op": "move", "src": str(final_dest), "dest": str(src)},
+        ]
+        if quarantine:
+            q_target = self._quarantine_move / src.name
+            _ensure_dir(q_target.parent)
+            unique = q_target
+            counter = 0
+            while unique.exists():
+                counter += 1
+                unique = q_target.with_name(f"{q_target.stem}-{counter}{q_target.suffix}")
+            shutil.move(str(src), str(unique))
+            rollback_steps.append({"op": "move", "src": str(unique), "dest": str(src)})
+            metadata["quarantine"] = str(unique)
+        metadata["rollback"] = json.dumps(rollback_steps)
+        return final_dest, metadata
+
+
+__all__ = ["LocalFSExecutor", "resolve_collision_append_1"]

--- a/core/api/http.py
+++ b/core/api/http.py
@@ -42,6 +42,7 @@ from core.plans.commit import commit_local
 from core.plans.model import Plan, PlanStatus
 from core.plans.preview import preview_plan
 from core.plans.store import get_plan, list_plans, save_plan
+from core.pipeline.plan_engine import ENGINE as PLAN_ENGINE
 from core.runtime.core_alpha import CoreAlpha
 from core.runtime.policy import PolicyDecision
 from core.runtime.probe import PROBE_TIMEOUT_SEC
@@ -1030,6 +1031,44 @@ def plans_export(plan_id: str) -> Response:
     if not plan:
         raise HTTPException(status_code=404, detail="plan_not_found")
     return JSONResponse(plan.model_dump())
+
+
+@protected.post("/plan.preview")
+def pipeline_plan_preview(body: Dict[str, Any] = Body(...)) -> Dict[str, Any]:
+    batches = body.get("batches")
+    if not isinstance(batches, list):
+        raise HTTPException(status_code=400, detail="invalid_batches")
+    try:
+        return PLAN_ENGINE.preview(batches)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+
+
+@protected.post("/plan.execute")
+def pipeline_plan_execute(body: Dict[str, Any] = Body(...)) -> Dict[str, Any]:
+    batches = body.get("batches")
+    if not isinstance(batches, list):
+        raise HTTPException(status_code=400, detail="invalid_batches")
+    label = body.get("job_label")
+    try:
+        result = PLAN_ENGINE.execute(batches, label=str(label) if label else None)
+    except ValueError as exc:
+        raise HTTPException(status_code=400, detail=str(exc))
+    return result
+
+
+@protected.get("/jobs/{job_id}")
+def pipeline_job_status(job_id: str) -> Dict[str, Any]:
+    job = PLAN_ENGINE.get_job(job_id)
+    if not job:
+        raise HTTPException(status_code=404, detail="job_not_found")
+    return job
+
+
+@protected.get("/audit.log")
+def pipeline_audit_log() -> Response:
+    content = PLAN_ENGINE.audit_log()
+    return Response(content=content, media_type="text/plain")
 
 
 @protected.get("/health")

--- a/core/domain/bundles.py
+++ b/core/domain/bundles.py
@@ -1,0 +1,126 @@
+from __future__ import annotations
+
+import io
+import os
+import time
+import zipfile
+from pathlib import Path
+from typing import Dict, Iterable, List
+
+try:  # pragma: no cover - optional dependency
+    from pypdf import PdfReader, PdfWriter
+except Exception:  # pragma: no cover - gracefully degrade
+    PdfReader = PdfWriter = None  # type: ignore
+
+try:  # pragma: no cover - optional dependency
+    from docx import Document
+except Exception:  # pragma: no cover - gracefully degrade
+    Document = None  # type: ignore
+
+
+MAX_FILE_SIZE = 50 * 1024 * 1024
+MAX_TOTAL_SIZE = 500 * 1024 * 1024
+TIME_LIMIT_SECONDS = 10
+
+
+class BundleBuildError(Exception):
+    pass
+
+
+def _check_limits(paths: Iterable[Path]) -> None:
+    total = 0
+    for path in paths:
+        size = path.stat().st_size
+        if size > MAX_FILE_SIZE:
+            raise BundleBuildError(f"file_too_large:{path.name}")
+        total += size
+        if total > MAX_TOTAL_SIZE:
+            raise BundleBuildError("bundle_too_large")
+
+
+def _build_pdf(input_paths: List[Path], out_path: Path) -> Dict[str, object]:
+    if PdfReader is None or PdfWriter is None:
+        raise BundleBuildError("pdf_support_unavailable")
+    writer = PdfWriter()
+    pages = 0
+    for path in input_paths:
+        reader = PdfReader(str(path))
+        for page in reader.pages:
+            writer.add_page(page)
+            pages += 1
+    with open(out_path, "wb") as handle:
+        writer.write(handle)
+    return {"ok": True, "bytes_written": out_path.stat().st_size, "pages": pages, "warnings": []}
+
+
+def _build_docx(input_paths: List[Path], out_path: Path) -> Dict[str, object]:
+    if Document is None:
+        raise BundleBuildError("docx_support_unavailable")
+    if not input_paths:
+        doc = Document()
+        doc.add_paragraph("Empty bundle")
+        doc.save(out_path)
+        return {"ok": True, "bytes_written": out_path.stat().st_size, "warnings": []}
+    result = Document(str(input_paths[0]))
+    for path in input_paths[1:]:
+        segment = Document(str(path))
+        for element in segment.element.body:
+            result.element.body.append(element)
+    result.save(out_path)
+    return {"ok": True, "bytes_written": out_path.stat().st_size, "warnings": []}
+
+
+def _build_text(input_paths: List[Path], out_path: Path) -> Dict[str, object]:
+    buffer = io.StringIO()
+    warnings: List[str] = []
+    for idx, path in enumerate(input_paths):
+        try:
+            text = path.read_text(encoding="utf-8")
+        except UnicodeDecodeError:
+            warnings.append(f"non_utf8:{path.name}")
+            text = path.read_text(encoding="utf-8", errors="replace")
+        if idx:
+            buffer.write("\n\n")
+        buffer.write(text)
+    data = buffer.getvalue().encode("utf-8")
+    with open(out_path, "wb") as handle:
+        handle.write(data)
+    return {"ok": True, "bytes_written": len(data), "warnings": warnings}
+
+
+def _build_zip(input_paths: List[Path], out_path: Path) -> Dict[str, object]:
+    with zipfile.ZipFile(out_path, "w", compression=zipfile.ZIP_DEFLATED) as archive:
+        for path in input_paths:
+            archive.write(path, arcname=path.name)
+    return {"ok": True, "bytes_written": out_path.stat().st_size, "warnings": []}
+
+
+def build_bundle(mode: str, input_paths: Iterable[str], out_tmp_path: Path) -> Dict[str, object]:
+    paths = [Path(p) for p in input_paths]
+    start = time.time()
+    _check_limits(paths)
+    for path in paths:
+        if not path.exists():
+            raise BundleBuildError(f"missing_input:{path}")
+    if time.time() - start > TIME_LIMIT_SECONDS:
+        raise BundleBuildError("time_budget_exceeded")
+    tmp_parent = out_tmp_path.parent
+    tmp_parent.mkdir(parents=True, exist_ok=True)
+
+    mode = mode or "zip_bundle"
+    if mode == "pdf_merge":
+        result = _build_pdf(paths, out_tmp_path)
+    elif mode == "docx_merge":
+        result = _build_docx(paths, out_tmp_path)
+    elif mode == "text_concat":
+        result = _build_text(paths, out_tmp_path)
+    else:
+        result = _build_zip(paths, out_tmp_path)
+    if time.time() - start > TIME_LIMIT_SECONDS:
+        raise BundleBuildError("time_budget_exceeded")
+    result.setdefault("warnings", [])
+    result.setdefault("bytes_written", out_tmp_path.stat().st_size)
+    return result
+
+
+__all__ = ["build_bundle", "BundleBuildError"]

--- a/core/pipeline/plan_engine.py
+++ b/core/pipeline/plan_engine.py
@@ -1,0 +1,517 @@
+from __future__ import annotations
+
+import json
+import os
+import threading
+import uuid
+from concurrent.futures import ThreadPoolExecutor
+from dataclasses import dataclass, field
+from datetime import datetime
+from pathlib import Path
+from typing import Any, Dict, Iterable, List, Optional
+
+from core.adapters.fs.executor import LocalFSExecutor
+from core.domain.bundles import build_bundle
+from core.settings.reader import load_reader_settings
+
+
+def _utc_now() -> str:
+    return datetime.utcnow().replace(microsecond=0).isoformat() + "Z"
+
+
+def _norm_paths(roots: Iterable[str]) -> List[str]:
+    result = []
+    for root in roots:
+        try:
+            result.append(str(Path(root).resolve()))
+        except Exception:
+            continue
+    return result
+
+
+def _safe_int(value: Any, default: int = 0) -> int:
+    try:
+        return int(value)
+    except Exception:
+        return default
+
+
+def _ndjson_append(path: Path, payload: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    with path.open("a", encoding="utf-8") as handle:
+        handle.write(json.dumps(payload, separators=(",", ":")))
+        handle.write("\n")
+        handle.flush()
+        os.fsync(handle.fileno())
+
+
+@dataclass
+class ItemResult:
+    item: Dict[str, Any]
+    status: str
+    resolved_path: Optional[str] = None
+    reason: Optional[str] = None
+    warnings: List[str] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        data: Dict[str, Any] = {
+            "item": self.item,
+            "status": self.status,
+        }
+        if self.resolved_path is not None:
+            data["resolved_path"] = self.resolved_path
+        if self.reason:
+            data["reason"] = self.reason
+        if self.warnings:
+            data["warnings"] = list(self.warnings)
+        return data
+
+
+@dataclass
+class BatchPreview:
+    op: str
+    results: List[ItemResult] = field(default_factory=list)
+
+    def to_dict(self) -> Dict[str, Any]:
+        return {"op": self.op, "results": [item.to_dict() for item in self.results]}
+
+
+class Journal:
+    def __init__(self, path: Path):
+        self._path = path
+        self._path.parent.mkdir(parents=True, exist_ok=True)
+
+    def record(self, payload: Dict[str, Any]) -> None:
+        payload = dict(payload)
+        payload.setdefault("ts", _utc_now())
+        _ndjson_append(self._path, payload)
+
+
+class PlanEngine:
+    def __init__(self):
+        self._data_root = Path("data")
+        self._journal_root = self._data_root / "journal"
+        self._tmp_root = self._data_root / "tmp" / "bundles"
+        self._jobs_path = self._data_root / "jobs.json"
+        self._audit_path = self._data_root / "audit.log"
+        self._idempo_path = self._data_root / "idempo.jsonl"
+        self._jobs: Dict[str, Dict[str, Any]] = {}
+        self._jobs_lock = threading.Lock()
+        self._idempo: Dict[str, str] = {}
+        self._executor = ThreadPoolExecutor(max_workers=2)
+        self._load_jobs()
+        self._load_idempo()
+        self._fs_executor = LocalFSExecutor(self._current_roots())
+
+    # region helpers
+    def _current_roots(self) -> List[str]:
+        settings = load_reader_settings()
+        roots = settings.get("local_roots", []) if isinstance(settings, dict) else []
+        if not isinstance(roots, list):
+            return []
+        return _norm_paths([str(item) for item in roots if isinstance(item, str)])
+
+    def _reload_executor(self) -> None:
+        self._fs_executor = LocalFSExecutor(self._current_roots())
+
+    def _load_jobs(self) -> None:
+        try:
+            data = json.loads(self._jobs_path.read_text(encoding="utf-8"))
+            if isinstance(data, dict):
+                self._jobs = data
+        except FileNotFoundError:
+            self._jobs = {}
+        except json.JSONDecodeError:
+            self._jobs = {}
+
+    def _persist_jobs(self) -> None:
+        self._jobs_path.parent.mkdir(parents=True, exist_ok=True)
+        tmp = self._jobs_path.with_suffix(".tmp")
+        tmp.write_text(json.dumps(self._jobs, indent=2, sort_keys=True), encoding="utf-8")
+        os.replace(tmp, self._jobs_path)
+
+    def _load_idempo(self) -> None:
+        try:
+            with self._idempo_path.open("r", encoding="utf-8") as handle:
+                for line in handle:
+                    try:
+                        obj = json.loads(line.strip())
+                        if not isinstance(obj, dict):
+                            continue
+                        key = obj.get("key")
+                        job_id = obj.get("job_id")
+                        if isinstance(key, str) and isinstance(job_id, str):
+                            self._idempo[key] = job_id
+                    except json.JSONDecodeError:
+                        continue
+        except FileNotFoundError:
+            self._idempo = {}
+
+    def _record_idempo(self, key: str, job_id: str) -> None:
+        if not key:
+            return
+        self._idempo[key] = job_id
+        _ndjson_append(self._idempo_path, {"key": key, "job_id": job_id, "ts": _utc_now()})
+
+    def _update_job(self, job_id: str, **updates: Any) -> None:
+        with self._jobs_lock:
+            job = self._jobs.setdefault(job_id, {})
+            job.update(updates)
+            self._persist_jobs()
+
+    def _update_progress(self, job_id: str, done: int) -> None:
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            if not job:
+                return
+            total = job.get("progress", {}).get("total", 0)
+            job["progress"] = {"done": done, "total": total}
+            self._persist_jobs()
+
+    # endregion
+
+    # region preview
+    def preview(self, batches: List[Dict[str, Any]]) -> Dict[str, Any]:
+        self._reload_executor()
+        batch_results: List[BatchPreview] = []
+        total = ok = deny = error = 0
+
+        for batch in batches:
+            op = str(batch.get("op") or "").strip()
+            items = batch.get("items")
+            constraint = batch.get("constraints") if isinstance(batch.get("constraints"), dict) else {}
+            if not isinstance(items, list):
+                items = []
+            if len(items) > 500:
+                raise ValueError("batch_limit_exceeded")
+            scope = constraint.get("scope") if isinstance(constraint, dict) else None
+            if scope not in ("local_only", None):
+                results = [
+                    ItemResult(
+                        item=item if isinstance(item, dict) else {},
+                        status="DENY",
+                        reason="unsupported_scope",
+                    )
+                    for item in items
+                ]
+                batch_results.append(BatchPreview(op=op, results=results))
+                deny += len(results)
+                total += len(results)
+                continue
+
+            if op in ("rename.batch", "move.batch"):
+                results = []
+                for item in items:
+                    if not isinstance(item, dict):
+                        results.append(ItemResult(item={}, status="ERROR", reason="invalid_item"))
+                        error += 1
+                        total += 1
+                        continue
+                    old_raw = item.get("old_path")
+                    new_raw = item.get("new_path")
+                    if not isinstance(old_raw, str) or not isinstance(new_raw, str) or not old_raw or not new_raw:
+                        results.append(ItemResult(item=item, status="DENY", reason="missing_paths"))
+                        deny += 1
+                        total += 1
+                        continue
+                    old_path = Path(str(old_raw))
+                    new_path = Path(str(new_raw))
+                    if not old_path.exists():
+                        results.append(ItemResult(item=item, status="ERROR", reason="missing_source"))
+                        error += 1
+                        total += 1
+                        continue
+                    warnings: List[str] = []
+                    if not self._fs_executor.is_allowed(old_path) or not self._fs_executor.is_allowed(new_path):
+                        results.append(ItemResult(item=item, status="DENY", reason="out_of_scope"))
+                        deny += 1
+                        total += 1
+                        continue
+                    collision_mode = constraint.get("collision", "append-1") if isinstance(constraint, dict) else "append-1"
+                    collision = self._fs_executor.collision_resolve(new_path, collision_mode)
+                    if not self._fs_executor.same_drive(old_path, collision.resolved_path):
+                        warnings.append("cross_drive_copy_quarantine")
+                    results.append(
+                        ItemResult(
+                            item=item,
+                            status="OK",
+                            resolved_path=str(collision.resolved_path),
+                            warnings=warnings,
+                        )
+                    )
+                    ok += 1
+                    total += 1
+                batch_results.append(BatchPreview(op=op, results=results))
+                continue
+
+            if op == "bundle.create":
+                results = []
+                target_raw = batch.get("target_path")
+                target_path = Path(str(target_raw)) if isinstance(target_raw, str) and target_raw else None
+                mode = str(batch.get("mode") or "zip_bundle")
+                if not target_path:
+                    for item in items:
+                        results.append(ItemResult(item=item if isinstance(item, dict) else {}, status="ERROR", reason="missing_target"))
+                        error += 1
+                        total += 1
+                    batch_results.append(BatchPreview(op=op, results=results))
+                    continue
+                if not self._fs_executor.is_allowed(target_path):
+                    for item in items:
+                        results.append(ItemResult(item=item if isinstance(item, dict) else {}, status="DENY", reason="out_of_scope"))
+                        deny += 1
+                        total += 1
+                    batch_results.append(BatchPreview(op=op, results=results))
+                    continue
+                collision_mode = constraint.get("collision", "append-1") if isinstance(constraint, dict) else "append-1"
+                collision = self._fs_executor.collision_resolve(target_path, collision_mode)
+                for item in items:
+                    if not isinstance(item, dict):
+                        results.append(ItemResult(item={}, status="ERROR", reason="invalid_item"))
+                        error += 1
+                        total += 1
+                        continue
+                    path_hint = item.get("path") or item.get("source_path") or item.get("old_path")
+                    if not isinstance(path_hint, str) or not path_hint:
+                        results.append(ItemResult(item=item, status="ERROR", reason="missing_input_path"))
+                        error += 1
+                        total += 1
+                        continue
+                    source_path = Path(str(path_hint))
+                    if not source_path.exists():
+                        results.append(ItemResult(item=item, status="ERROR", reason="missing_source"))
+                        error += 1
+                        total += 1
+                        continue
+                    if not self._fs_executor.is_allowed(source_path):
+                        results.append(ItemResult(item=item, status="DENY", reason="out_of_scope"))
+                        deny += 1
+                        total += 1
+                        continue
+                    warnings: List[str] = []
+                    results.append(
+                        ItemResult(
+                            item=item,
+                            status="OK",
+                            resolved_path=str(collision.resolved_path),
+                            warnings=warnings,
+                        )
+                    )
+                    ok += 1
+                    total += 1
+                batch_results.append(BatchPreview(op=op, results=results))
+                continue
+
+            # unknown op
+            results = [
+                ItemResult(
+                    item=item if isinstance(item, dict) else {},
+                    status="DENY",
+                    reason="unsupported_op",
+                )
+                for item in items
+            ]
+            batch_results.append(BatchPreview(op=op, results=results))
+            deny += len(results)
+            total += len(results)
+
+        summary = {"total": total, "ok": ok, "deny": deny, "error": error}
+        return {"summary": summary, "batches": [batch.to_dict() for batch in batch_results]}
+
+    # endregion
+
+    # region execution
+    def execute(self, batches: List[Dict[str, Any]], *, label: Optional[str] = None) -> Dict[str, Any]:
+        # idempotency check
+        duplicate_job: Optional[str] = None
+        for batch in batches:
+            key = str(batch.get("idempotency_key") or "").strip()
+            if not key:
+                continue
+            existing = self._idempo.get(key)
+            if existing:
+                if duplicate_job and duplicate_job != existing:
+                    raise ValueError("idempotency_conflict")
+                duplicate_job = existing
+        if duplicate_job:
+            return {"job_id": duplicate_job, "accepted": False, "duplicate": True}
+
+        preview = self.preview(batches)
+        job_id = uuid.uuid4().hex
+        total = _safe_int(preview.get("summary", {}).get("total"), 0)
+        job_record = {
+            "job_id": job_id,
+            "status": "running",
+            "progress": {"done": 0, "total": total},
+            "errors": [],
+            "started_at": _utc_now(),
+            "finished_at": None,
+            "label": label,
+            "journal": str(self._journal_root / f"{job_id}.ndjson"),
+        }
+        with self._jobs_lock:
+            self._jobs[job_id] = job_record
+            self._persist_jobs()
+
+        for batch in batches:
+            key = str(batch.get("idempotency_key") or "").strip()
+            if key:
+                self._record_idempo(key, job_id)
+
+        self._executor.submit(self._run_job, job_id, batches, preview)
+        return {"job_id": job_id, "accepted": True}
+
+    def _run_job(self, job_id: str, batches: List[Dict[str, Any]], preview: Dict[str, Any]) -> None:
+        journal_path = self._journal_root / f"{job_id}.ndjson"
+        journal = Journal(journal_path)
+        journal.record({"type": "prepare", "job_id": job_id, "batches": len(batches)})
+        done = 0
+        rollback_map: List[Dict[str, Any]] = []
+        errors: List[str] = []
+        try:
+            for batch, preview_batch in zip(batches, preview.get("batches", [])):
+                op = batch.get("op")
+                if op in ("rename.batch", "move.batch"):
+                    constraint = batch.get("constraints") if isinstance(batch.get("constraints"), dict) else {}
+                    collision_mode = constraint.get("collision", "append-1") if isinstance(constraint, dict) else "append-1"
+                    for item_result in preview_batch.get("results", []):
+                        status = item_result.get("status")
+                        if status != "OK":
+                            continue
+                        item = item_result.get("item", {})
+                        src = Path(str(item.get("old_path")))
+                        dest = Path(str(item_result.get("resolved_path")))
+                        final_path, meta = self._fs_executor.rename_or_move(
+                            src, dest, collision_mode=collision_mode
+                        )
+                        rollback_entry = {
+                            "op": "move",
+                            "src": str(final_path),
+                            "dest": str(src),
+                        }
+                        rollback_map.append(rollback_entry)
+                        done += 1
+                        self._update_progress(job_id, done)
+                        journal.record({"type": "step", "op": op, "src": str(src), "dest": str(final_path)})
+                elif op == "bundle.create":
+                    preview_results = [
+                        res
+                        for res in preview_batch.get("results", [])
+                        if isinstance(res, dict) and res.get("status") == "OK"
+                    ]
+                    target_candidate = None
+                    if preview_results:
+                        rp = preview_results[0].get("resolved_path")
+                        if rp:
+                            target_candidate = Path(str(rp))
+                    if not target_candidate:
+                        fallback = batch.get("target_path")
+                        target_candidate = (
+                            Path(str(fallback)) if isinstance(fallback, str) and fallback else None
+                        )
+                    if not target_candidate:
+                        continue
+                    inputs: List[str] = []
+                    for item in batch.get("items", []):
+                        if isinstance(item, dict):
+                            source = item.get("path") or item.get("source_path") or item.get("old_path")
+                            if source:
+                                inputs.append(str(source))
+                    if not inputs:
+                        raise RuntimeError("bundle_missing_inputs")
+                    tmp_dir = self._tmp_root / job_id
+                    tmp_path = tmp_dir / f"bundle-{uuid.uuid4().hex}.tmp"
+                    mode = str(batch.get("mode") or "zip_bundle")
+                    result = build_bundle(mode, inputs, tmp_path)
+                    target = target_candidate
+                    target.parent.mkdir(parents=True, exist_ok=True)
+                    os.replace(tmp_path, target)
+                    manifest_path = Path(str(target) + ".bundle.json")
+                    manifest = {
+                        "inputs": inputs,
+                        "mode": batch.get("mode"),
+                        "meta": batch.get("meta", {}),
+                        "bytes": result.get("bytes_written"),
+                        "warnings": result.get("warnings", []),
+                    }
+                    manifest_path.write_text(json.dumps(manifest, indent=2), encoding="utf-8")
+                    rollback_map.append({"op": "remove", "path": str(target)})
+                    done += 1
+                    self._update_progress(job_id, done)
+                    journal.record({"type": "step", "op": op, "target": str(target), "inputs": inputs})
+                else:
+                    continue
+        except Exception as exc:  # pragma: no cover - unexpected failure
+            errors.append(str(exc))
+            journal.record({"type": "error", "error": str(exc)})
+            status = "failed"
+        else:
+            status = "done"
+        finally:
+            finished = _utc_now()
+            with self._jobs_lock:
+                job = self._jobs.get(job_id, {})
+                total_expected = job.get("progress", {}).get("total", done)
+                job.update(
+                    {
+                        "status": status,
+                        "progress": {"done": done, "total": total_expected},
+                        "errors": errors,
+                        "finished_at": finished,
+                        "journal": str(journal_path),
+                        "rollback": rollback_map,
+                    }
+                )
+                self._persist_jobs()
+            journal.record({"type": "finalize", "status": status, "errors": errors, "rollback": rollback_map})
+            self._append_audit(job_id, batches, status, errors, finished)
+
+    def _append_audit(
+        self,
+        job_id: str,
+        batches: List[Dict[str, Any]],
+        status: str,
+        errors: List[str],
+        finished_at: str,
+    ) -> None:
+        prev_hash = ""
+        if self._audit_path.exists():
+            try:
+                last_line = self._audit_path.read_text(encoding="utf-8").strip().splitlines()[-1]
+                obj = json.loads(last_line)
+                prev_hash = obj.get("hash") or ""
+            except Exception:
+                prev_hash = ""
+        payload = {
+            "job_id": job_id,
+            "status": status,
+            "finished_at": finished_at,
+            "batches": [batch.get("meta", {}).get("hash") for batch in batches],
+            "errors": errors,
+            "prev_hash": prev_hash,
+        }
+        blob = json.dumps(payload, sort_keys=True).encode("utf-8")
+        import hashlib
+
+        payload["hash"] = hashlib.sha256(blob).hexdigest()
+        _ndjson_append(self._audit_path, payload)
+
+    # endregion
+
+    def get_job(self, job_id: str) -> Optional[Dict[str, Any]]:
+        with self._jobs_lock:
+            job = self._jobs.get(job_id)
+            return dict(job) if job else None
+
+    def list_jobs(self) -> List[Dict[str, Any]]:
+        with self._jobs_lock:
+            return [dict(job) for job in self._jobs.values()]
+
+    def audit_log(self) -> str:
+        if not self._audit_path.exists():
+            return ""
+        return self._audit_path.read_text(encoding="utf-8")
+
+
+ENGINE = PlanEngine()
+

--- a/core/plugins_builtin/organizer/__init__.py
+++ b/core/plugins_builtin/organizer/__init__.py
@@ -1,0 +1,3 @@
+"""Organizer built-in tools plugin."""
+
+__all__ = []

--- a/core/plugins_builtin/organizer/plugin.py
+++ b/core/plugins_builtin/organizer/plugin.py
@@ -1,0 +1,23 @@
+SERVICE_ID = "core.organizer"
+VERSION = "0.1.0"
+
+
+def describe() -> dict:
+    return {
+        "id": SERVICE_ID,
+        "name": "Organizer",
+        "version": VERSION,
+        "builtin": True,
+        "services": [],
+        "scopes": [],
+        "ui": {
+            "tools_pages": [
+                {
+                    "id": "organizer",
+                    "title": "Organizer",
+                    "path": "ui/index.html",
+                    "order": 100,
+                }
+            ]
+        },
+    }

--- a/core/plugins_builtin/organizer/ui/app.js
+++ b/core/plugins_builtin/organizer/ui/app.js
@@ -1,0 +1,307 @@
+(function () {
+  const previewBtn = document.getElementById("btn-preview");
+  const executeBtn = document.getElementById("btn-execute");
+  const downloadBtn = document.getElementById("btn-download");
+  const rollbackBtn = document.getElementById("btn-rollback");
+  const planInput = document.getElementById("plan-json");
+  const previewSummary = document.getElementById("preview-summary");
+  const previewTable = document.getElementById("preview-table");
+  const crossDriveNote = document.getElementById("cross-drive-note");
+  const jobStatus = document.getElementById("job-status");
+  const logEl = document.getElementById("log");
+
+  const STORAGE_KEY = "tgc.organizer.plan";
+  let lastPlan = [];
+  let currentJobId = null;
+  let pollTimer = null;
+
+  function log(message) {
+    if (!logEl) {
+      return;
+    }
+    const now = new Date().toISOString();
+    const line = `[${now}] ${message}`;
+    logEl.textContent = `${line}\n${logEl.textContent || ""}`;
+  }
+
+  function fetchJson(path, options = {}) {
+    const fetchImpl = window.tgcAuthenticatedFetch || window.fetch;
+    const headers = Object.assign({ "Content-Type": "application/json" }, options.headers || {});
+    const opts = Object.assign({}, options, { headers });
+    return fetchImpl(path, opts).then(async (response) => {
+      if (!response.ok) {
+        const text = await response.text().catch(() => "");
+        const error = new Error(`Request failed: ${response.status}`);
+        error.status = response.status;
+        error.body = text;
+        throw error;
+      }
+      if (response.status === 204) {
+        return {};
+      }
+      return response.json();
+    });
+  }
+
+  function parsePlanInput() {
+    if (!planInput) {
+      return [];
+    }
+    const raw = planInput.value.trim();
+    if (!raw) {
+      return [];
+    }
+    try {
+      const parsed = JSON.parse(raw);
+      if (Array.isArray(parsed)) {
+        return parsed;
+      }
+      if (parsed && Array.isArray(parsed.batches)) {
+        return parsed.batches;
+      }
+    } catch (error) {
+      throw new Error("Plan JSON must be an array or {batches: []}");
+    }
+    throw new Error("Plan JSON must be an array or {batches: []}");
+  }
+
+  function savePlanToStorage(value) {
+    try {
+      window.localStorage.setItem(STORAGE_KEY, value);
+    } catch (error) {
+      // ignore storage errors
+    }
+  }
+
+  function loadPlanFromStorage() {
+    try {
+      const stored = window.localStorage.getItem(STORAGE_KEY);
+      if (stored && planInput) {
+        planInput.value = stored;
+      }
+    } catch (error) {
+      // ignore
+    }
+  }
+
+  function renderPreview(result) {
+    if (!result || !previewSummary || !previewTable) {
+      return;
+    }
+    const summary = result.summary || {};
+    previewSummary.textContent = `OK: ${summary.ok || 0} • Deny: ${summary.deny || 0} • Error: ${summary.error || 0}`;
+
+    const batches = Array.isArray(result.batches) ? result.batches : [];
+    const table = document.createElement("table");
+    const head = document.createElement("thead");
+    head.innerHTML = "<tr><th>Operation</th><th>Source</th><th>Target</th><th>Status</th><th>Reason</th></tr>";
+    table.appendChild(head);
+    const body = document.createElement("tbody");
+    let crossDrive = false;
+    batches.forEach((batch) => {
+      const op = batch.op || "";
+      const results = Array.isArray(batch.results) ? batch.results : [];
+      results.forEach((item) => {
+        const tr = document.createElement("tr");
+        const itemData = item.item || {};
+        const warnings = Array.isArray(item.warnings) ? item.warnings : [];
+        if (warnings.includes("cross_drive_copy_quarantine")) {
+          crossDrive = true;
+        }
+        tr.innerHTML = `
+          <td>${op}</td>
+          <td>${itemData.old_path || itemData.path || ""}</td>
+          <td>${item.resolved_path || ""}</td>
+          <td class="status-${String(item.status || "").toLowerCase()}">${item.status || ""}</td>
+          <td>${item.reason || ""}</td>
+        `;
+        body.appendChild(tr);
+      });
+    });
+    table.appendChild(body);
+    previewTable.innerHTML = "";
+    previewTable.appendChild(table);
+    if (crossDrive && crossDriveNote) {
+      crossDriveNote.style.display = "block";
+      crossDriveNote.textContent = "Will copy to target and quarantine the original for cross-drive moves.";
+    } else if (crossDriveNote) {
+      crossDriveNote.style.display = "none";
+      crossDriveNote.textContent = "";
+    }
+  }
+
+  function hasBlockingIssues(result) {
+    if (!result) {
+      return true;
+    }
+    const summary = result.summary || {};
+    return (summary.error || 0) > 0 || (summary.deny || 0) > 0;
+  }
+
+  function enableExecute(enabled) {
+    if (executeBtn) {
+      executeBtn.disabled = !enabled;
+    }
+  }
+
+  function stopPolling() {
+    if (pollTimer) {
+      clearTimeout(pollTimer);
+      pollTimer = null;
+    }
+  }
+
+  function schedulePoll(jobId) {
+    stopPolling();
+    pollTimer = setTimeout(() => pollJob(jobId), 500);
+  }
+
+  function pollJob(jobId) {
+    fetchJson(`/jobs/${jobId}`)
+      .then((job) => {
+        currentJobId = jobId;
+        if (jobStatus) {
+          const progress = job.progress || { done: 0, total: 0 };
+          jobStatus.textContent = `Status: ${job.status} • ${progress.done}/${progress.total}`;
+        }
+        if (job.status === "running") {
+          schedulePoll(jobId);
+        } else {
+          stopPolling();
+          if (job.status === "done") {
+            log(`Job ${jobId} finished.`);
+            enableExecute(false);
+            if (rollbackBtn) {
+              rollbackBtn.style.display = "inline-block";
+            }
+          } else {
+            log(`Job ${jobId} failed: ${(job.errors || []).join(", ")}`);
+          }
+        }
+      })
+      .catch((error) => {
+        stopPolling();
+        log(`Failed to poll job: ${error}`);
+      });
+  }
+
+  function onPreview() {
+    if (!planInput) {
+      return;
+    }
+    try {
+      const batches = parsePlanInput();
+      savePlanToStorage(planInput.value);
+      lastPlan = batches;
+      if (!batches.length) {
+      if (previewSummary) {
+        previewSummary.textContent = "Provide at least one batch to preview.";
+      }
+      if (previewTable) {
+        previewTable.innerHTML = "";
+      }
+        enableExecute(false);
+        return;
+      }
+      log("Preview → submitting batches");
+      fetchJson("/plan.preview", {
+        method: "POST",
+        body: JSON.stringify({ batches }),
+      })
+          .then((result) => {
+            renderPreview(result);
+          const ready = !hasBlockingIssues(result);
+          enableExecute(ready);
+          if (jobStatus) {
+            jobStatus.textContent = ready
+              ? "Preview succeeded. Ready to execute."
+              : "Preview blocked. Resolve Deny/Error items.";
+          }
+          log("Preview → received response");
+        })
+        .catch((error) => {
+          enableExecute(false);
+          if (previewSummary) {
+            previewSummary.textContent = "Preview failed.";
+          }
+          if (previewTable) {
+            previewTable.innerHTML = "";
+          }
+          log(`Preview failed: ${error.body || error}`);
+        });
+    } catch (error) {
+      enableExecute(false);
+      if (previewSummary) {
+        previewSummary.textContent = error.message;
+      }
+      if (previewTable) {
+        previewTable.innerHTML = "";
+      }
+    }
+  }
+
+  function onExecute() {
+    if (!lastPlan || !lastPlan.length) {
+      return;
+    }
+    enableExecute(false);
+    if (jobStatus) {
+      jobStatus.textContent = "Submitting job…";
+    }
+    log("Execute → submitting batches");
+    fetchJson("/plan.execute", {
+      method: "POST",
+      body: JSON.stringify({ batches: lastPlan }),
+    })
+      .then((result) => {
+        if (result.accepted) {
+          log(`Job ${result.job_id} accepted.`);
+          schedulePoll(result.job_id);
+        } else {
+          log(`Job reused existing id ${result.job_id}.`);
+          schedulePoll(result.job_id);
+        }
+      })
+      .catch((error) => {
+        log(`Execute failed: ${error.body || error}`);
+        enableExecute(true);
+      });
+  }
+
+  function onDownload() {
+    if (!planInput) {
+      return;
+    }
+    const blob = new Blob([planInput.value || "[]"], { type: "application/json" });
+    const url = URL.createObjectURL(blob);
+    const a = document.createElement("a");
+    a.href = url;
+    a.download = `plan-${new Date().toISOString().replace(/[:.]/g, "-")}.json`;
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    URL.revokeObjectURL(url);
+  }
+
+  if (previewBtn) {
+    previewBtn.addEventListener("click", onPreview);
+  }
+  if (executeBtn) {
+    executeBtn.addEventListener("click", onExecute);
+  }
+  if (downloadBtn) {
+    downloadBtn.addEventListener("click", onDownload);
+  }
+  if (rollbackBtn) {
+    rollbackBtn.addEventListener("click", () => {
+      log("Rollback will be available in a future release.");
+    });
+  }
+  if (planInput) {
+    planInput.addEventListener("input", () => {
+      savePlanToStorage(planInput.value);
+    });
+  }
+
+  loadPlanFromStorage();
+})();

--- a/core/plugins_builtin/organizer/ui/index.html
+++ b/core/plugins_builtin/organizer/ui/index.html
@@ -1,0 +1,137 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <title>Organizer</title>
+    <style>
+      body {
+        font-family: -apple-system, BlinkMacSystemFont, "Segoe UI", sans-serif;
+        margin: 0;
+        padding: 16px;
+        background: #f7f7f9;
+        color: #1a1a1a;
+      }
+
+      h1 {
+        font-size: 20px;
+        margin-bottom: 12px;
+      }
+
+      section {
+        background: #ffffff;
+        border-radius: 8px;
+        padding: 16px;
+        box-shadow: 0 1px 2px rgba(0, 0, 0, 0.08);
+        margin-bottom: 16px;
+      }
+
+      button.primary {
+        background: #0055ff;
+        border: none;
+        color: #ffffff;
+        padding: 8px 16px;
+        border-radius: 4px;
+        cursor: pointer;
+        font-weight: 600;
+      }
+
+      button.primary:disabled {
+        opacity: 0.5;
+        cursor: default;
+      }
+
+      .controls {
+        display: flex;
+        gap: 8px;
+        margin-bottom: 12px;
+      }
+
+      table {
+        width: 100%;
+        border-collapse: collapse;
+      }
+
+      th,
+      td {
+        text-align: left;
+        padding: 6px 8px;
+        border-bottom: 1px solid #e4e6eb;
+        font-size: 13px;
+      }
+
+      .muted {
+        color: #6b6b6b;
+      }
+
+      .log {
+        font-family: "SFMono-Regular", Consolas, "Liberation Mono", monospace;
+        font-size: 12px;
+        background: #1b1b1f;
+        color: #e7e7ec;
+        padding: 8px;
+        border-radius: 6px;
+        max-height: 200px;
+        overflow-y: auto;
+      }
+
+      .status-ok {
+        color: #056839;
+        font-weight: 600;
+      }
+
+      .status-deny {
+        color: #b34700;
+        font-weight: 600;
+      }
+
+      .status-error {
+        color: #c71f37;
+        font-weight: 600;
+      }
+
+      .note {
+        background: #f0f6ff;
+        border-left: 3px solid #0055ff;
+        padding: 8px 12px;
+        border-radius: 4px;
+        margin-top: 12px;
+        font-size: 13px;
+      }
+    </style>
+  </head>
+  <body>
+    <h1>Organizer</h1>
+    <section>
+      <div class="controls">
+        <button id="btn-preview" class="primary">Preview</button>
+        <button id="btn-execute" class="primary" disabled>Execute</button>
+        <button id="btn-download" type="button">Download Plan JSON</button>
+      </div>
+      <label for="plan-json" class="muted" style="display: block; margin-bottom: 4px"
+        >Plan batches (Plan Engine v1 JSON)</label
+      >
+      <textarea
+        id="plan-json"
+        rows="8"
+        style="width: 100%; font-family: 'SFMono-Regular', Consolas, 'Liberation Mono', monospace; font-size: 12px; padding: 8px; border-radius: 4px; border: 1px solid #cbd1dc; box-sizing: border-box;"
+        placeholder='[{"op":"rename.batch",...}]'
+      ></textarea>
+      <div id="preview-summary" class="muted">Preview pending…</div>
+      <div id="preview-table"></div>
+      <div id="cross-drive-note" class="note" style="display: none"></div>
+    </section>
+
+    <section>
+      <h2 style="font-size: 16px; margin-top: 0">Execution</h2>
+      <div id="job-status" class="muted">No active job.</div>
+      <button id="btn-rollback" type="button" style="display: none">Rollback (coming soon)</button>
+    </section>
+
+    <section>
+      <h2 style="font-size: 16px; margin-top: 0">Log</h2>
+      <div id="log" class="log"></div>
+    </section>
+
+    <script src="./app.js"></script>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- implement a local-only plan engine that validates batches, records journals, and executes rename, move, and bundle operations using new filesystem and bundling helpers
- expose plan preview, execution, job status, and audit log endpoints backed by the new engine
- add an Organizer tools UI page that lets operators preview plans, execute jobs, and monitor progress from the browser

## Testing
- pytest

------
https://chatgpt.com/codex/tasks/task_e_68f97e1a1bc883228ca9d76526149c5a