### PR TITLE
Add default export for API helpers

### DIFF
--- a/core/ui/js/api.js
+++ b/core/ui/js/api.js
@@ -1,22 +1,22 @@
 /* Minimal API helpers; fetch is already patched by token.js */
 
-export async function apiGet(url) {
+async function apiGet(url) {
   const r = await fetch(url, { cache: 'no-store' });
   if (!r.ok) throw new Error(`${url} ${r.status}`);
   return r.json();
 }
 
-export async function apiPost(url, body) {
+async function apiPost(url, body) {
   const r = await fetch(url, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' }, // X-Session-Token added by fetch patch
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body || {})
   });
   if (!r.ok) throw new Error(`${url} ${r.status}`);
   return r.json();
 }
 
-export async function apiPut(url, body) {
+async function apiPut(url, body) {
   const r = await fetch(url, {
     method: 'PUT',
     headers: { 'Content-Type': 'application/json' },
@@ -26,8 +26,12 @@ export async function apiPut(url, body) {
   return r.json();
 }
 
-export async function apiDel(url) {
+async function apiDel(url) {
   const r = await fetch(url, { method: 'DELETE' });
   if (!r.ok) throw new Error(`${url} ${r.status}`);
   return r.json();
 }
+
+// Named + default (for backwards compatibility)
+export { apiGet, apiPost, apiPut, apiDel };
+export default { apiGet, apiPost, apiPut, apiDel };


### PR DESCRIPTION
## Summary
- add named and default exports for the shared API helper functions to maintain compatibility

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68fd1c39c0d08322999cb39e223917c0