### PR TITLE
Add static shell dashboard UI

### DIFF
--- a/core/ui/js/api.js
+++ b/core/ui/js/api.js
@@ -1,0 +1,10 @@
+export async function get(url){
+  const r = await fetch(url, {cache:'no-store'});
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}
+export async function post(url, body){
+  const r = await fetch(url, {method:'POST', headers:{'Content-Type':'application/json'}, body: JSON.stringify(body||{})});
+  if (!r.ok) throw new Error(await r.text());
+  return r.json();
+}

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -1,0 +1,13 @@
+import { get } from '/ui/js/api.js';
+export async function mountDev(root){
+  root.innerHTML = `
+    <h2>Dev Tools</h2>
+    <button id="ping">Ping Plugin</button>
+    <pre id="out" style="margin-top:8px" class="muted"></pre>
+  `;
+  const $ = sel => root.querySelector(sel);
+  $('#ping').onclick = async ()=>{
+    const j = await get('/dev/ping_plugin');
+    $('#out').textContent = JSON.stringify(j,null,2);
+  };
+}

--- a/core/ui/js/cards/organizer.js
+++ b/core/ui/js/cards/organizer.js
@@ -1,0 +1,39 @@
+import { post } from '/ui/js/api.js';
+export async function mountOrganizer(root){
+  root.innerHTML = `
+    <h2>Organizer (beta)</h2>
+    <div class="row">
+      <input id="start" placeholder="Start folder (absolute path under allowed roots)" style="min-width:360px">
+      <input id="qdir" placeholder="Quarantine dir (optional)" style="min-width:320px">
+      <button id="dup">Duplicates → Plan</button>
+      <button id="ren">Normalize Names → Plan</button>
+    </div>
+    <div class="row" style="margin-top:8px">
+      <input id="pid" placeholder="Plan ID" style="min-width:320px">
+      <button id="prev">Preview</button>
+      <button id="commit">Commit</button>
+    </div>
+    <pre id="out" style="margin-top:8px" class="muted"></pre>
+  `;
+  const $ = sel => root.querySelector(sel);
+  $('#dup').onclick = async ()=>{
+    const j = await post('/organizer/duplicates/plan', {start_path: $('#start').value.trim(), quarantine_dir: $('#qdir').value.trim()||null});
+    $('#pid').value = j.plan_id || '';
+    $('#out').textContent = JSON.stringify(j,null,2);
+  };
+  $('#ren').onclick = async ()=>{
+    const j = await post('/organizer/rename/plan', {start_path: $('#start').value.trim()});
+    $('#pid').value = j.plan_id || '';
+    $('#out').textContent = JSON.stringify(j,null,2);
+  };
+  $('#prev').onclick = async ()=>{
+    const id = $('#pid').value.trim(); if(!id){alert('No plan id'); return;}
+    const j = await post(`/plans/${encodeURIComponent(id)}/preview`, {});
+    $('#out').textContent = JSON.stringify(j,null,2);
+  };
+  $('#commit').onclick = async ()=>{
+    const id = $('#pid').value.trim(); if(!id){alert('No plan id'); return;}
+    const j = await post(`/plans/${encodeURIComponent(id)}/commit`, {});
+    $('#out').textContent = JSON.stringify(j,null,2);
+  };
+}

--- a/core/ui/js/cards/writes.js
+++ b/core/ui/js/cards/writes.js
@@ -1,0 +1,25 @@
+import { get, post } from '/ui/js/api.js';
+export async function mountWrites(root){
+  root.innerHTML = `
+    <h2>Writes</h2>
+    <div class="row">
+      <div id="status" class="muted">Loading…</div>
+      <button id="toggle" disabled>Toggle</button>
+    </div>
+    <pre id="out" class="muted"></pre>
+  `;
+  const $ = sel => root.querySelector(sel);
+  async function refresh(){
+    const j = await get('/dev/writes');
+    $('#status').textContent = 'Writes: ' + (j.enabled ? 'Enabled' : 'Disabled');
+    $('#toggle').disabled = false;
+    $('#toggle').textContent = j.enabled ? 'Disable' : 'Enable';
+  }
+  $('#toggle').onclick = async ()=>{
+    $('#toggle').disabled = true;
+    const j = await post('/dev/writes', {enabled: $('#toggle').textContent==='Enable'});
+    $('#out').textContent = JSON.stringify(j,null,2);
+    await refresh();
+  };
+  await refresh();
+}

