### PR TITLE
Fix token bootstrapping and API retry logic

### DIFF
--- a/core/ui/js/api.js
+++ b/core/ui/js/api.js
@@ -1,2 +1,88 @@
-export async function get(url){ const r=await fetch(url,{cache:'no-store'}); if(!r.ok) throw new Error(await r.text()); return r.json(); }
-export async function post(url,body){ const r=await fetch(url,{method:'POST',headers:{'Content-Type':'application/json'},body:JSON.stringify(body||{})}); if(!r.ok) throw new Error(await r.text()); return r.json(); }
+import { getToken } from '/ui/js/token.js';
+
+const TOKEN_KEY = 'tgc_token';
+const MAX_ATTEMPTS = 2;
+
+function normalizeMethod(method = 'GET') {
+  return method.toUpperCase();
+}
+
+function normalizeBody(method, body) {
+  if (method === 'GET' || body == null || body instanceof FormData || body instanceof Blob) {
+    return body;
+  }
+  if (typeof body === 'string') {
+    return body;
+  }
+  return JSON.stringify(body);
+}
+
+async function ensureToken(forceRefresh = false) {
+  const token = await getToken(forceRefresh);
+  if (!token) {
+    throw new Error('No token');
+  }
+  return token;
+}
+
+export async function apiCall(path, opts = {}) {
+  const init = { ...opts };
+  init.method = normalizeMethod(init.method);
+  for (let attempt = 0; attempt < MAX_ATTEMPTS; attempt += 1) {
+    let token = '';
+    try {
+      token = localStorage.getItem(TOKEN_KEY) || '';
+    } catch (err) {
+      console.warn('[api] Unable to access localStorage', err);
+    }
+
+    if (!token) {
+      console.warn('[api] Missing token, requesting…');
+      token = await ensureToken(attempt > 0);
+    }
+
+    const headers = new Headers(init.headers || {});
+    headers.set('X-Session-Token', token);
+    if (init.method !== 'GET' && !headers.has('Content-Type')) {
+      headers.set('Content-Type', 'application/json');
+    }
+
+    const request = {
+      ...init,
+      headers,
+    };
+
+    if (init.method !== 'GET') {
+      request.body = normalizeBody(init.method, init.body);
+    }
+
+    console.log('[api] Fetch', init.method, path);
+    const response = await fetch(path, request);
+    console.log('[api] Response', response.status, path);
+
+    if (response.status === 401 && attempt === 0) {
+      console.warn('[api] 401 received, refreshing token');
+      try {
+        localStorage.removeItem(TOKEN_KEY);
+      } catch (err) {
+        console.warn('[api] Failed clearing token', err);
+      }
+      await ensureToken(true);
+      continue;
+    }
+
+    if (!response.ok) {
+      const message = await response.text();
+      throw new Error(message || `HTTP ${response.status}`);
+    }
+
+    return init.method === 'GET' ? response.json() : response;
+  }
+
+  localStorage.removeItem(TOKEN_KEY);
+  throw new Error('Token expired—reload');
+}
+
+export const get = (path, options = {}) => apiCall(path, { ...options, method: 'GET' });
+export const post = (path, body, options = {}) => apiCall(path, { ...options, method: 'POST', body });
+export const del = (path, options = {}) => apiCall(path, { ...options, method: 'DELETE' });

