### PR TITLE
Improve UI token bootstrap reliability

### DIFF
--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -61,7 +61,15 @@
   }
 
   window.addEventListener('hashchange', render);
+  document.addEventListener('DOMContentLoaded', render);
   document.addEventListener('bus:token-ready', render);
+
+  document.addEventListener('bus:token-ready', (e)=>{
+    const tok = (e?.detail?.token||'');
+    const pfx = tok ? tok.slice(0,6)+'…' : '—';
+    const lic = document.getElementById('license');
+    if (lic) lic.textContent = (lic.textContent||'Local-only') + ` · token ${pfx}`;
+  });
 
   (async ()=>{
     try{

--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -1,33 +1,63 @@
-export const Token = (()=> {
-  function readCookie(name){
-    const m = document.cookie.match(new RegExp('(?:^|; )'+name.replace(/([.$?*|{}()[\\]\\/+^])/g,'\\$1')+'=([^;]*)'));
-    return m ? decodeURIComponent(m[1]) : '';
-  }
-  async function ensure(){
-    let t = window.BUS_SESSION_TOKEN || localStorage.getItem('BUS_SESSION_TOKEN') || readCookie('X-Session-Token') || '';
-    if (!t) {
-      try { const r = await fetch('/session/token',{cache:'no-store'}); const j = await r.json(); t = j.token || ''; } catch(e) {}
+const COOKIE = 'X-Session-Token';
+const STORE  = 'BUS_SESSION_TOKEN';
+
+function setCookie(name, value) {
+  document.cookie = name + '=' + encodeURIComponent(value) + '; SameSite=Lax; Path=/';
+}
+function getCookie(name) {
+  const m = document.cookie.match(new RegExp('(?:^|; )'+name.replace(/([.$?*|{}()[\\]\\/+^])/g,'\\$1')+'=([^;]*)'));
+  return m ? decodeURIComponent(m[1]) : '';
+}
+function setToken(t) {
+  if (!t) return;
+  window.BUS_SESSION_TOKEN = t;
+  try { localStorage.setItem(STORE, t); } catch {}
+  setCookie(COOKIE, t);
+}
+function getToken() {
+  return window.BUS_SESSION_TOKEN
+      || (typeof localStorage!=='undefined' && localStorage.getItem(STORE))
+      || getCookie(COOKIE)
+      || '';
+}
+
+async function fetchTokenOnce(abortMs=1500) {
+  const ctl = new AbortController();
+  const to = setTimeout(()=>ctl.abort('timeout'), abortMs);
+  try {
+    const r = await fetch('/session/token', {cache:'no-store', signal: ctl.signal});
+    if (r.ok) {
+      const j = await r.json();
+      if (j && j.token) return j.token;
     }
-    if (t){
-      window.BUS_SESSION_TOKEN = t;
-      localStorage.setItem('BUS_SESSION_TOKEN', t);
-      document.cookie = 'X-Session-Token=' + encodeURIComponent(t) + '; SameSite=Lax; Path=/';
-      document.dispatchEvent(new CustomEvent('bus:token-ready', {detail:{token:t}}));
-    }
-    return t;
-  }
-  if (!window.__fetchPatched){
-    const _f = window.fetch;
-    window.fetch = async (input, init)=>{
-      init = init || {};
-      const headers = new Headers(init.headers || {});
-      const t = window.BUS_SESSION_TOKEN || localStorage.getItem('BUS_SESSION_TOKEN') || readCookie('X-Session-Token') || '';
-      if (t && typeof input === 'string' && input.startsWith('/')) headers.set('X-Session-Token', t);
-      init.headers = headers;
-      return _f(input, init);
-    };
-    window.__fetchPatched = true;
-  }
-  ensure();
-  return { ensure };
-})();
+  } catch(_) {}
+  finally { clearTimeout(to); }
+  return '';
+}
+
+async function ensure() {
+  let t = getToken();
+  if (!t) t = await fetchTokenOnce();
+  if (t) setToken(t);
+  // Always notify once; cards can enable buttons on this event
+  document.dispatchEvent(new CustomEvent('bus:token-ready', { detail: { token: getToken() } }));
+  return getToken();
+}
+
+// Patch fetch once – inject header for same-origin requests
+if (!window.__fetchPatched) {
+  const _f = window.fetch;
+  window.fetch = async (input, init) => {
+    init = init || {};
+    const headers = new Headers(init.headers || {});
+    const t = getToken();
+    if (t && typeof input === 'string' && input.startsWith('/')) headers.set('X-Session-Token', t);
+    init.headers = headers;
+    return _f(input, init);
+  };
+  window.__fetchPatched = true;
+}
+
+ensure(); // kick off immediately
+
+export const Token = { get: getToken, ensure };


### PR DESCRIPTION
## Summary
- replace the UI token helper to persist the session token across storage layers and fail softly when the fetch aborts
- patch fetch to always include the session token header and always notify listeners once a token is available
- ensure the shell renders on DOMContentLoaded and append the token prefix to the license banner once ready

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fc35a1150483229175b4ff2327fc6e