### PR TITLE
Fix FixKit token bootstrap and navigation flow

### DIFF
--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -32,24 +32,60 @@
 </div>
 <script type="module" src="/ui/js/token.js"></script>
 <script type="module">
-  import { mountWrites }    from "/ui/js/cards/writes.js";
-  import { mountOrganizer } from "/ui/js/cards/organizer.js";
-  import { mountDev }       from "/ui/js/cards/dev.js";
-  const routes = { "/writes": mountWrites, "/organizer": mountOrganizer, "/dev": mountDev };
-  function setActive(hash){ document.querySelectorAll('.nav a').forEach(a=>a.classList.remove('active'));
-    const el=document.getElementById('nav-'+(hash.replace('#/','')||'writes')); if(el) el.classList.add('active'); }
-  async function render(){
-    const view=document.getElementById('view'); const hash=location.hash||'#/writes';
-    const mount = routes[hash.replace('#','')] || routes['/writes']; view.innerHTML='';
-    const card=document.createElement('div'); card.className='card'; view.appendChild(card); await mount(card);
-    setActive(hash);
+  import '/ui/js/token.js';
+  import { apiGet } from '/ui/js/api.js';
+  import { mountWrites }    from '/ui/js/cards/writes.js';
+  import { mountOrganizer } from '/ui/js/cards/organizer.js';
+  import { mountDev }       from '/ui/js/cards/dev.js';
+
+  const routes = {
+    '/writes':    mountWrites,
+    '/organizer': mountOrganizer,
+    '/dev':       mountDev,
+  };
+
+  function currentRoute() {
+    const h = location.hash || '#/writes';
+    const key = h.startsWith('#') ? h.slice(1) : h;
+    return routes[key] ? key : '/writes';
   }
-  document.addEventListener('DOMContentLoaded', render);
-  document.addEventListener('bus:token-ready', render);
-  document.addEventListener('bus:token-ready', (e)=>{
-    const tok = e?.detail?.token||''; const pfx = tok ? tok.slice(0,6)+'…' : '—';
-    const lic = document.getElementById('license'); if (lic) lic.textContent = (lic.textContent||'Local-only') + ` · token ${pfx}`;
+
+  function setActive(hash) {
+    document.querySelectorAll('.nav a').forEach(a=>a.classList.remove('active'));
+    const id = 'nav-' + (hash.replace('#/','') || 'writes');
+    const el = document.getElementById(id);
+    if (el) el.classList.add('active');
+  }
+
+  async function render() {
+    const view = document.getElementById('view');
+    if (!view) return;
+    const key = currentRoute();
+    const mount = routes[key] || routes['/writes'];
+    view.innerHTML = '';
+    const card = document.createElement('div');
+    card.className = 'card';
+    view.appendChild(card);
+    await mount(card);
+    setActive('#' + key);
+  }
+
+  // Re-render on navigation and when token becomes available
+  window.addEventListener('hashchange', render);
+  window.addEventListener('bus:token-ready', async (e) => {
+    // avoid 401: call /health only after token ready
+    try {
+      const j = await apiGet('/health');
+      const tok = e?.detail?.token || '';
+      const lic = document.getElementById('license');
+      if (lic) {
+        const pfx = tok ? tok.slice(0,6) + '…' : '—';
+        lic.textContent = `Local-only · Core: ${j?.licenses?.core?.name || '—'} · v ${j?.version || '—'} · token ${pfx}`;
+      }
+    } catch {}
+    render();
   });
-  (async()=>{ try{ const r=await fetch('/health'); const j=await r.json();
-    const lic=document.getElementById('license'); if(lic) lic.textContent=`Local-only · Core: ${j?.licenses?.core?.name||'—'} · v ${j?.version||'—'}`;}catch{} })();
+
+  // Initial paint (if token already cached)
+  document.addEventListener('DOMContentLoaded', render);
 </script>

--- a/core/ui/js/api.js
+++ b/core/ui/js/api.js
@@ -1,88 +1,33 @@
-let tokenRetryCount=0;
+/* Minimal API helpers; fetch is already patched by token.js */
 
-export async function apiCall(path,options={method:'GET'}){
-  const method=(options.method||'GET').toUpperCase();
-  const stored=localStorage.getItem('tgc_token');
-  if(!stored) throw new Error('No token—reload page');
-  let token=stored;
-  if(typeof token==='string'){
-    try{
-      const parsed=JSON.parse(stored);
-      if(parsed && typeof parsed.token==='string'){
-        token=parsed.token;
-      }
-    }catch{}
-  }else{
-    try{
-      const parsed=JSON.parse(String(stored));
-      if(parsed && typeof parsed.token==='string'){
-        token=parsed.token;
-      }
-    }catch{}
-  }
-  if(typeof token!=='string' || !token) throw new Error('Invalid token');
-  const headers=new Headers({...(options.headers||{}),'X-Session-Token':token});
-  if(method!=='GET') headers.set('Content-Type','application/json');
-  let response;
-  try{
-    response=await fetch(path,{...options,method,headers});
-  }catch(error){
-    throw new Error(`Fetch error: ${error.message}`);
-  }
-  if(response.status===401){
-    if(tokenRetryCount<1){
-      tokenRetryCount+=1;
-      localStorage.removeItem('tgc_token');
-      if(typeof getToken==='function'){
-        await getToken();
-      }else if(typeof window!=='undefined' && typeof window.getToken==='function'){
-        await window.getToken();
-      }else if(typeof globalThis!=='undefined' && typeof globalThis.getToken==='function'){
-        await globalThis.getToken();
-      }
-      throw new Error('Token refreshed—retry call');
-    }
-    tokenRetryCount=0;
-    throw new Error('Auth failed');
-  }
-  tokenRetryCount=0;
-  if(!response.ok){
-    const errText=await response.text();
-    throw new Error(`API ${response.status}: ${errText}`);
-  }
-  const contentType=response.headers.get('content-type')||'';
-  if(contentType.includes('application/json')){
-    try{
-      return await response.json();
-    }catch{
-      return null;
-    }
-  }
-  const raw=await response.text();
-  if(!raw){
-    return method==='GET'?null:{success:true};
-  }
-  try{
-    return JSON.parse(raw);
-  }catch{
-    return method==='GET'?raw:{message:raw};
-  }
+export async function apiGet(url) {
+  const r = await fetch(url, { cache: 'no-store' });
+  if (!r.ok) throw new Error(`${url} ${r.status}`);
+  return r.json();
 }
 
-async function get(path){
-  return apiCall(path);
+export async function apiPost(url, body) {
+  const r = await fetch(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' }, // X-Session-Token added by fetch patch
+    body: JSON.stringify(body || {})
+  });
+  if (!r.ok) throw new Error(`${url} ${r.status}`);
+  return r.json();
 }
 
-async function post(path,body){
-  return apiCall(path,{method:'POST',body:JSON.stringify(body)});
+export async function apiPut(url, body) {
+  const r = await fetch(url, {
+    method: 'PUT',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(body || {})
+  });
+  if (!r.ok) throw new Error(`${url} ${r.status}`);
+  return r.json();
 }
 
-async function put(path,body){
-  return apiCall(path,{method:'PUT',body:JSON.stringify(body)});
+export async function apiDel(url) {
+  const r = await fetch(url, { method: 'DELETE' });
+  if (!r.ok) throw new Error(`${url} ${r.status}`);
+  return r.json();
 }
-
-async function del(path){
-  return apiCall(path,{method:'DELETE'});
-}
-
-export {get,post,put,del};


### PR DESCRIPTION
## Summary
- normalize the FixKit session token bootstrap and patch fetch to inject X-Session-Token
- simplify API helpers to rely on the global fetch patch
- rework UI routing to re-render on hash change and defer the health check until the token is ready

## Testing
- Not run (UI-only changes)


------
https://chatgpt.com/codex/tasks/task_e_68fd1a68690c8322a649b04f52cd8b8b