--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -1,13 +1,91 @@
-const COOKIE='X-Session-Token', STORE='BUS_SESSION_TOKEN';
-function setCookie(k,v){ document.cookie=k+'='+encodeURIComponent(v)+'; SameSite=Lax; Path=/'; }
-function getCookie(k){ const m=document.cookie.match(new RegExp('(?:^|; )'+k.replace(/([.$?*|{}()[\\]\\/+^])/g,'\\$1')+'=([^;]*)')); return m?decodeURIComponent(m[1]):''; }
-function setToken(t){ if(!t) return; window.BUS_SESSION_TOKEN=t; try{localStorage.setItem(STORE,t);}catch{} setCookie(COOKIE,t); }
-function getToken(){ return window.BUS_SESSION_TOKEN || (typeof localStorage!=='undefined'&&localStorage.getItem(STORE)) || getCookie(COOKIE) || ''; }
-async function fetchTokenOnce(ms=1500){ const ctl=new AbortController(); const to=setTimeout(()=>ctl.abort(),ms);
-  try{ const r=await fetch('/session/token',{cache:'no-store',signal:ctl.signal}); if(r.ok){ const j=await r.json(); if(j?.token) return j.token; } }catch{} finally{ clearTimeout(to); }
-  return ''; }
-async function ensure(){ let t=getToken(); if(!t) t=await fetchTokenOnce(); if(t) setToken(t);
-  document.dispatchEvent(new CustomEvent('bus:token-ready',{detail:{token:getToken()}})); return getToken(); }
-if(!window.__fetchPatched){ const _f=window.fetch; window.fetch=async(i,n)=>{ n=n||{}; const h=new Headers(n.headers||{}); const t=getToken(); if(t&&typeof i==='string'&&i.startsWith('/')) h.set('X-Session-Token',t); n.headers=h; return _f(i,n); }; window.__fetchPatched=true; }
-ensure();
-export const Token={get:getToken,ensure};
+const TOKEN_KEY = 'tgc_token';
+const EVENT_NAME = 'bus:token-ready';
+let pendingToken = null;
+
+function readStoredToken() {
+  try {
+    return localStorage.getItem(TOKEN_KEY) || '';
+  } catch (err) {
+    console.warn('[token] Unable to access localStorage', err);
+    return '';
+  }
+}
+
+function storeToken(token) {
+  try {
+    if (token) {
+      localStorage.setItem(TOKEN_KEY, token);
+    } else {
+      localStorage.removeItem(TOKEN_KEY);
+    }
+  } catch (err) {
+    console.warn('[token] Failed to store token', err);
+  }
+}
+
+function dispatchToken(token) {
+  const payload = token || '';
+  console.log('[token] Token ready event', payload ? payload.slice(0, 8) + '…' : '(empty)');
+  document.dispatchEvent(new CustomEvent(EVENT_NAME, { detail: payload }));
+  return payload;
+}
+
+async function requestToken() {
+  try {
+    console.log('[token] Fetching session token…');
+    const response = await fetch('/session/token', { cache: 'no-store' });
+    if (response.status === 401) {
+      console.warn('[token] Token request returned 401');
+      storeToken('');
+      return '';
+    }
+    if (response.ok) {
+      const token = (await response.text()).trim();
+      if (token) {
+        storeToken(token);
+        return token;
+      }
+    }
+    console.warn('[token] Unexpected response while fetching token', response.status);
+  } catch (error) {
+    console.error('Token fail:', error);
+  }
+  return '';
+}
+
+export async function getToken(forceRefresh = false) {
+  if (forceRefresh) {
+    storeToken('');
+  }
+
+  const cached = forceRefresh ? '' : readStoredToken();
+  if (cached) {
+    return dispatchToken(cached);
+  }
+
+  if (!pendingToken) {
+    pendingToken = (async () => {
+      const token = await requestToken();
+      pendingToken = null;
+      return dispatchToken(token);
+    })();
+  }
+
+  return pendingToken;
+}
+
+export const Token = { get: getToken };
+
+function init() {
+  const cached = readStoredToken();
+  if (cached) {
+    dispatchToken(cached);
+  }
+  if (document.readyState === 'complete') {
+    getToken();
+  } else {
+    window.addEventListener('load', () => getToken());
+  }
+}
+
+init();

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -41,6 +41,20 @@
 </div>
 
 <script type="module" src="/ui/js/token.js"></script>
+<script type="module" src="/ui/js/api.js"></script>
+<script>
+  document.addEventListener('DOMContentLoaded', () => {
+    try {
+      const cachedToken = localStorage.getItem('tgc_token');
+      if (cachedToken) {
+        console.log('[shell] Dispatching cached token');
+        document.dispatchEvent(new CustomEvent('bus:token-ready', { detail: cachedToken }));
+      }
+    } catch (err) {
+      console.warn('[shell] Unable to access localStorage', err);
+    }
+  });
+</script>
 <script type="module">
   import { mountWrites }    from "/ui/js/cards/writes.js";
   import { mountOrganizer } from "/ui/js/cards/organizer.js";


### PR DESCRIPTION
## Summary
- ensure the UI token helper always dispatches bus:token-ready and caches tokens safely
- harden the API wrapper with automatic 401 retries and consistent logging
- bootstrap cached tokens on shell load so feature cards render immediately

## Testing
- not run (UI-only change)


------
https://chatgpt.com/codex/tasks/task_e_68fd0a8cf4208322ad2610b73c51e4a5