### PR TITLE
Implement domain database CRUD and UI

### DIFF
--- a/app.py
+++ b/app.py
@@ -3,14 +3,33 @@
 from __future__ import annotations
 
 import sys
+from typing import Iterable
+
+from core.api.app_router import router as app_router
+from core.api.http import APP as app
 from core.version import VERSION
 from tgc.cli_main import main as cli_main
+
+
+def _has_domain_routes(routes: Iterable[object]) -> bool:
+    for route in routes:
+        path = getattr(route, "path", "")
+        if isinstance(path, str) and path.startswith("/app/"):
+            return True
+    return False
+
+
+if not _has_domain_routes(app.router.routes):
+    app.include_router(app_router, prefix="/app")
 
 print(f"TGC Controller — version {VERSION}")
 
 
 def main() -> int:
     return cli_main()
+
+
+__all__ = ["app", "main"]
 
 
 if __name__ == "__main__":

--- a/core/api/app_router.py
+++ b/core/api/app_router.py
@@ -1,0 +1,371 @@
+"""FastAPI router for domain CRUD backed by SQLAlchemy."""
+
+from __future__ import annotations
+
+from datetime import date, datetime
+from typing import List, Optional
+
+from fastapi import APIRouter, Depends, HTTPException, Query
+from pydantic import BaseModel
+from sqlalchemy.exc import IntegrityError
+from sqlalchemy.orm import Session
+
+from core.services.models import Attachment, Item, Task, Vendor, get_session
+
+router = APIRouter(tags=["app"])
+
+
+# ---- Pydantic models -----------------------------------------------------
+
+
+class VendorBase(BaseModel):
+    name: str
+    contact: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class VendorCreate(VendorBase):
+    pass
+
+
+class VendorUpdate(BaseModel):
+    name: Optional[str] = None
+    contact: Optional[str] = None
+    notes: Optional[str] = None
+
+
+class VendorOut(VendorBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class ItemBase(BaseModel):
+    vendor_id: Optional[int] = None
+    sku: Optional[str] = None
+    name: str
+    qty: Optional[float] = 0
+    unit: Optional[str] = None
+    price: Optional[float] = None
+    notes: Optional[str] = None
+
+
+class ItemCreate(ItemBase):
+    pass
+
+
+class ItemUpdate(BaseModel):
+    vendor_id: Optional[int] = None
+    sku: Optional[str] = None
+    name: Optional[str] = None
+    qty: Optional[float] = None
+    unit: Optional[str] = None
+    price: Optional[float] = None
+    notes: Optional[str] = None
+
+
+class ItemOut(ItemBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class TaskBase(BaseModel):
+    item_id: Optional[int] = None
+    title: str
+    status: Optional[str] = "pending"
+    due: Optional[date] = None
+    notes: Optional[str] = None
+
+
+class TaskCreate(TaskBase):
+    pass
+
+
+class TaskUpdate(BaseModel):
+    item_id: Optional[int] = None
+    title: Optional[str] = None
+    status: Optional[str] = None
+    due: Optional[date] = None
+    notes: Optional[str] = None
+
+
+class TaskOut(TaskBase):
+    id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+class AttachmentBase(BaseModel):
+    reader_id: str
+    label: Optional[str] = None
+
+
+class AttachmentOut(AttachmentBase):
+    id: int
+    entity_type: str
+    entity_id: int
+    created_at: datetime
+
+    class Config:
+        orm_mode = True
+
+
+# ---- Helpers -------------------------------------------------------------
+
+
+def _require_vendor(db: Session, vendor_id: Optional[int]) -> None:
+    if vendor_id is None:
+        return
+    if db.get(Vendor, vendor_id) is None:
+        raise HTTPException(status_code=422, detail="vendor_not_found")
+
+
+def _require_item(db: Session, item_id: Optional[int]) -> None:
+    if item_id is None:
+        return
+    if db.get(Item, item_id) is None:
+        raise HTTPException(status_code=422, detail="item_not_found")
+
+
+def _require_entity(db: Session, entity_type: str, entity_id: int) -> None:
+    mapping = {
+        "vendor": Vendor,
+        "item": Item,
+        "task": Task,
+    }
+    model = mapping.get(entity_type)
+    if model is None:
+        raise HTTPException(status_code=400, detail="unsupported_entity_type")
+    if db.get(model, entity_id) is None:
+        raise HTTPException(status_code=404, detail="entity_not_found")
+
+
+# ---- Vendor endpoints ----------------------------------------------------
+
+
+@router.get("/vendors", response_model=List[VendorOut])
+def list_vendors(db: Session = Depends(get_session)) -> List[Vendor]:
+    return db.query(Vendor).order_by(Vendor.id.desc()).all()
+
+
+@router.post("/vendors", response_model=VendorOut)
+def create_vendor(payload: VendorCreate, db: Session = Depends(get_session)) -> Vendor:
+    vendor = Vendor(name=payload.name, contact=payload.contact, notes=payload.notes)
+    db.add(vendor)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="vendor_name_conflict") from exc
+    db.refresh(vendor)
+    return vendor
+
+
+@router.put("/vendors/{vendor_id}", response_model=VendorOut)
+def update_vendor(
+    vendor_id: int, payload: VendorUpdate, db: Session = Depends(get_session)
+) -> Vendor:
+    vendor = db.get(Vendor, vendor_id)
+    if vendor is None:
+        raise HTTPException(status_code=404, detail="vendor_not_found")
+    updates = payload.dict(exclude_unset=True)
+    for field, value in updates.items():
+        setattr(vendor, field, value)
+    try:
+        db.commit()
+    except IntegrityError as exc:
+        db.rollback()
+        raise HTTPException(status_code=409, detail="vendor_name_conflict") from exc
+    db.refresh(vendor)
+    return vendor
+
+
+@router.delete("/vendors/{vendor_id}")
+def delete_vendor(vendor_id: int, db: Session = Depends(get_session)) -> dict:
+    vendor = db.get(Vendor, vendor_id)
+    if vendor is None:
+        raise HTTPException(status_code=404, detail="vendor_not_found")
+    db.delete(vendor)
+    db.commit()
+    return {"ok": True}
+
+
+# ---- Item endpoints ------------------------------------------------------
+
+
+@router.get("/items", response_model=List[ItemOut])
+def list_items(
+    vendor_id: Optional[int] = Query(default=None),
+    db: Session = Depends(get_session),
+) -> List[Item]:
+    query = db.query(Item)
+    if vendor_id is not None:
+        query = query.filter(Item.vendor_id == vendor_id)
+    return query.order_by(Item.id.desc()).all()
+
+
+@router.post("/items", response_model=ItemOut)
+def create_item(payload: ItemCreate, db: Session = Depends(get_session)) -> Item:
+    _require_vendor(db, payload.vendor_id)
+    item = Item(
+        vendor_id=payload.vendor_id,
+        sku=payload.sku,
+        name=payload.name,
+        qty=payload.qty if payload.qty is not None else 0,
+        unit=payload.unit,
+        price=payload.price,
+        notes=payload.notes,
+    )
+    db.add(item)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.put("/items/{item_id}", response_model=ItemOut)
+def update_item(
+    item_id: int, payload: ItemUpdate, db: Session = Depends(get_session)
+) -> Item:
+    item = db.get(Item, item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="item_not_found")
+    updates = payload.dict(exclude_unset=True)
+    if "vendor_id" in updates:
+        _require_vendor(db, updates.get("vendor_id"))
+    for field, value in updates.items():
+        if field == "qty" and value is None:
+            continue
+        setattr(item, field, value)
+    db.commit()
+    db.refresh(item)
+    return item
+
+
+@router.delete("/items/{item_id}")
+def delete_item(item_id: int, db: Session = Depends(get_session)) -> dict:
+    item = db.get(Item, item_id)
+    if item is None:
+        raise HTTPException(status_code=404, detail="item_not_found")
+    db.delete(item)
+    db.commit()
+    return {"ok": True}
+
+
+# ---- Task endpoints ------------------------------------------------------
+
+
+@router.get("/tasks", response_model=List[TaskOut])
+def list_tasks(
+    item_id: Optional[int] = Query(default=None),
+    db: Session = Depends(get_session),
+) -> List[Task]:
+    query = db.query(Task)
+    if item_id is not None:
+        query = query.filter(Task.item_id == item_id)
+    return query.order_by(Task.id.desc()).all()
+
+
+@router.post("/tasks", response_model=TaskOut)
+def create_task(payload: TaskCreate, db: Session = Depends(get_session)) -> Task:
+    _require_item(db, payload.item_id)
+    task = Task(
+        item_id=payload.item_id,
+        title=payload.title,
+        status=payload.status or "pending",
+        due=payload.due,
+        notes=payload.notes,
+    )
+    db.add(task)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@router.put("/tasks/{task_id}", response_model=TaskOut)
+def update_task(
+    task_id: int, payload: TaskUpdate, db: Session = Depends(get_session)
+) -> Task:
+    task = db.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="task_not_found")
+    updates = payload.dict(exclude_unset=True)
+    if "item_id" in updates:
+        _require_item(db, updates.get("item_id"))
+    for field, value in updates.items():
+        setattr(task, field, value)
+    db.commit()
+    db.refresh(task)
+    return task
+
+
+@router.delete("/tasks/{task_id}")
+def delete_task(task_id: int, db: Session = Depends(get_session)) -> dict:
+    task = db.get(Task, task_id)
+    if task is None:
+        raise HTTPException(status_code=404, detail="task_not_found")
+    db.delete(task)
+    db.commit()
+    return {"ok": True}
+
+
+# ---- Attachment endpoints ------------------------------------------------
+
+
+@router.get(
+    "/attachments/{entity_type}/{entity_id}", response_model=List[AttachmentOut]
+)
+def list_attachments(
+    entity_type: str, entity_id: int, db: Session = Depends(get_session)
+) -> List[Attachment]:
+    _require_entity(db, entity_type, entity_id)
+    return (
+        db.query(Attachment)
+        .filter(
+            Attachment.entity_type == entity_type,
+            Attachment.entity_id == entity_id,
+        )
+        .order_by(Attachment.id.desc())
+        .all()
+    )
+
+
+@router.post(
+    "/attachments/{entity_type}/{entity_id}", response_model=AttachmentOut
+)
+def create_attachment(
+    entity_type: str,
+    entity_id: int,
+    payload: AttachmentBase,
+    db: Session = Depends(get_session),
+) -> Attachment:
+    _require_entity(db, entity_type, entity_id)
+    attachment = Attachment(
+        entity_type=entity_type,
+        entity_id=entity_id,
+        reader_id=payload.reader_id,
+        label=payload.label,
+    )
+    db.add(attachment)
+    db.commit()
+    db.refresh(attachment)
+    return attachment
+
+
+@router.delete("/attachments/{attachment_id}")
+def delete_attachment(attachment_id: int, db: Session = Depends(get_session)) -> dict:
+    attachment = db.get(Attachment, attachment_id)
+    if attachment is None:
+        raise HTTPException(status_code=404, detail="attachment_not_found")
+    db.delete(attachment)
+    db.commit()
+    return {"ok": True}
+
+
+__all__ = ["router"]

