### PR TITLE
Fix UI boot order and gate cards on token ready

### DIFF
--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -18,36 +18,24 @@
   button{background:#1f1f25;border:1px solid #2a2a32;border-radius:8px;color:#fff;padding:8px 12px;cursor:pointer}
   input{background:#101015;border:1px solid #26262e;border-radius:8px;color:#fff;padding:8px;width:100%}
 </style>
-<!-- BEGIN ui-scripts -->
-<link rel="preload" href="/ui/js/token.js?v={{version}}" as="script">
-<link rel="preload" href="/ui/js/api.js?v={{version}}" as="script">
-<script src="/ui/js/token.js?v={{version}}" defer></script>
-<script src="/ui/js/api.js?v={{version}}" defer></script>
+<!-- BEGIN ui boot -->
 <script>
-  // Route bootstrap waits for token
-  window.addEventListener('bus:token-ready', function(){
-    if (!location.hash) location.hash = '#/writes';
-    window.dispatchEvent(new HashChangeEvent('hashchange'));
-  });
-</script>
-<!-- END ui-scripts -->
-<div class="wrap">
-  <aside>
-    <h1>BUS Core</h1>
-    <div class="muted" id="license">Local-only. Token loading…</div>
-    <div class="nav">
-      <a id="nav-writes"    href="#/writes">Writes</a>
-      <a id="nav-organizer" href="#/organizer">Organizer</a>
-      <a id="nav-dev"       href="#/dev">Dev</a>
-    </div>
-  </aside>
-  <main><div id="view"></div></main>
-</div>
-<script src="/ui/js/cards/writes.js?v={{version}}" defer></script>
-<script src="/ui/js/cards/organizer.js?v={{version}}" defer></script>
-<script src="/ui/js/cards/dev.js?v={{version}}" defer></script>
-<script>
+  // Load scripts in order with a runtime cache-bust value
   (function(){
+    const v = Date.now();
+    function add(src){
+      const s = document.createElement('script');
+      s.defer = true;
+      s.src = src + '?v=' + v;
+      document.head.appendChild(s);
+    }
+    // token first, then api, then cards
+    add('/ui/js/token.js');
+    add('/ui/js/api.js');
+    add('/ui/js/cards/writes.js');
+    add('/ui/js/cards/organizer.js');
+    add('/ui/js/cards/dev.js');
+
     const TOKEN_KEY = 'BUS_SESSION_TOKEN';
     window.busCards = window.busCards || {};
 
@@ -108,15 +96,24 @@
     }
 
     window.addEventListener('hashchange', render);
-    window.addEventListener('bus:token-ready', () => {
-      updateLicense().finally(() => {
-        render();
-        setTimeout(render, 0);
+    window.addEventListener('bus:token-ready', function(){
+      updateLicense().finally(function(){
+        if (!location.hash) location.hash = '#/writes';
+        window.dispatchEvent(new HashChangeEvent('hashchange'));
       });
-    });
-
-    document.addEventListener('DOMContentLoaded', () => {
-      updateLicense().finally(render);
     });
   })();
 </script>
+<!-- END ui boot -->
+<div class="wrap">
+  <aside>
+    <h1>BUS Core</h1>
+    <div class="muted" id="license">Local-only. Token loading…</div>
+    <div class="nav">
+      <a id="nav-writes"    href="#/writes">Writes</a>
+      <a id="nav-organizer" href="#/organizer">Organizer</a>
+      <a id="nav-dev"       href="#/dev">Dev</a>
+    </div>
+  </aside>
+  <main><div id="view"></div></main>
+</div>

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -1,4 +1,4 @@
-// Ensure we wait for token
+// Gate card init on token readiness
 (function(){
   function init(){
     const busApi = window.busApi || {};

--- a/core/ui/js/cards/organizer.js
+++ b/core/ui/js/cards/organizer.js
@@ -1,4 +1,4 @@
-// Ensure we wait for token
+// Gate card init on token readiness
 (function(){
   function init(){
     const busApi = window.busApi || {};

--- a/core/ui/js/cards/writes.js
+++ b/core/ui/js/cards/writes.js
@@ -1,4 +1,4 @@
-// Ensure we wait for token
+// Gate card init on token readiness
 (function(){
   function init(){
     const busApi = window.busApi || {};


### PR DESCRIPTION
## Summary
- load UI scripts with a runtime cache-busting boot block and defer route rendering until the token is ready
- trigger navigation rendering and license health fetch only after authentication while keeping default hash routing
- align card modules with the shared token-ready gate wrapper

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd22962750832285492c4277cabfd2