### PR TITLE
Replace core UI with token-safe dashboard

### DIFF
--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -1,5 +1,72 @@
 <!doctype html>
 <meta charset="utf-8">
-<title>BUS Core</title>
-<script>location.replace('/ui/shell.html');</script>
-<p>Redirecting to <a href="/ui/shell.html">new dashboard</a>…</p>
+<meta name="viewport" content="width=device-width, initial-scale=1" />
+<title>BUS Core — Local Dashboard</title>
+<style>
+  :root { --bg:#0b0b0c; --fg:#e8e8ea; --muted:#9aa; --card:#141417; --accent:#6ea8fe; }
+  *{box-sizing:border-box} body{margin:0;background:var(--bg);color:var(--fg);font:14px/1.4 system-ui,Segoe UI,Roboto,Arial}
+  a{color:var(--accent);text-decoration:none}
+  .wrap{display:grid;grid-template-columns:240px 1fr;min-height:100vh}
+  aside{background:#0f0f12;border-right:1px solid #222;padding:16px;position:sticky;top:0;height:100vh}
+  main{padding:16px}
+  h1{font-size:18px;margin:0 0 12px}
+  h2{margin:0 0 10px}
+  .nav a{display:block;padding:8px 10px;border-radius:8px;margin-bottom:4px;color:var(--fg)}
+  .nav a.active{background:#1b1b20}
+  .card{background:var(--card);border:1px solid #222;border-radius:12px;padding:12px;margin-bottom:12px}
+  .muted{color:var(--muted)}
+  button{background:#1f1f25;border:1px solid #2a2a32;border-radius:8px;color:#fff;padding:8px 12px;cursor:pointer}
+  button[disabled]{opacity:.5;cursor:not-allowed}
+  input{background:#101015;border:1px solid #26262e;border-radius:8px;color:#fff;padding:8px;width:100%}
+  .row{display:flex;gap:8px;flex-wrap:wrap;align-items:center}
+  pre{white-space:pre-wrap;word-break:break-word}
+</style>
+<div class="wrap">
+  <aside>
+    <h1>BUS Core</h1>
+    <div class="muted" id="license">Local-only. Token loading…</div>
+    <div class="nav" id="nav">
+      <a href="#/writes"    id="nav-writes">Writes</a>
+      <a href="#/organizer" id="nav-organizer">Organizer</a>
+      <a href="#/dev"       id="nav-dev">Dev</a>
+    </div>
+  </aside>
+  <main><div id="view"></div></main>
+</div>
+
+<!-- Token must load first -->
+<script type="module" src="/ui/js/token.js"></script>
+<script type="module">
+  import { mountWrites }    from "/ui/js/cards/writes.js";
+  import { mountOrganizer } from "/ui/js/cards/organizer.js";
+  import { mountDev }       from "/ui/js/cards/dev.js";
+
+  const routes = { "/writes": mountWrites, "/organizer": mountOrganizer, "/dev": mountDev };
+
+  function setActive(hash){
+    document.querySelectorAll('.nav a').forEach(a=>a.classList.remove('active'));
+    const el = document.getElementById('nav-' + (hash.replace('#/','')||'writes'));
+    if (el) el.classList.add('active');
+  }
+
+  async function render(){
+    const view = document.getElementById('view');
+    const hash = location.hash || '#/writes';
+    const mount = routes[hash.replace('#','')] || routes['/writes'];
+    view.innerHTML = '';
+    const card = document.createElement('div'); card.className='card';
+    view.appendChild(card);
+    await mount(card);
+    setActive(hash);
+  }
+
+  window.addEventListener('hashchange', render);
+  document.addEventListener('bus:token-ready', render);
+
+  (async ()=>{
+    try{
+      const r = await fetch('/health',{cache:'no-store'}); const j = await r.json();
+      document.getElementById('license').textContent = `Local-only · Core: ${j?.licenses?.core?.name||'—'} · v ${j?.version||'—'}`;
+    }catch(e){}
+  })();
+</script>

--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -1,6 +1,6 @@
 export const Token = (()=> {
   function readCookie(name){
-    const m = document.cookie.match(new RegExp('(?:^|; )'+name.replace(/([.$?*|{}()[\\]\\/+^])/g,'\\\\$1')+'=([^;]*)'));
+    const m = document.cookie.match(new RegExp('(?:^|; )'+name.replace(/([.$?*|{}()[\\]\\/+^])/g,'\\$1')+'=([^;]*)'));
     return m ? decodeURIComponent(m[1]) : '';
   }
   async function ensure(){

--- a/tools/launch_buscore.ps1
+++ b/tools/launch_buscore.ps1
@@ -102,6 +102,6 @@ try { & "$py" -m pywin32_postinstall -install | Out-Null } catch { }
 Push-Location $app
 $u = "http://127.0.0.1:$Port"
 Write-Host "Starting BUS Core on http://127.0.0.1:$Port/ui"
-Start-Process "$u/ui/shell.html"
+Start-Process "$u/ui/"
 & "$py" app.py serve --port $Port
 Pop-Location


### PR DESCRIPTION
## Summary
- replace the root UI with the new token-aware dashboard shell
- add modular JavaScript cards and shared helpers for token-safe API calls
- update the Windows launcher to open the new /ui/ entry point

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fc33409f648322a4d22f9f470826ee