### PR TITLE
Add organizer duplicate and rename planning tools

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -54,6 +54,7 @@ from pydantic import BaseModel
 from core.domain.bootstrap import get_broker
 from core.settings.reader import load_reader_settings, save_reader_settings
 from core.reader.api import router as reader_local_router
+from core.organizer.api import router as organizer_router
 
 if os.name == "nt":  # pragma: no cover - windows specific
     from core.broker.pipes import NamedPipeServer
@@ -220,6 +221,7 @@ def require_token_ctx(
 
 protected = APIRouter(dependencies=[Depends(require_token_ctx)])
 protected.include_router(reader_local_router)
+protected.include_router(organizer_router)
 oauth = APIRouter()
 
 

--- a/core/organizer/__init__.py
+++ b/core/organizer/__init__.py
@@ -1,0 +1,6 @@
+"""Organizer utilities for BUS Core."""
+
+__all__ = [
+    "duplicates",
+    "rename",
+]

--- a/core/organizer/api.py
+++ b/core/organizer/api.py
@@ -1,0 +1,158 @@
+"""Organizer API endpoints for generating file operation plans."""
+
+from __future__ import annotations
+
+import os
+from datetime import datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, HTTPException
+from pydantic import BaseModel
+
+from core.organizer.duplicates import find_duplicates, pick_keeper
+from core.organizer.rename import normalize_filename
+from core.plans.model import Action, ActionKind, Plan
+from core.plans.store import save_plan
+from core.reader.ids import to_rid
+from core.reader.roots import get_allowed_local_roots
+
+router = APIRouter(prefix="/organizer", tags=["organizer"])
+
+
+class DupBody(BaseModel):
+    start_path: str
+    quarantine_dir: Optional[str] = None
+
+
+class RenameBody(BaseModel):
+    start_path: str
+
+
+def _allowed(path: str, roots: Optional[List[str]] = None) -> bool:
+    abs_path = os.path.normcase(os.path.abspath(path))
+    for root in roots or get_allowed_local_roots():
+        abs_root = os.path.normcase(os.path.abspath(root))
+        try:
+            if os.path.commonpath([abs_path, abs_root]) == abs_root:
+                return True
+        except ValueError:
+            # Different drive letters on Windows raise ValueError.
+            continue
+    return False
+
+
+def _maybe_to_rid(path: str, roots: List[str]) -> Optional[str]:
+    try:
+        return to_rid(path, roots)
+    except Exception:
+        return None
+
+
+@router.post("/duplicates/plan")
+def duplicates_plan(body: DupBody):
+    start = os.path.normpath(body.start_path)
+    if not os.path.exists(start):
+        raise HTTPException(status_code=404, detail="start_path does not exist")
+    if not os.path.isdir(start):
+        raise HTTPException(status_code=400, detail="start_path must be a directory")
+    roots = get_allowed_local_roots()
+    if not _allowed(start, roots):
+        raise HTTPException(status_code=400, detail="start_path not under allowed local roots")
+    quarantine_dir = body.quarantine_dir or os.path.join(
+        os.path.expanduser("~"), "Documents", "Quarantine", "Duplicates"
+    )
+    if not _allowed(quarantine_dir, roots):
+        raise HTTPException(status_code=400, detail="quarantine_dir not under allowed local roots")
+    os.makedirs(quarantine_dir, exist_ok=True)
+
+    duplicates = find_duplicates(start)
+    actions: List[Action] = []
+    for digest, group in duplicates.items():
+        keeper = pick_keeper(group)
+        counter = 1
+        for path in group:
+            if path == keeper:
+                continue
+            name = os.path.basename(path)
+            destination = os.path.join(quarantine_dir, name)
+            base, ext = os.path.splitext(name)
+            suffix = 1
+            while os.path.exists(destination):
+                destination = os.path.join(quarantine_dir, f"{base}-dup{suffix}{ext}")
+                suffix += 1
+            action = Action(
+                id=f"dup-{digest[:8]}-{counter}",
+                kind=ActionKind.MOVE,
+                src_id=_maybe_to_rid(path, roots),
+                dst_parent_id=_maybe_to_rid(os.path.dirname(destination), roots),
+                dst_name=os.path.basename(destination),
+                meta={
+                    "src_path": path,
+                    "dst_path": destination,
+                    "dst_parent_path": os.path.dirname(destination),
+                    "dst_name": os.path.basename(destination),
+                },
+            )
+            actions.append(action)
+            counter += 1
+
+    plan = Plan(
+        id=f"org-dup-{int(datetime.utcnow().timestamp())}",
+        source="organizer",
+        title=f"Organizer: Duplicates from {start}",
+        note=f"Move duplicates to {quarantine_dir}",
+        actions=actions,
+    )
+    save_plan(plan)
+    return {"plan_id": plan.id, "actions": len(actions)}
+
+
+@router.post("/rename/plan")
+def rename_plan(body: RenameBody):
+    start = os.path.normpath(body.start_path)
+    if not os.path.exists(start):
+        raise HTTPException(status_code=404, detail="start_path does not exist")
+    if not os.path.isdir(start):
+        raise HTTPException(status_code=400, detail="start_path must be a directory")
+    roots = get_allowed_local_roots()
+    if not _allowed(start, roots):
+        raise HTTPException(status_code=400, detail="start_path not under allowed local roots")
+    actions: List[Action] = []
+    counter = 1
+    for dirpath, _, filenames in os.walk(start):
+        for filename in filenames:
+            current_path = os.path.join(dirpath, filename)
+            normalized_name = normalize_filename(filename)
+            if normalized_name == filename:
+                continue
+            destination_path = os.path.join(dirpath, normalized_name)
+            # Skip if another file already occupies the destination name.
+            if os.path.exists(destination_path) and os.path.normcase(destination_path) != os.path.normcase(
+                current_path
+            ):
+                continue
+            action = Action(
+                id=f"rn-{counter}",
+                kind=ActionKind.RENAME,
+                src_id=_maybe_to_rid(current_path, roots),
+                dst_parent_id=_maybe_to_rid(dirpath, roots),
+                dst_name=normalized_name,
+                meta={
+                    "src_path": current_path,
+                    "dst_path": destination_path,
+                    "dst_parent_path": dirpath,
+                    "dst_name": normalized_name,
+                },
+            )
+            actions.append(action)
+            counter += 1
+
+    plan = Plan(
+        id=f"org-rn-{int(datetime.utcnow().timestamp())}",
+        source="organizer",
+        title=f"Organizer: Rename normalize under {start}",
+        note="Conservative normalization of filenames",
+        actions=actions,
+    )
+    save_plan(plan)
+    return {"plan_id": plan.id, "actions": len(actions)}

--- a/core/organizer/duplicates.py
+++ b/core/organizer/duplicates.py
@@ -1,0 +1,86 @@
+"""Helpers for discovering duplicate files within allowed roots."""
+
+from __future__ import annotations
+
+import hashlib
+import os
+from dataclasses import dataclass
+from typing import Dict, Iterator, List
+
+
+@dataclass
+class FileInfo:
+    """Snapshot of a file encountered during a walk."""
+
+    path: str
+    size: int
+    mtime: float
+
+
+def iter_files(root: str) -> Iterator[FileInfo]:
+    """Yield files under ``root`` along with metadata."""
+
+    for dirpath, _, filenames in os.walk(root):
+        for name in filenames:
+            full_path = os.path.join(dirpath, name)
+            try:
+                stat = os.stat(full_path)
+            except OSError:
+                # File may disappear or be inaccessible; skip best-effort.
+                continue
+            yield FileInfo(full_path, stat.st_size, stat.st_mtime)
+
+
+def sha256_of(path: str, bufsize: int = 1024 * 1024) -> str:
+    """Return SHA-256 digest for ``path`` using buffered reads."""
+
+    digest = hashlib.sha256()
+    with open(path, "rb") as handle:
+        while True:
+            chunk = handle.read(bufsize)
+            if not chunk:
+                break
+            digest.update(chunk)
+    return digest.hexdigest()
+
+
+def find_duplicates(start_root: str) -> Dict[str, List[str]]:
+    """Return mapping of sha256 digest -> duplicate file paths."""
+
+    size_buckets: Dict[int, List[str]] = {}
+    for info in iter_files(start_root):
+        size_buckets.setdefault(info.size, []).append(info.path)
+
+    duplicates: Dict[str, List[str]] = {}
+    for paths in size_buckets.values():
+        if len(paths) < 2:
+            continue
+        digest_groups: Dict[str, List[str]] = {}
+        for path in paths:
+            try:
+                digest = sha256_of(path)
+            except (OSError, IOError):
+                continue
+            digest_groups.setdefault(digest, []).append(path)
+        for digest, group in digest_groups.items():
+            if len(group) > 1:
+                duplicates[digest] = group
+    return duplicates
+
+
+def pick_keeper(paths: List[str]) -> str:
+    """Pick the file to keep among duplicates.
+
+    The oldest modification time wins; ties fall back to shortest path length.
+    Missing files are treated as newest so healthy files win.
+    """
+
+    ranked: List[tuple[float, int, str]] = []
+    for path in paths:
+        try:
+            mtime = os.stat(path).st_mtime
+        except OSError:
+            mtime = float("inf")
+        ranked.append((mtime, len(path), path))
+    ranked.sort()
+    return ranked[0][2] if ranked else ""

--- a/core/organizer/rename.py
+++ b/core/organizer/rename.py
@@ -1,0 +1,16 @@
+"""Filename normalization helpers for Organizer."""
+
+from __future__ import annotations
+
+import os
+import re
+
+
+def normalize_filename(name: str) -> str:
+    """Return a conservatively normalized filename."""
+
+    base, ext = os.path.splitext(name)
+    base = re.sub(r"[._-]+", " ", base)
+    base = re.sub(r"\s+", " ", base).strip()
+    normalized = base or "unnamed"
+    return normalized + ext

--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -214,6 +214,38 @@
         </div>
 
         <div style="margin-top:16px; padding:12px; border:1px solid #333; border-radius:6px;">
+          <h3 style="margin:0 0 8px 0;">Organizer (beta)</h3>
+          <div style="display:flex; gap:8px; flex-wrap:wrap; align-items:center;">
+            <input
+              id="orgStart"
+              type="text"
+              placeholder="Start folder (absolute path under allowed roots)"
+              style="min-width:360px;padding:6px;"
+            />
+            <input
+              id="orgQdir"
+              type="text"
+              placeholder="Quarantine dir (optional)"
+              style="min-width:320px;padding:6px;"
+            />
+            <button id="btnDupPlan" type="button">Find Duplicates → Plan</button>
+            <button id="btnRenPlan" type="button">Normalize Names → Plan</button>
+          </div>
+          <div id="orgOut" style="margin-top:8px; white-space:pre-wrap;"></div>
+          <div class="muted" style="margin-top:6px;">After a plan is created, use Preview/Commit below.</div>
+          <div style="margin-top:8px; display:flex; gap:8px; flex-wrap:wrap;">
+            <input
+              id="orgPlanId"
+              type="text"
+              placeholder="Plan ID"
+              style="min-width:300px;padding:6px;"
+            />
+            <button id="btnPrev" type="button">Preview</button>
+            <button id="btnCommit" type="button">Commit</button>
+          </div>
+        </div>
+
+        <div style="margin-top:16px; padding:12px; border:1px solid #333; border-radius:6px;">
           <h3 style="margin:0 0 8px 0;">Dev Tools</h3>
           <button id="btnPingPlugin" type="button">Ping Plugin</button>
           <pre id="pingOut" style="margin-top:8px; white-space:pre-wrap;"></pre>
@@ -301,6 +333,114 @@
       toggle.disabled = false;
     }
   });
