### PR TITLE
Disable automated CI workflows

### DIFF
--- a/.github/workflows/build-test.yml
+++ b/.github/workflows/build-test.yml
@@ -1,0 +1,11 @@
+# .github/workflows/build-test.yml
+name: build-test
+on:
+  workflow_dispatch: {}   # manual only
+permissions: {}
+jobs:
+  build-test:
+    if: ${{ false }}      # never runs
+    runs-on: ubuntu-latest
+    steps:
+      - run: echo "Workflow disabled"

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,13 +1,11 @@
 name: CI
 
 on:
-  push:
-    branches: [ "**" ]
-  pull_request:
-    branches: [ "**" ]
+  workflow_dispatch: {}
 
 jobs:
   build-test:
+    if: ${{ false }}
     runs-on: ubuntu-latest
     timeout-minutes: 15
     steps:


### PR DESCRIPTION
## Summary
- add a build-test workflow placeholder that is manual-only and never runs
- convert the CI workflow to manual dispatch and prevent the job from executing

## Testing
- not run (CI disabled)


------
https://chatgpt.com/codex/tasks/task_e_68fd2804529c83228e2b214e20d17199