--- a/core/api/http.py
+++ b/core/api/http.py
@@ -60,7 +60,7 @@ from core.settings.reader_state import (
 )
 from core.reader.api import router as reader_local_router
 from core.organizer.api import router as organizer_router
-from core.app.api import router as app_router
+from core.api.app_router import router as app_router
 
 if os.name == "nt":  # pragma: no cover - windows specific
     from core.broker.pipes import NamedPipeServer
@@ -279,7 +279,7 @@ def require_token_ctx(
 protected = APIRouter(dependencies=[Depends(require_token_ctx)])
 protected.include_router(reader_local_router)
 protected.include_router(organizer_router)
-protected.include_router(app_router)
+protected.include_router(app_router, prefix="/app")
 oauth = APIRouter()
 
 

--- a/core/services/models.py
+++ b/core/services/models.py
@@ -1,0 +1,114 @@
+"""SQLAlchemy models for BUS Core domain data."""
+
+from __future__ import annotations
+
+import os
+import sys
+from pathlib import Path
+from typing import Generator
+
+from sqlalchemy import (
+    Column,
+    Date,
+    DateTime,
+    Float,
+    ForeignKey,
+    Integer,
+    String,
+    Text,
+    create_engine,
+    func,
+)
+from sqlalchemy.orm import Session, declarative_base, sessionmaker
+
+
+def _resolve_db_path() -> Path:
+    """Resolve the SQLite database path with launcher-aware defaults."""
+
+    if getattr(sys, "frozen", False):  # running from the packaged launcher
+        base = Path(os.environ.get("LOCALAPPDATA", "./data")) / "BUSCore"
+    else:
+        base = Path("./data")
+    base.mkdir(parents=True, exist_ok=True)
+    return (base / "app.db").resolve()
+
+
+DB_PATH = _resolve_db_path()
+ENGINE = create_engine(
+    f"sqlite:///{DB_PATH.as_posix()}", connect_args={"check_same_thread": False}
+)
+SessionLocal = sessionmaker(autocommit=False, autoflush=False, bind=ENGINE)
+
+Base = declarative_base()
+
+
+class Vendor(Base):
+    __tablename__ = "vendors"
+
+    id = Column(Integer, primary_key=True, index=True)
+    name = Column(String, unique=True, nullable=False)
+    contact = Column(String, nullable=True)
+    notes = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+
+class Item(Base):
+    __tablename__ = "items"
+
+    id = Column(Integer, primary_key=True, index=True)
+    vendor_id = Column(Integer, ForeignKey("vendors.id"), nullable=True)
+    sku = Column(String, nullable=True)
+    name = Column(String, nullable=False)
+    qty = Column(Float, nullable=False, server_default="0")
+    unit = Column(String, nullable=True)
+    price = Column(Float, nullable=True)
+    notes = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+
+class Task(Base):
+    __tablename__ = "tasks"
+
+    id = Column(Integer, primary_key=True, index=True)
+    item_id = Column(Integer, ForeignKey("items.id"), nullable=True)
+    title = Column(String, nullable=False)
+    status = Column(String, nullable=False, server_default="pending")
+    due = Column(Date, nullable=True)
+    notes = Column(Text, nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+
+class Attachment(Base):
+    __tablename__ = "attachments"
+
+    id = Column(Integer, primary_key=True, index=True)
+    entity_type = Column(String, nullable=False)
+    entity_id = Column(Integer, nullable=False)
+    reader_id = Column(String, nullable=False)
+    label = Column(String, nullable=True)
+    created_at = Column(DateTime, nullable=False, server_default=func.now())
+
+
+Base.metadata.create_all(ENGINE)
+
+
+def get_session() -> Generator[Session, None, None]:
+    """FastAPI dependency that yields a database session."""
+
+    db = SessionLocal()
+    try:
+        yield db
+    finally:
+        db.close()
+
+
+__all__ = [
+    "Attachment",
+    "Base",
+    "ENGINE",
+    "Item",
+    "SessionLocal",
+    "Task",
+    "Vendor",
+    "get_session",
+]

--- a/core/ui/js/cards/domain.js
+++ b/core/ui/js/cards/domain.js
@@ -1,0 +1,415 @@
+let initialized = false;
+let vendorEditId = null;
+let itemEditId = null;
+let vendorCache = [];
+let vendorTableEl;
+let vendorForm;
+let vendorSubmitBtn;
+let vendorCancelBtn;
+let vendorNameInput;
+let vendorContactInput;
+let vendorNotesInput;
+let itemForm;
+let itemSubmitBtn;
+let itemCancelBtn;
+let itemVendorSelect;
+let itemSkuInput;
+let itemNameInput;
+let itemQtyInput;
+let itemUnitInput;
+let itemPriceInput;
+let itemNotesInput;
+let itemTableEl;
+let itemFilterSelect;
+
+async function jsonRequest(url, options){
+  const opts = options||{};
+  opts.headers = opts.headers || {};
+  if(opts.body && !opts.headers['Content-Type']){
+    opts.headers['Content-Type']='application/json';
+  }
+  const resp = await fetch(url, opts);
+  if(!resp.ok){
+    const text = await resp.text();
+    throw new Error(text || resp.statusText);
+  }
+  return resp.json();
+}
+
+function clearVendorForm(){
+  vendorEditId = null;
+  vendorNameInput.value = '';
+  vendorContactInput.value = '';
+  vendorNotesInput.value = '';
+  vendorSubmitBtn.textContent = 'Add Vendor';
+  vendorCancelBtn.style.display = 'none';
+}
+
+function clearItemForm(){
+  itemEditId = null;
+  itemVendorSelect.value = '';
+  itemSkuInput.value = '';
+  itemNameInput.value = '';
+  itemQtyInput.value = '';
+  itemUnitInput.value = '';
+  itemPriceInput.value = '';
+  itemNotesInput.value = '';
+  itemSubmitBtn.textContent = 'Add Item';
+  itemCancelBtn.style.display = 'none';
+}
+
+function ensureTableStyles(table){
+  table.style.width='100%';
+  table.style.borderCollapse='collapse';
+  table.querySelectorAll('th,td').forEach(cell=>{
+    cell.style.borderBottom='1px solid #222';
+    cell.style.padding='6px 8px';
+    cell.style.verticalAlign='top';
+  });
+}
+
+function renderVendors(vendors){
+  vendorTableEl.innerHTML='';
+  if(!vendors.length){
+    vendorTableEl.textContent='No vendors yet.';
+    return;
+  }
+  const table=document.createElement('table');
+  const thead=document.createElement('thead');
+  const headerRow=document.createElement('tr');
+  ['ID','Name','Contact','Notes','Created','Actions'].forEach(label=>{
+    const th=document.createElement('th');
+    th.textContent=label;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+  const tbody=document.createElement('tbody');
+  vendors.forEach(v=>{
+    const tr=document.createElement('tr');
+    const cells=[v.id,v.name||'',v.contact||'',v.notes||'',new Date(v.created_at).toLocaleString()];
+    cells.forEach(val=>{
+      const td=document.createElement('td');
+      td.textContent=val==null?'':String(val);
+      tr.appendChild(td);
+    });
+    const actions=document.createElement('td');
+    const edit=document.createElement('button');
+    edit.textContent='Edit';
+    edit.onclick=()=>{
+      vendorEditId=v.id;
+      vendorNameInput.value=v.name||'';
+      vendorContactInput.value=v.contact||'';
+      vendorNotesInput.value=v.notes||'';
+      vendorSubmitBtn.textContent='Update Vendor';
+      vendorCancelBtn.style.display='inline-block';
+    };
+    const del=document.createElement('button');
+    del.style.marginLeft='8px';
+    del.textContent='Delete';
+    del.onclick=async()=>{
+      if(!confirm('Delete vendor '+(v.name||v.id)+'?')) return;
+      try{
+        await jsonRequest(`/app/vendors/${v.id}`,{method:'DELETE'});
+        await loadVendors();
+        await loadItems();
+      }catch(err){
+        alert('Delete failed: '+err.message);
+      }
+    };
+    actions.appendChild(edit);
+    actions.appendChild(del);
+    tr.appendChild(actions);
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  ensureTableStyles(table);
+  vendorTableEl.appendChild(table);
+}
+
+function vendorOptions(){
+  const frag=document.createDocumentFragment();
+  const empty=document.createElement('option');
+  empty.value='';
+  empty.textContent='— Vendor (optional) —';
+  frag.appendChild(empty);
+  vendorCache.forEach(v=>{
+    const opt=document.createElement('option');
+    opt.value=String(v.id);
+    opt.textContent=v.name||`Vendor ${v.id}`;
+    frag.appendChild(opt);
+  });
+  return frag;
+}
+
+function updateVendorSelects(){
+  const currentVendorValue=itemVendorSelect.value;
+  itemVendorSelect.innerHTML='';
+  itemVendorSelect.appendChild(vendorOptions());
+  if(currentVendorValue){
+    itemVendorSelect.value=currentVendorValue;
+  }
+  const currentFilterValue=itemFilterSelect.value;
+  const filterOptions=document.createDocumentFragment();
+  const allOpt=document.createElement('option');
+  allOpt.value='';
+  allOpt.textContent='All vendors';
+  filterOptions.appendChild(allOpt);
+  vendorCache.forEach(v=>{
+    const opt=document.createElement('option');
+    opt.value=String(v.id);
+    opt.textContent=v.name||`Vendor ${v.id}`;
+    filterOptions.appendChild(opt);
+  });
+  itemFilterSelect.innerHTML='';
+  itemFilterSelect.appendChild(filterOptions);
+  if(currentFilterValue){
+    itemFilterSelect.value=currentFilterValue;
+  }
+}
+
+function vendorNameById(id){
+  const found=vendorCache.find(v=>v.id===id);
+  return found?found.name||`Vendor ${id}`:'';
+}
+
+function renderItems(items){
+  itemTableEl.innerHTML='';
+  if(!items.length){
+    itemTableEl.textContent='No items yet.';
+    return;
+  }
+  const table=document.createElement('table');
+  const thead=document.createElement('thead');
+  const headerRow=document.createElement('tr');
+  ['ID','Vendor','SKU','Name','Qty','Unit','Price','Notes','Created','Actions'].forEach(label=>{
+    const th=document.createElement('th');
+    th.textContent=label;
+    headerRow.appendChild(th);
+  });
+  thead.appendChild(headerRow);
+  table.appendChild(thead);
+  const tbody=document.createElement('tbody');
+  items.forEach(it=>{
+    const tr=document.createElement('tr');
+    const cells=[
+      it.id,
+      vendorNameById(it.vendor_id||0),
+      it.sku||'',
+      it.name||'',
+      it.qty!=null?String(it.qty):'',
+      it.unit||'',
+      it.price!=null?String(it.price):'',
+      it.notes||'',
+      new Date(it.created_at).toLocaleString()
+    ];
+    cells.forEach(val=>{
+      const td=document.createElement('td');
+      td.textContent=val==null?'':String(val);
+      tr.appendChild(td);
+    });
+    const actions=document.createElement('td');
+    const edit=document.createElement('button');
+    edit.textContent='Edit';
+    edit.onclick=()=>{
+      itemEditId=it.id;
+      itemVendorSelect.value=it.vendor_id!=null?String(it.vendor_id):'';
+      itemSkuInput.value=it.sku||'';
+      itemNameInput.value=it.name||'';
+      itemQtyInput.value=it.qty!=null?String(it.qty):'';
+      itemUnitInput.value=it.unit||'';
+      itemPriceInput.value=it.price!=null?String(it.price):'';
+      itemNotesInput.value=it.notes||'';
+      itemSubmitBtn.textContent='Update Item';
+      itemCancelBtn.style.display='inline-block';
+    };
+    const del=document.createElement('button');
+    del.style.marginLeft='8px';
+    del.textContent='Delete';
+    del.onclick=async()=>{
+      if(!confirm('Delete item '+(it.name||it.id)+'?')) return;
+      try{
+        await jsonRequest(`/app/items/${it.id}`,{method:'DELETE'});
+        await loadItems();
+      }catch(err){
+        alert('Delete failed: '+err.message);
+      }
+    };
+    actions.appendChild(edit);
+    actions.appendChild(del);
+    tr.appendChild(actions);
+    tbody.appendChild(tr);
+  });
+  table.appendChild(tbody);
+  ensureTableStyles(table);
+  itemTableEl.appendChild(table);
+}
+
+async function loadVendors(){
+  try{
+    vendorTableEl.textContent='Loading vendors…';
+    vendorCache = await jsonRequest('/app/vendors');
+    renderVendors(vendorCache);
+    updateVendorSelects();
+  }catch(err){
+    vendorTableEl.textContent='Failed to load vendors';
+  }
+}
+
+async function loadItems(){
+  try{
+    itemTableEl.textContent='Loading items…';
+    const vendorFilter=itemFilterSelect.value?`?vendor_id=${encodeURIComponent(itemFilterSelect.value)}`:'';
+    const items=await jsonRequest(`/app/items${vendorFilter}`);
+    renderItems(items);
+  }catch(err){
+    itemTableEl.textContent='Failed to load items';
+  }
+}
+
+function normalizeFloat(value){
+  if(value===''||value==null) return null;
+  const n=parseFloat(value);
+  return Number.isFinite(n)?n:null;
+}
+
+function normalizeInt(value){
+  if(value===''||value==null) return null;
+  const n=parseInt(value,10);
+  return Number.isFinite(n)?n:null;
+}
+
+export async function mountDomainCard(root){
+  if(initialized){
+    await loadVendors();
+    await loadItems();
+    return;
+  }
+  initialized=true;
+  root.innerHTML=`
+    <section>
+      <h3>Vendors</h3>
+      <form id="vendor-form">
+        <div class="row">
+          <input id="vendor-name" name="name" placeholder="Name" required>
+          <input id="vendor-contact" name="contact" placeholder="Contact">
+        </div>
+        <textarea id="vendor-notes" name="notes" placeholder="Notes" rows="2" style="width:100%;margin-top:8px"></textarea>
+        <div class="row" style="margin-top:8px">
+          <button type="submit" id="vendor-submit">Add Vendor</button>
+          <button type="button" id="vendor-cancel" style="display:none">Cancel</button>
+        </div>
+      </form>
+      <div id="vendor-table" class="muted" style="margin-top:12px"></div>
+    </section>
+    <section style="margin-top:20px">
+      <h3>Items</h3>
+      <form id="item-form">
+        <div class="row">
+          <select id="item-vendor" name="vendor" style="min-width:200px"></select>
+          <input id="item-sku" name="sku" placeholder="SKU">
+          <input id="item-name" name="name" placeholder="Name" required>
+        </div>
+        <div class="row" style="margin-top:8px">
+          <input id="item-qty" name="qty" placeholder="Qty" style="max-width:120px">
+          <input id="item-unit" name="unit" placeholder="Unit" style="max-width:160px">
+          <input id="item-price" name="price" placeholder="Price" style="max-width:160px">
+        </div>
+        <textarea id="item-notes" name="notes" placeholder="Notes" rows="2" style="width:100%;margin-top:8px"></textarea>
+        <div class="row" style="margin-top:8px">
+          <button type="submit" id="item-submit">Add Item</button>
+          <button type="button" id="item-cancel" style="display:none">Cancel</button>
+        </div>
+      </form>
+      <div class="row" style="margin-top:12px;align-items:center">
+        <label class="muted">Filter by vendor:
+          <select id="item-filter" style="margin-left:8px;min-width:200px"></select>
+        </label>
+      </div>
+      <div id="item-table" class="muted" style="margin-top:12px"></div>
+    </section>
+  `;
+
+  vendorForm=root.querySelector('#vendor-form');
+  vendorSubmitBtn=root.querySelector('#vendor-submit');
+  vendorCancelBtn=root.querySelector('#vendor-cancel');
+  vendorNameInput=root.querySelector('#vendor-name');
+  vendorContactInput=root.querySelector('#vendor-contact');
+  vendorNotesInput=root.querySelector('#vendor-notes');
+  vendorTableEl=root.querySelector('#vendor-table');
+
+  vendorForm.addEventListener('submit',async (ev)=>{
+    ev.preventDefault();
+    const body={
+      name:vendorNameInput.value.trim(),
+      contact:vendorContactInput.value.trim()||null,
+      notes:vendorNotesInput.value.trim()||null,
+    };
+    try{
+      if(!body.name){
+        alert('Name required');
+        return;
+      }
+      if(vendorEditId){
+        await jsonRequest(`/app/vendors/${vendorEditId}`,{method:'PUT',body:JSON.stringify(body)});
+      }else{
+        await jsonRequest('/app/vendors',{method:'POST',body:JSON.stringify(body)});
+      }
+      clearVendorForm();
+      await loadVendors();
+      await loadItems();
+    }catch(err){
+      alert('Save failed: '+err.message);
+    }
+  });
+
+  vendorCancelBtn.addEventListener('click',()=>clearVendorForm());
+
+  itemForm=root.querySelector('#item-form');
+  itemSubmitBtn=root.querySelector('#item-submit');
+  itemCancelBtn=root.querySelector('#item-cancel');
+  itemVendorSelect=root.querySelector('#item-vendor');
+  itemSkuInput=root.querySelector('#item-sku');
+  itemNameInput=root.querySelector('#item-name');
+  itemQtyInput=root.querySelector('#item-qty');
+  itemUnitInput=root.querySelector('#item-unit');
+  itemPriceInput=root.querySelector('#item-price');
+  itemNotesInput=root.querySelector('#item-notes');
+  itemTableEl=root.querySelector('#item-table');
+  itemFilterSelect=root.querySelector('#item-filter');
+
+  itemForm.addEventListener('submit',async(ev)=>{
+    ev.preventDefault();
+    const body={
+      vendor_id:normalizeInt(itemVendorSelect.value),
+      sku:itemSkuInput.value.trim()||null,
+      name:itemNameInput.value.trim(),
+      qty:normalizeFloat(itemQtyInput.value),
+      unit:itemUnitInput.value.trim()||null,
+      price:normalizeFloat(itemPriceInput.value),
+      notes:itemNotesInput.value.trim()||null,
+    };
+    try{
+      if(!body.name){
+        alert('Name required');
+        return;
+      }
+      if(itemEditId){
+        await jsonRequest(`/app/items/${itemEditId}`,{method:'PUT',body:JSON.stringify(body)});
+      }else{
+        await jsonRequest('/app/items',{method:'POST',body:JSON.stringify(body)});
+      }
+      clearItemForm();
+      await loadItems();
+      await loadVendors();
+    }catch(err){
+      alert('Save failed: '+err.message);
+    }
+  });
+
+  itemCancelBtn.addEventListener('click',()=>clearItemForm());
+  itemFilterSelect.addEventListener('change',()=>loadItems());
+
+  await loadVendors();
+  await loadItems();
+}

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -31,7 +31,13 @@
       <a href="#/dev"       id="nav-dev">Dev</a>
     </div>
   </aside>
-  <main><div id="view"></div></main>
+  <main>
+    <div id="view"></div>
+    <details id="domain-card" class="card" style="margin-top:16px">
+      <summary>Domain Data</summary>
+      <div id="domain-forms" style="margin-top:12px"></div>
+    </details>
+  </main>
 </div>
 
 <script type="module" src="/ui/js/token.js"></script>
@@ -39,8 +45,10 @@
   import { mountWrites }    from "/ui/js/cards/writes.js";
   import { mountOrganizer } from "/ui/js/cards/organizer.js";
   import { mountDev }       from "/ui/js/cards/dev.js";
+  import { mountDomainCard } from "/ui/js/cards/domain.js";
 
   const routes = { "/writes": mountWrites, "/organizer": mountOrganizer, "/dev": mountDev };
+  const domainRoot = document.getElementById('domain-forms');
 
   function setActive(hash){
     document.querySelectorAll('.nav a').forEach(a=>a.classList.remove('active'));
@@ -60,7 +68,10 @@
   }
 
   window.addEventListener('hashchange', render);
-  document.addEventListener('bus:token-ready', render);
+  document.addEventListener('bus:token-ready', async ()=>{
+    await render();
+    if(domainRoot){ await mountDomainCard(domainRoot); }
+  });
 
   (async ()=>{
     try{

--- a/requirements.txt
+++ b/requirements.txt
@@ -14,5 +14,6 @@ cryptography>=42.0.0
 fastapi
 uvicorn[standard]
 pydantic
+sqlalchemy
 Send2Trash==1.8.2
 pywin32>=306; platform_system == "Windows"


### PR DESCRIPTION
## Summary
- add SQLAlchemy models and session helpers for the local domain database
- implement a FastAPI router providing vendor, item, task, and attachment CRUD endpoints
- expose the new domain data UI card with vendor and item forms and update requirements for SQLAlchemy

## Testing
- python - <<'PY'
from fastapi.testclient import TestClient
from core.api.http import build_app

app, token = build_app()
client = TestClient(app)
headers = {"X-Session-Token": token}

vend = client.post("/app/vendors", json={"name": "Acme", "contact": "a@b.com"}, headers=headers).json()
item = client.post(
    "/app/items",
    json={"vendor_id": vend["id"], "name": "Widget", "qty": 5},
    headers=headers,
).json()
listing = client.get("/app/vendors", headers=headers).json()
print({"vend": vend, "item": item, "vendors": listing})
PY *(fails: ModuleNotFoundError: No module named 'sqlalchemy'; SQLAlchemy could not be installed in the sandbox)*

------
https://chatgpt.com/codex/tasks/task_e_68fd04acd71083229f810e86ae4eeca8