+
+  // --- Organizer (beta) ---
+  const orgStart = document.getElementById("orgStart");
+  const orgQdir = document.getElementById("orgQdir");
+  const orgOut = document.getElementById("orgOut");
+  const orgPlan = document.getElementById("orgPlanId");
+  const btnDup = document.getElementById("btnDupPlan");
+  const btnRen = document.getElementById("btnRenPlan");
+  const btnPrev = document.getElementById("btnPrev");
+  const btnCommit = document.getElementById("btnCommit");
+
+  function orgSetOut(value){
+    if (!orgOut) return;
+    if (typeof value === "string"){
+      orgOut.textContent = value;
+    } else {
+      try{
+        orgOut.textContent = JSON.stringify(value,null,2);
+      }catch(err){
+        orgOut.textContent = String(value);
+      }
+    }
+  }
+
+  async function orgPost(url, body){
+    const response = await fetch(url, {
+      method: "POST",
+      headers: headers(),
+      body: JSON.stringify(body || {}),
+    });
+    const text = await response.text();
+    let parsed;
+    try{
+      parsed = text ? JSON.parse(text) : {};
+    }catch(err){
+      parsed = {error: String(err), raw: text};
+    }
+    if (!response.ok){
+      const detail = parsed && typeof parsed === "object" ? (parsed.detail || parsed.error) : undefined;
+      throw new Error(detail || `HTTP ${response.status}`);
+    }
+    return parsed;
+  }
+
+  if (orgStart && orgOut && btnDup && btnRen && btnPrev && btnCommit){
+    btnDup.addEventListener("click", async ()=>{
+      if (!orgStart.value.trim()){
+        alert("Provide a start folder under allowed roots.");
+        return;
+      }
+      orgSetOut("Scanning for duplicates…");
+      try{
+        const payload = await orgPost("/organizer/duplicates/plan", {
+          start_path: orgStart.value.trim(),
+          quarantine_dir: orgQdir ? (orgQdir.value.trim() || null) : null,
+        });
+        if (orgPlan) orgPlan.value = payload.plan_id || "";
+        orgSetOut(payload);
+      }catch(err){
+        orgSetOut({error: String(err)});
+      }
+    });
+
+    btnRen.addEventListener("click", async ()=>{
+      if (!orgStart.value.trim()){
+        alert("Provide a start folder under allowed roots.");
+        return;
+      }
+      orgSetOut("Scanning filenames…");
+      try{
+        const payload = await orgPost("/organizer/rename/plan", {
+          start_path: orgStart.value.trim(),
+        });
+        if (orgPlan) orgPlan.value = payload.plan_id || "";
+        orgSetOut(payload);
+      }catch(err){
+        orgSetOut({error: String(err)});
+      }
+    });
+
+    btnPrev.addEventListener("click", async ()=>{
+      if (!orgPlan || !orgPlan.value.trim()){
+        alert("No plan id");
+        return;
+      }
+      orgSetOut("Loading preview…");
+      try{
+        const payload = await orgPost(`/plans/${encodeURIComponent(orgPlan.value.trim())}/preview`, {});
+        orgSetOut(payload);
+      }catch(err){
+        orgSetOut({error: String(err)});
+      }
+    });
+
+    btnCommit.addEventListener("click", async ()=>{
+      if (!orgPlan || !orgPlan.value.trim()){
+        alert("No plan id");
+        return;
+      }
+      orgSetOut("Committing plan…");
+      try{
+        const payload = await orgPost(`/plans/${encodeURIComponent(orgPlan.value.trim())}/commit`, {});
+        orgSetOut(payload);
+      }catch(err){
+        orgSetOut({error: String(err)});
+      }
+    });
+  }
 
   // --- Dev: Ping Plugin ---
   const pingBtn = document.getElementById("btnPingPlugin");


### PR DESCRIPTION
## Summary
- add organizer API endpoints for duplicate moves and filename normalization that build Plan records with reader IDs when possible
- implement helpers to scan for duplicate files and normalize filenames
- wire the organizer router and surface a Settings UI card that can create, preview, and commit organizer plans

## Testing
- python -m compileall core/organizer

------
https://chatgpt.com/codex/tasks/task_e_68fa8639ead08322b10595c5bf39bcaf