--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -1,0 +1,38 @@
+export const Token = (()=> {
+  function readCookie(name){
+    const m = document.cookie.match(new RegExp('(?:^|; )'+name.replace(/([.$?*|{}()[\\]\\/+^])/g,'\\\\$1')+'=([^;]*)'));
+    return m ? decodeURIComponent(m[1]) : '';
+  }
+  async function ensure(){
+    let t = window.BUS_SESSION_TOKEN || localStorage.getItem('BUS_SESSION_TOKEN') || readCookie('X-Session-Token') || '';
+    if (!t) {
+      try {
+        const r = await fetch('/session/token', {cache:'no-store'});
+        const j = await r.json();
+        t = j.token || '';
+      } catch(e) {}
+    }
+    if (t){
+      window.BUS_SESSION_TOKEN = t;
+      localStorage.setItem('BUS_SESSION_TOKEN', t);
+      document.cookie = 'X-Session-Token=' + encodeURIComponent(t) + '; SameSite=Lax; Path=/';
+      document.dispatchEvent(new CustomEvent('bus:token-ready', {detail:{token:t}}));
+    }
+    return t;
+  }
+  // Patch fetch once
+  if (!window.__fetchPatched){
+    const _f = window.fetch;
+    window.fetch = async (input, init)=>{
+      init = init || {};
+      const headers = new Headers(init.headers || {});
+      const t = window.BUS_SESSION_TOKEN || localStorage.getItem('BUS_SESSION_TOKEN') || readCookie('X-Session-Token') || '';
+      if (t && typeof input === 'string' && input.startsWith('/')) headers.set('X-Session-Token', t);
+      init.headers = headers;
+      return _f(input, init);
+    };
+    window.__fetchPatched = true;
+  }
+  ensure(); // kick off
+  return { ensure };
+})();

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -1,0 +1,83 @@
+<!doctype html>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>BUS Core — Local Dashboard</title>
+<style>
+  :root { --bg:#0b0b0c; --fg:#e8e8ea; --muted:#9aa; --card:#141417; --accent:#6ea8fe; }
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font:14px/1.4 system-ui,Segoe UI,Roboto,Arial}
+  a{color:var(--accent);text-decoration:none}
+  .wrap{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+  aside{background:#0f0f12;border-right:1px solid #222;padding:16px;position:sticky;top:0;height:100vh}
+  main{padding:16px}
+  h1{font-size:18px;margin:0 0 12px}
+  .nav a{display:block;padding:8px 10px;border-radius:8px;margin-bottom:4px;color:var(--fg)}
+  .nav a.active{background:#1b1b20}
+  .card{background:var(--card);border:1px solid #222;border-radius:12px;padding:12px;margin-bottom:12px}
+  .muted{color:var(--muted)}
+  button{background:#1f1f25;border:1px solid #2a2a32;border-radius:8px;color:#fff;padding:8px 12px;cursor:pointer}
+  button[disabled]{opacity:.5;cursor:not-allowed}
+  input,textarea{background:#101015;border:1px solid #26262e;border-radius:8px;color:#fff;padding:8px;width:100%}
+  .row{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+  pre{white-space:pre-wrap;word-break:break-word}
+</style>
+<div class="wrap">
+  <aside>
+    <h1>BUS Core</h1>
+    <div class="muted" id="license">Local-only. Token loading…</div>
+    <div class="nav" id="nav">
+      <a href="#/writes"   id="nav-writes">Writes</a>
+      <a href="#/organizer" id="nav-organizer">Organizer</a>
+      <a href="#/dev"       id="nav-dev">Dev</a>
+    </div>
+    <div class="muted" style="margin-top:12px;font-size:12px">vIA /health</div>
+  </aside>
+  <main>
+    <div id="view"></div>
+  </main>
+</div>
+
+<script type="module" src="/ui/js/token.js"></script>
+<script type="module">
+  import { mountWrites }    from "/ui/js/cards/writes.js";
+  import { mountOrganizer } from "/ui/js/cards/organizer.js";
+  import { mountDev }       from "/ui/js/cards/dev.js";
+
+  const routes = {
+    "/writes": mountWrites,
+    "/organizer": mountOrganizer,
+    "/dev": mountDev,
+  };
+
+  function setActive(hash){
+    document.querySelectorAll('.nav a').forEach(a=>a.classList.remove('active'));
+    const id = 'nav-' + (hash.replace('#/','')||'writes');
+    const el = document.getElementById(id);
+    if (el) el.classList.add('active');
+  }
+
+  async function render(){
+    const view = document.getElementById('view');
+    const hash = location.hash || '#/writes';
+    const key = hash.replace('#','');
+    const mount = routes[key] || routes['/writes'];
+    view.innerHTML = '';
+    const card = document.createElement('div');
+    card.className = 'card';
+    view.appendChild(card);
+    await mount(card);
+    setActive(hash);
+  }
+
+  window.addEventListener('hashchange', render);
+  document.addEventListener('bus:token-ready', render);
+
+  // Try to show license/version
+  (async ()=>{
+    try{
+      const r = await fetch('/health', {cache:'no-store'});
+      const j = await r.json();
+      document.getElementById('license').textContent =
+        `Local-only. Core: ${j?.licenses?.core?.name||'—'} · v ${j?.version||'—'}`;
+    }catch(e){}
+  })();
+</script>


### PR DESCRIPTION
## Summary
- add shell layout at /ui/shell.html for navigation between sections
- provide token management and API helpers for existing endpoints
- add writes, organizer, and dev cards to interact with existing services

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc23e31c688322a6141c405f14ae82