### PR TITLE
Ensure UI fetches and applies session token automatically

### DIFF
--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -4,6 +4,59 @@
     <meta charset="utf-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1" />
     <title>Core Dashboard</title>
+    <script>
+(function(){
+  // Read cookie helper
+  function readCookie(name){
+    const m = document.cookie.match(new RegExp('(?:^|; )'+name.replace(/([.$?*|{}()[\]\\/+^])/g,'\\$1')+'=([^;]*)'));
+    return m ? decodeURIComponent(m[1]) : '';
+  }
+
+  // Ensure token available ASAP
+  async function ensureToken(){
+    let t = window.BUS_SESSION_TOKEN || localStorage.getItem('BUS_SESSION_TOKEN') || readCookie('X-Session-Token') || '';
+    if (!t) {
+      try {
+        const r = await fetch('/session/token', {cache:'no-store'});
+        const j = await r.json();
+        t = j.token || '';
+      } catch(e) { /* ignore */ }
+    }
+    if (t) {
+      window.BUS_SESSION_TOKEN = t;
+      localStorage.setItem('BUS_SESSION_TOKEN', t);
+      document.cookie = 'X-Session-Token=' + encodeURIComponent(t) + '; SameSite=Lax; Path=/';
+      // If there is a visible Session Token <input>, fill it once
+      const inp = document.querySelector('input[id*=session][type=password],input[id*=session][type=text]');
+      if (inp && !inp.value) inp.value = t;
+      document.dispatchEvent(new CustomEvent('bus:token-ready', {detail:{token:t}}));
+    }
+    return t;
+  }
+
+  // Patch fetch to always add header for same-origin requests
+  const _fetch = window.fetch;
+  window.fetch = async function(input, init){
+    init = init || {};
+    const headers = new Headers(init.headers || {});
+    const t = window.BUS_SESSION_TOKEN || localStorage.getItem('BUS_SESSION_TOKEN') || readCookie('X-Session-Token') || '';
+    if (t && typeof input === 'string' && input.startsWith('/')) headers.set('X-Session-Token', t);
+    init.headers = headers;
+    return _fetch(input, init);
+  };
+
+  // Disable token-required buttons until we have a token
+  document.addEventListener('DOMContentLoaded', ()=>{
+    document.querySelectorAll('[data-require-token]').forEach(el => el.disabled = true);
+  });
+  document.addEventListener('bus:token-ready', ()=>{
+    document.querySelectorAll('[data-require-token]').forEach(el => el.disabled = false);
+  });
+
+  // Kick it off
+  ensureToken();
+})();
+</script>
     <link rel="stylesheet" href="/ui/static/styles.css" />
   </head>
   <body>
@@ -237,8 +290,8 @@
               placeholder="Quarantine dir (optional)"
               style="min-width:320px;padding:6px;"
             />
-            <button id="btnDupPlan" type="button">Find Duplicates → Plan</button>
-            <button id="btnRenPlan" type="button">Normalize Names → Plan</button>
+            <button id="btnDupPlan" type="button" data-require-token>Find Duplicates → Plan</button>
+            <button id="btnRenPlan" type="button" data-require-token>Normalize Names → Plan</button>
           </div>
           <div id="orgOut" style="margin-top:8px; white-space:pre-wrap;"></div>
           <div class="muted" style="margin-top:6px;">After a plan is created, use Preview/Commit below.</div>
@@ -249,14 +302,14 @@
               placeholder="Plan ID"
               style="min-width:300px;padding:6px;"
             />
-            <button id="btnPrev" type="button">Preview</button>
-            <button id="btnCommit" type="button">Commit</button>
+            <button id="btnPrev" type="button" data-require-token>Preview</button>
+            <button id="btnCommit" type="button" data-require-token>Commit</button>
           </div>
         </div>
 
         <div style="margin-top:16px; padding:12px; border:1px solid #333; border-radius:6px;">
           <h3 style="margin:0 0 8px 0;">Dev Tools</h3>
-          <button id="btnPingPlugin" type="button">Ping Plugin</button>
+          <button id="btnPingPlugin" type="button" data-require-token>Ping Plugin</button>
           <pre id="pingOut" style="margin-top:8px; white-space:pre-wrap;"></pre>
         </div>
       </div>


### PR DESCRIPTION
## Summary
- auto-fetch and persist the session token on load and patch fetch to include it on same-origin requests
- gate token-dependent UI actions until the token is ready

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fab0953bf083229139cfb89fef3a67