### PR TITLE
Revamp UI shell with licensing-aware cards

### DIFF
--- a/core/ui/UI_NOTES.md
+++ b/core/ui/UI_NOTES.md
@@ -1,0 +1,24 @@
+# BUS Core UI Notes
+
+## Layout IDs
+
+- `#license-badge` — Updated by `API.loadLicense()` and displays the active license tier.
+- `#writes-toggle` — Header checkbox controlling `data-writes-enabled` on `<body>`.
+- `#app-version` — Populated from `window.APP_VERSION` (fallback `v0.6`).
+- `#main` — Primary card container swapped by `Cards.render()`.
+- `#modal-root` — Overlay target used by `ui/modals.js`.
+
+## Script responsibilities
+
+- `ui/js/api.js` — REST wrapper providing caching for `/dev/license`, standard headers, and write/feature gating.
+- `ui/js/app.js` — Bootstraps tabs, writes toggle, license badge, and card registry.
+- `ui/js/ui/dom.js` — DOM utilities (`el`, `$`) plus `bindDisabledWithProGate()` helper.
+- `ui/js/ui/modals.js` — Shared alert/confirm modals rendered into `#modal-root`.
+- `ui/js/cards/*.js` — Individual card renderers responsible for their section of the dashboard.
+
+## Adding a gated control
+
+1. Create the button/input normally inside your card render function.
+2. Call `bindDisabledWithProGate(element, '<feature_key>')` after the element is created.
+3. Use `API.post`/`API.request` for the action so 403 responses surface through the shared modal.
+4. If the control requires additional enablement beyond licensing (e.g., preview before commit), set a custom `data-` flag and re-disable the element when the flag is not satisfied.

--- a/core/ui/css/app.css
+++ b/core/ui/css/app.css
@@ -1,0 +1,426 @@
+:root {
+  color-scheme: light dark;
+  --bg: #f5f7fb;
+  --bg-dark: #17191f;
+  --surface: #ffffff;
+  --surface-dark: #20232b;
+  --border: rgba(15, 23, 42, 0.12);
+  --border-dark: rgba(255, 255, 255, 0.15);
+  --text: #1f2933;
+  --text-muted: #5f6c80;
+  --text-dark: #e4e7ed;
+  --accent: #2563eb;
+  --accent-dark: #60a5fa;
+  --danger: #dc2626;
+  --badge-bg: rgba(37, 99, 235, 0.12);
+  --badge-text: #2563eb;
+  font-family: "Segoe UI", system-ui, -apple-system, BlinkMacSystemFont, "Helvetica Neue", sans-serif;
+}
+
+* {
+  box-sizing: border-box;
+}
+
+body {
+  margin: 0;
+  background: var(--bg);
+  color: var(--text);
+}
+
+body.modal-open {
+  overflow: hidden;
+}
+
+.app-shell {
+  min-height: 100vh;
+  display: flex;
+}
+
+.sidebar {
+  width: 220px;
+  padding: 24px 16px;
+  background: linear-gradient(180deg, #111827 0%, #1f2937 100%);
+  color: #e5e7eb;
+  display: flex;
+  flex-direction: column;
+  gap: 24px;
+}
+
+.sidebar-brand {
+  font-size: 1.2rem;
+  font-weight: 700;
+  letter-spacing: 0.04em;
+}
+
+.sidebar-nav {
+  display: grid;
+  gap: 8px;
+}
+
+.sidebar-tab {
+  border: none;
+  border-radius: 8px;
+  padding: 10px 12px;
+  text-align: left;
+  font-size: 0.95rem;
+  background: rgba(255, 255, 255, 0.08);
+  color: inherit;
+  cursor: pointer;
+  transition: background 0.2s, transform 0.2s;
+}
+
+.sidebar-tab:hover,
+.sidebar-tab:focus-visible {
+  background: rgba(255, 255, 255, 0.18);
+}
+
+.sidebar-tab.active {
+  background: #ffffff;
+  color: #111827;
+  transform: translateX(4px);
+}
+
+.workspace {
+  flex: 1;
+  display: flex;
+  flex-direction: column;
+  min-height: 100vh;
+}
+
+.app-header {
+  padding: 16px 24px;
+  border-bottom: 1px solid var(--border);
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  background: var(--surface);
+}
+
+.header-left {
+  display: flex;
+  align-items: center;
+  gap: 12px;
+}
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  color: var(--text-muted);
+}
+
+.writes-toggle {
+  display: inline-flex;
+  align-items: center;
+  gap: 10px;
+  padding: 4px 12px 4px 4px;
+  border-radius: 999px;
+  background: rgba(37, 99, 235, 0.1);
+  cursor: pointer;
+}
+
+.writes-toggle input {
+  display: none;
+}
+
+.toggle-indicator {
+  width: 38px;
+  height: 20px;
+  border-radius: 999px;
+  background: rgba(15, 23, 42, 0.2);
+  position: relative;
+  transition: background 0.2s;
+}
+
+.toggle-indicator::after {
+  content: "";
+  position: absolute;
+  top: 2px;
+  left: 2px;
+  width: 16px;
+  height: 16px;
+  border-radius: 50%;
+  background: #ffffff;
+  transition: transform 0.2s;
+}
+
+.writes-toggle input:checked + .toggle-indicator {
+  background: var(--accent);
+}
+
+.writes-toggle input:checked + .toggle-indicator::after {
+  transform: translateX(18px);
+}
+
+.toggle-label {
+  font-weight: 600;
+}
+
+.license-badge {
+  display: inline-flex;
+  align-items: center;
+  padding: 4px 10px;
+  border-radius: 999px;
+  font-weight: 600;
+  font-size: 0.85rem;
+  background: var(--badge-bg);
+  color: var(--badge-text);
+  text-transform: uppercase;
+}
+
+.app-version {
+  font-weight: 600;
+}
+
+.main {
+  flex: 1;
+  padding: 24px;
+  display: flex;
+  flex-direction: column;
+  gap: 20px;
+}
+
+.card {
+  background: var(--surface);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 20px;
+  box-shadow: 0 12px 24px rgba(15, 23, 42, 0.08);
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.card h2 {
+  margin: 0;
+  font-size: 1.3rem;
+}
+
+.section-title {
+  font-size: 1rem;
+  font-weight: 700;
+  margin: 0 0 8px 0;
+}
+
+.table-wrapper {
+  overflow: auto;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+}
+
+table {
+  width: 100%;
+  border-collapse: collapse;
+  font-size: 0.9rem;
+}
+
+thead {
+  background: rgba(37, 99, 235, 0.08);
+}
+
+td,
+th {
+  padding: 10px 12px;
+  border-bottom: 1px solid var(--border);
+  text-align: left;
+}
+
+.actions {
+  display: flex;
+  gap: 8px;
+}
+
+button {
+  border: none;
+  border-radius: 8px;
+  padding: 8px 14px;
+  font-weight: 600;
+  cursor: pointer;
+  background: var(--accent);
+  color: #ffffff;
+  transition: opacity 0.2s, transform 0.2s;
+}
+
+button:hover:not(:disabled),
+button:focus-visible:not(:disabled) {
+  opacity: 0.9;
+  transform: translateY(-1px);
+}
+
+button.secondary {
+  background: rgba(15, 23, 42, 0.08);
+  color: inherit;
+}
+
+button.danger {
+  background: var(--danger);
+}
+
+button:disabled {
+  opacity: 0.55;
+  cursor: not-allowed;
+  transform: none;
+}
+
+form {
+  display: grid;
+  gap: 12px;
+}
+
+.form-grid {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(180px, 1fr));
+  gap: 12px;
+}
+
+label {
+  font-size: 0.85rem;
+  font-weight: 600;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+input,
+select,
+textarea {
+  border-radius: 8px;
+  border: 1px solid var(--border);
+  padding: 8px 10px;
+  font-size: 0.95rem;
+  font-family: inherit;
+  background: rgba(255, 255, 255, 0.9);
+}
+
+textarea {
+  min-height: 120px;
+  resize: vertical;
+}
+
+.status-box {
+  padding: 12px;
+  border-radius: 12px;
+  border: 1px solid var(--border);
+  background: rgba(15, 23, 42, 0.04);
+  white-space: pre-wrap;
+  font-family: "Fira Code", "Consolas", monospace;
+  font-size: 0.85rem;
+}
+
+.badge-note {
+  font-size: 0.75rem;
+  color: var(--text-muted);
+}
+
+.pro-badge {
+  display: inline-flex;
+  align-items: center;
+  margin-left: 8px;
+  padding: 2px 8px;
+  border-radius: 999px;
+  background: rgba(180, 83, 9, 0.15);
+  color: #b45309;
+  font-size: 0.7rem;
+  font-weight: 700;
+  text-transform: uppercase;
+}
+
+.modal-overlay {
+  position: fixed;
+  inset: 0;
+  background: rgba(15, 23, 42, 0.55);
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  z-index: 1000;
+  padding: 24px;
+}
+
+.modal {
+  background: var(--surface);
+  border-radius: 16px;
+  border: 1px solid var(--border);
+  padding: 24px;
+  max-width: 420px;
+  width: 100%;
+  display: grid;
+  gap: 16px;
+}
+
+.modal h3 {
+  margin: 0;
+  font-size: 1.2rem;
+}
+
+.modal-actions {
+  display: flex;
+  justify-content: flex-end;
+  gap: 12px;
+}
+
+@media (max-width: 960px) {
+  .app-shell {
+    flex-direction: column;
+  }
+  .sidebar {
+    width: 100%;
+    flex-direction: row;
+    align-items: center;
+    justify-content: space-between;
+  }
+  .sidebar-nav {
+    grid-template-columns: repeat(auto-fit, minmax(120px, 1fr));
+    width: 100%;
+  }
+  .workspace {
+    min-height: auto;
+  }
+}
+
+@media (prefers-color-scheme: dark) {
+  body {
+    background: var(--bg-dark);
+    color: var(--text-dark);
+  }
+  .sidebar {
+    background: linear-gradient(180deg, #0f172a 0%, #111827 100%);
+  }
+  .sidebar-tab.active {
+    background: rgba(255, 255, 255, 0.94);
+    color: #0f172a;
+  }
+  .workspace {
+    background: var(--bg-dark);
+  }
+  .app-header,
+  .card {
+    background: var(--surface-dark);
+    border-color: var(--border-dark);
+  }
+  input,
+  select,
+  textarea {
+    background: rgba(15, 23, 42, 0.35);
+    color: inherit;
+    border-color: var(--border-dark);
+  }
+  .table-wrapper {
+    border-color: var(--border-dark);
+  }
+  td,
+  th {
+    border-bottom-color: var(--border-dark);
+  }
+  thead {
+    background: rgba(37, 99, 235, 0.25);
+  }
+  .status-box {
+    background: rgba(15, 23, 42, 0.4);
+    border-color: var(--border-dark);
+  }
+  .modal {
+    background: var(--surface-dark);
+    border-color: var(--border-dark);
+  }
+}

--- a/core/ui/js/api.js
+++ b/core/ui/js/api.js
@@ -1,51 +1,179 @@
-// core/ui/js/api.js
 (function(){
-  const KEY = 'BUS_SESSION_TOKEN';
-  let refreshPromise = null;
+  const LICENSE_EVENT = 'license:updated';
+  const MODAL_TITLE_NETWORK = 'Network Error';
+  const MODAL_TITLE_LOCKED = 'Locked';
+  const MODAL_TITLE_WRITES = 'Writes disabled';
 
-  async function refreshToken(){
-    if (refreshPromise) return refreshPromise;
-    refreshPromise = (async () => {
-      const r = await fetch('/session/token', { credentials: 'same-origin' });
-      if (!r.ok) throw new Error('refresh http ' + r.status);
-      const j = await r.json();
-      if (!j || !j.token) throw new Error('refresh missing token');
-      const tok = String(j.token);
-      localStorage.setItem(KEY, tok);
-      document.cookie = 'X-Session-Token=' + encodeURIComponent(tok) + '; SameSite=Lax; Path=/';
-      return tok;
-    })();
-    try {
-      return await refreshPromise;
-    } finally {
-      refreshPromise = null; // clear after completion to avoid cycles
+  function showModal(title, message){
+    if (window.Modals && typeof window.Modals.alert === 'function') {
+      window.Modals.alert(title, message);
+    } else {
+      window.alert(title + ': ' + message);
     }
   }
 
-  async function doFetch(method, url, body){
-    const init = { method, headers: { 'Accept': 'application/json' } };
-    if (body !== undefined){ init.body = JSON.stringify(body); init.headers['Content-Type'] = 'application/json'; }
-
-    let resp = await fetch(url, init);
-    if (resp.status === 401){
-      try { await refreshToken(); }
-      catch(e){ window.dispatchEvent(new CustomEvent('bus:auth-failed', { detail: { stage: 'refresh', error: String(e) } })); throw e; }
-      resp = await fetch(url, init);
+  function normalizePath(path){
+    if (!path) return '';
+    if (/^https?:/i.test(path)) return path;
+    let value = path.startsWith('/') ? path : '/' + path;
+    if (value.startsWith('/app/') || value.startsWith('/dev/')) {
+      return value;
     }
-    if (!resp.ok) {
-      const text = await resp.text().catch(()=>String(resp.status));
-      throw new Error('HTTP ' + resp.status + ' ' + text);
-    }
-    const ct = resp.headers.get('Content-Type') || '';
-    return ct.includes('application/json') ? resp.json() : resp.text();
+    return '/app' + value;
   }
 
-  function apiGet(u){ return doFetch('GET', u); }
-  function apiPost(u,b){ return doFetch('POST', u, b); }
-  function apiPut(u,b){ return doFetch('PUT', u, b); }
-  function apiDel(u){ return doFetch('DELETE', u); }
+  async function parseResponse(response, method){
+    const contentType = (response.headers && response.headers.get('content-type')) || '';
+    const isJson = contentType.includes('application/json');
+    if (response.status === 204) {
+      return {};
+    }
+    if (!response.ok) {
+      if (isJson) {
+        try {
+          return await response.json();
+        } catch (err) {
+          return { error: 'Request failed', detail: err instanceof Error ? err.message : String(err) };
+        }
+      }
+      try {
+        return await response.text();
+      } catch (err) {
+        return '';
+      }
+    }
+    if (isJson) {
+      return await response.json();
+    }
+    // Non-JSON payloads (e.g. RFQ download)
+    if (method === 'GET') {
+      return await response.text();
+    }
+    return await response.blob();
+  }
 
-  // global helpers expected by cards
-  window.apiGet = apiGet; window.apiPost = apiPost; window.apiPut = apiPut; window.apiDel = apiDel;
-  window.busApi = { apiGet, apiPost, apiPut, apiDel };
+  const API = {
+    license: null,
+    _licensePromise: null,
+
+    async loadLicense(force){
+      const shouldForce = Boolean(force);
+      if (shouldForce) {
+        this.license = null;
+        this._licensePromise = null;
+      }
+      if (this.license && !shouldForce) {
+        return this.license;
+      }
+      if (this._licensePromise && !shouldForce) {
+        return this._licensePromise;
+      }
+      const task = (async () => {
+        let response;
+        try {
+          response = await fetch('/dev/license', {
+            method: 'GET',
+            headers: { 'Accept': 'application/json', 'X-Plugin-Name': 'ui' },
+          });
+        } catch (error) {
+          showModal(MODAL_TITLE_NETWORK, 'Local API unavailable.');
+          throw error;
+        }
+        if (!response.ok) {
+          const payload = await parseResponse(response, 'GET');
+          const message = payload && payload.detail ? String(payload.detail) : 'Unable to load license information.';
+          showModal('Error', message);
+          throw new Error(message);
+        }
+        const data = await response.json();
+        this.license = data || {};
+        document.dispatchEvent(new CustomEvent(LICENSE_EVENT, { detail: this.license }));
+        return this.license;
+      })();
+      if (!shouldForce) {
+        this._licensePromise = task;
+      }
+      try {
+        return await task;
+      } finally {
+        this._licensePromise = null;
+      }
+    },
+
+    async request(method, path, body){
+      const normalized = normalizePath(path);
+      const headers = { 'Accept': 'application/json', 'X-Plugin-Name': 'ui' };
+      const hasBody = body !== undefined && body !== null;
+      if (hasBody && method !== 'GET') {
+        headers['Content-Type'] = 'application/json';
+      }
+      if (method === 'POST') {
+        const flag = document.body.dataset.writesEnabled;
+        if (flag === 'false') {
+          showModal(MODAL_TITLE_WRITES, 'Writes disabled.');
+          return Promise.reject(new Error('Writes disabled'));
+        }
+      }
+      let response;
+      try {
+        response = await fetch(normalized, {
+          method,
+          headers,
+          body: hasBody && method !== 'GET' ? JSON.stringify(body) : undefined,
+        });
+      } catch (error) {
+        showModal(MODAL_TITLE_NETWORK, 'Local API unavailable.');
+        throw error;
+      }
+
+      if (response.status === 403) {
+        let payload;
+        try {
+          payload = await response.json();
+        } catch (error) {
+          payload = { error: 'forbidden' };
+        }
+        if (payload && typeof payload === 'object' && payload.error === 'feature_locked') {
+          showModal(MODAL_TITLE_LOCKED, 'Feature not unlocked.');
+          return { locked: true };
+        }
+        const message = payload && payload.error ? String(payload.error) : 'Forbidden';
+        showModal('Error', message);
+        throw new Error(message);
+      }
+
+      const payload = await parseResponse(response, method);
+      if (!response.ok) {
+        const message = payload && payload.error ? String(payload.error) : (typeof payload === 'string' && payload ? payload : 'Request failed.');
+        showModal('Error', message);
+        throw new Error(message);
+      }
+      return payload;
+    },
+
+    get(path){
+      return this.request('GET', path);
+    },
+
+    post(path, body){
+      return this.request('POST', path, body);
+    },
+
+    put(path, body){
+      return this.request('PUT', path, body);
+    },
+
+    delete(path){
+      return this.request('DELETE', path);
+    },
+
+    feature(name){
+      if (!this.license || !this.license.features) {
+        return false;
+      }
+      return Boolean(this.license.features[name]);
+    },
+  };
+
+  window.API = API;
 })();

--- a/core/ui/js/app.js
+++ b/core/ui/js/app.js
@@ -1,0 +1,117 @@
+(function(){
+  const Cards = {
+    registry: {},
+    active: null,
+    inventory: null,
+    vendors: null,
+    manufacturing: null,
+    tasks: null,
+    backup: null,
+    settings: null,
+    rfq: null,
+    register(name, module){
+      if (!name || !module) return;
+      this.registry[name] = module;
+      this[name] = module;
+    },
+    async render(name){
+      const main = document.getElementById('main');
+      if (!main) return;
+      this.active = name;
+      main.innerHTML = '';
+      const cardContainer = document.createElement('div');
+      cardContainer.className = 'card';
+      main.appendChild(cardContainer);
+      const card = this.registry[name];
+      if (!card || typeof card.render !== 'function') {
+        cardContainer.textContent = 'Module unavailable.';
+        return;
+      }
+      try {
+        await Promise.resolve(card.render(cardContainer));
+      } catch (error) {
+        cardContainer.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
+      }
+    },
+  };
+
+  window.Cards = Cards;
+
+  function updateLicenseBadge(license){
+    const badge = document.getElementById('license-badge');
+    if (!badge) return;
+    const tier = license && typeof license.tier === 'string' ? license.tier.trim() : '';
+    badge.textContent = tier ? tier : 'Unknown';
+  }
+
+  function syncWritesToggle(toggle){
+    const enabled = toggle.checked;
+    document.body.dataset.writesEnabled = enabled ? 'true' : 'false';
+    toggle.setAttribute('aria-checked', String(enabled));
+    const label = document.getElementById('writes-toggle-status');
+    if (label) {
+      label.textContent = enabled ? 'Writes Enabled' : 'Writes Disabled';
+    }
+    document.dispatchEvent(new CustomEvent('writes:changed', { detail: { enabled } }));
+  }
+
+  function initTabs(){
+    const buttons = Array.from(document.querySelectorAll('.sidebar-tab'));
+    function activate(name){
+      buttons.forEach(button => {
+        const isActive = button.dataset.tab === name;
+        button.classList.toggle('active', isActive);
+      });
+      if (name) {
+        Cards.render(name);
+      }
+    }
+    buttons.forEach(button => {
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        const { tab } = button.dataset;
+        activate(tab);
+      });
+    });
+    return { buttons, activate };
+  }
+
+  function initVersion(){
+    const node = document.getElementById('app-version');
+    if (!node) return;
+    const value = (typeof window.APP_VERSION === 'string' && window.APP_VERSION.trim()) ? window.APP_VERSION.trim() : 'v0.6';
+    node.textContent = value;
+  }
+
+  async function bootstrapLicense(){
+    try {
+      const license = await window.API.loadLicense();
+      updateLicenseBadge(license);
+    } catch (error) {
+      updateLicenseBadge(null);
+    }
+  }
+
+  function init(){
+    document.body.dataset.writesEnabled = 'true';
+    initVersion();
+
+    const toggle = document.getElementById('writes-toggle');
+    if (toggle) {
+      toggle.checked = true;
+      syncWritesToggle(toggle);
+      toggle.addEventListener('change', () => syncWritesToggle(toggle));
+    }
+
+    document.addEventListener('license:updated', event => {
+      updateLicenseBadge(event.detail);
+    });
+
+    bootstrapLicense();
+
+    const tabs = initTabs();
+    tabs.activate('inventory');
+  }
+
+  document.addEventListener('DOMContentLoaded', init);
+})();

--- a/core/ui/js/cards/backup.js
+++ b/core/ui/js/cards/backup.js
@@ -1,0 +1,133 @@
+(function(){
+  const { el, bindDisabledWithProGate } = window.DOM || {};
+  const API = window.API;
+
+  async function render(container){
+    if (!el || !API) {
+      container.textContent = 'UI helpers unavailable.';
+      return;
+    }
+
+    const exportPassword = el('input', { type: 'password', placeholder: 'Export password' });
+    const exportButton = el('button', { type: 'button' }, 'Export Backup');
+    const importPath = el('input', { type: 'text', placeholder: 'Full path to .tgc file' });
+    const importPassword = el('input', { type: 'password', placeholder: 'Import password' });
+    const previewButton = el('button', { type: 'button', class: 'secondary' }, 'Preview Import');
+    const commitButton = el('button', { type: 'button' }, 'Commit Import');
+    bindDisabledWithProGate(commitButton, 'import_commit');
+    commitButton.dataset.previewReady = 'false';
+    const enforcePreviewLock = () => {
+      if (commitButton.dataset.pro !== 'true' && commitButton.dataset.previewReady !== 'true') {
+        commitButton.disabled = true;
+      }
+    };
+    enforcePreviewLock();
+    document.addEventListener('license:updated', enforcePreviewLock);
+    const status = el('div', { class: 'status-box' }, 'Awaiting action.');
+
+    const title = el('h2', {}, 'Backup & Restore');
+    const hint = el('div', { class: 'badge-note' }, '%LOCALAPPDATA%/BUSCore/exports will receive new exports.');
+
+    container.replaceChildren(
+      title,
+      hint,
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'Export'),
+        el('div', { class: 'form-grid' }, [
+          el('label', {}, ['Password', exportPassword]),
+        ]),
+        exportButton,
+      ]),
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'Import'),
+        el('div', { class: 'form-grid' }, [
+          el('label', {}, ['Archive path', importPath]),
+          el('label', {}, ['Password', importPassword]),
+        ]),
+        el('div', { class: 'actions' }, [previewButton, commitButton]),
+      ]),
+      status,
+    );
+
+    let lastPreview = null;
+
+    exportButton.addEventListener('click', async () => {
+      const password = exportPassword.value.trim();
+      if (!password) {
+        status.textContent = 'Enter an export password.';
+        return;
+      }
+      status.textContent = 'Exporting…';
+      try {
+        const result = await API.post('/export', { password });
+        if (result && result.path) {
+          status.textContent = `Export complete: ${result.path}`;
+        } else {
+          status.textContent = 'Export complete.';
+        }
+      } catch (error) {
+        status.textContent = 'Export failed: ' + (error && error.message ? error.message : String(error));
+      }
+    });
+
+    previewButton.addEventListener('click', async () => {
+      const path = importPath.value.trim();
+      const password = importPassword.value.trim();
+      if (!path || !password) {
+        status.textContent = 'Enter path and password for preview.';
+        return;
+      }
+      status.textContent = 'Previewing import…';
+      try {
+        const result = await API.post('/import/preview', { path, password });
+        lastPreview = { path, password, result };
+        status.textContent = JSON.stringify(result, null, 2);
+        commitButton.dataset.previewReady = 'true';
+        if (commitButton.dataset.pro !== 'true') {
+          commitButton.disabled = false;
+        }
+      } catch (error) {
+        status.textContent = 'Preview failed: ' + (error && error.message ? error.message : String(error));
+        lastPreview = null;
+        commitButton.dataset.previewReady = 'false';
+        enforcePreviewLock();
+      }
+    });
+
+    commitButton.addEventListener('click', async () => {
+      if (commitButton.dataset.previewReady !== 'true' && commitButton.dataset.pro !== 'true') {
+        status.textContent = 'Run a preview before committing.';
+        return;
+      }
+      if (!lastPreview) {
+        status.textContent = 'Run a preview before committing.';
+        return;
+      }
+      status.textContent = 'Committing import…';
+      try {
+        const result = await API.post('/import/commit', {
+          path: lastPreview.path,
+          password: lastPreview.password,
+        });
+        if (result && result.locked) {
+          return;
+        }
+        status.textContent = JSON.stringify(result, null, 2);
+        commitButton.dataset.previewReady = 'false';
+        enforcePreviewLock();
+      } catch (error) {
+        status.textContent = 'Commit failed: ' + (error && error.message ? error.message : String(error));
+      }
+    });
+
+    container.addEventListener('DOMNodeRemoved', event => {
+      if (event.target === container) {
+        document.removeEventListener('license:updated', enforcePreviewLock);
+      }
+    });
+  }
+
+  if (window.Cards && typeof window.Cards.register === 'function') {
+    window.Cards.register('backup', { render });
+  }
+})();

--- a/core/ui/js/cards/inventory.js
+++ b/core/ui/js/cards/inventory.js
@@ -1,0 +1,218 @@
+(function(){
+  const { el } = window.DOM || {};
+  const API = window.API;
+
+  function asArray(value){
+    return Array.isArray(value) ? value : [];
+  }
+
+  function formatNumber(value){
+    if (value === null || value === undefined) return '';
+    const number = Number(value);
+    if (Number.isNaN(number)) return '';
+    return number.toLocaleString(undefined, { maximumFractionDigits: 2 });
+  }
+
+  function buildForm(state, refresh){
+    const vendorSelect = el('select', { name: 'vendor_id' });
+    const nameInput = el('input', { name: 'name', required: true, placeholder: 'Item name' });
+    const skuInput = el('input', { name: 'sku', placeholder: 'SKU' });
+    const qtyInput = el('input', { name: 'qty', type: 'number', step: '0.01', placeholder: 'Quantity' });
+    const unitInput = el('input', { name: 'unit', placeholder: 'Unit' });
+    const priceInput = el('input', { name: 'price', type: 'number', step: '0.01', placeholder: 'Price' });
+    const notesInput = el('textarea', { name: 'notes', placeholder: 'Notes' });
+    const submit = el('button', { type: 'submit' }, 'Add Item');
+    const cancel = el('button', { type: 'button', class: 'secondary' }, 'Cancel');
+
+    function updateVendors(){
+      const vendors = asArray(state.vendors);
+      vendorSelect.innerHTML = '';
+      vendorSelect.appendChild(el('option', { value: '' }, '— No Vendor —'));
+      vendors.forEach(vendor => {
+        vendorSelect.appendChild(el('option', { value: String(vendor.id) }, vendor.name || `Vendor #${vendor.id}`));
+      });
+    }
+
+    function reset(){
+      state.editingId = null;
+      nameInput.value = '';
+      skuInput.value = '';
+      qtyInput.value = '';
+      unitInput.value = '';
+      priceInput.value = '';
+      notesInput.value = '';
+      vendorSelect.value = '';
+      submit.textContent = 'Add Item';
+      cancel.style.display = 'none';
+    }
+
+    function fill(item){
+      state.editingId = item.id;
+      nameInput.value = item.name || '';
+      skuInput.value = item.sku || '';
+      qtyInput.value = item.qty !== null && item.qty !== undefined ? String(item.qty) : '';
+      unitInput.value = item.unit || '';
+      priceInput.value = item.price !== null && item.price !== undefined ? String(item.price) : '';
+      notesInput.value = item.notes || '';
+      vendorSelect.value = item.vendor_id ? String(item.vendor_id) : '';
+      submit.textContent = 'Update Item';
+      cancel.style.display = 'inline-flex';
+    }
+
+    const form = el('form', {}, [
+      el('div', { class: 'section-title' }, state.editingId ? 'Edit Item' : 'Create Item'),
+      el('div', { class: 'form-grid' }, [
+        el('label', {}, ['Name', nameInput]),
+        el('label', {}, ['SKU', skuInput]),
+        el('label', {}, ['Quantity', qtyInput]),
+        el('label', {}, ['Unit', unitInput]),
+        el('label', {}, ['Price', priceInput]),
+        el('label', {}, ['Vendor', vendorSelect]),
+      ]),
+      el('label', {}, ['Notes', notesInput]),
+      el('div', { class: 'actions' }, [submit, cancel]),
+    ]);
+
+    form.addEventListener('submit', async event => {
+      event.preventDefault();
+      if (!API) return;
+      const payload = {
+        name: nameInput.value.trim(),
+        sku: skuInput.value.trim() || null,
+        qty: qtyInput.value === '' ? null : Number(qtyInput.value),
+        unit: unitInput.value.trim() || null,
+        price: priceInput.value === '' ? null : Number(priceInput.value),
+        notes: notesInput.value.trim() || null,
+        vendor_id: vendorSelect.value ? Number(vendorSelect.value) : null,
+      };
+      if (!payload.name) return;
+      try {
+        if (state.editingId) {
+          await API.put(`/items/${state.editingId}`, payload);
+        } else {
+          await API.post('/items', payload);
+        }
+        document.dispatchEvent(new CustomEvent('items:refresh'));
+        reset();
+        await refresh();
+      } catch (error) {
+        state.status.textContent = 'Save failed: ' + (error && error.message ? error.message : String(error));
+      }
+    });
+
+    cancel.addEventListener('click', () => {
+      reset();
+    });
+
+    state.updateForm = fill;
+    state.resetForm = reset;
+    state.syncVendors = updateVendors;
+    reset();
+    updateVendors();
+    cancel.style.display = 'none';
+    return form;
+  }
+
+  function buildTable(state, refresh){
+    const table = el('table');
+    const head = el('thead', {}, el('tr', {}, [
+      el('th', {}, 'Name'),
+      el('th', {}, 'SKU'),
+      el('th', {}, 'Qty'),
+      el('th', {}, 'Vendor'),
+      el('th', {}, 'Price'),
+      el('th', {}, 'Actions'),
+    ]));
+    const body = el('tbody');
+    table.appendChild(head);
+    table.appendChild(body);
+
+    function renderRows(){
+      body.innerHTML = '';
+      const vendors = new Map(asArray(state.vendors).map(v => [v.id, v]));
+      asArray(state.items).forEach(item => {
+        const vendor = vendors.get(item.vendor_id);
+        const row = el('tr', {}, [
+          el('td', {}, item.name || 'Untitled'),
+          el('td', {}, item.sku || '—'),
+          el('td', {}, formatNumber(item.qty)),
+          el('td', {}, vendor ? (vendor.name || `Vendor #${vendor.id}`) : '—'),
+          el('td', {}, item.price !== null && item.price !== undefined ? formatNumber(item.price) : '—'),
+          el('td', {}, createActions(item)),
+        ]);
+        body.appendChild(row);
+      });
+    }
+
+    function createActions(item){
+      const edit = el('button', { type: 'button', class: 'secondary' }, 'Edit');
+      const remove = el('button', { type: 'button', class: 'danger' }, 'Delete');
+      edit.addEventListener('click', () => {
+        if (state.updateForm) {
+          state.updateForm(item);
+        }
+      });
+      remove.addEventListener('click', () => {
+        if (!window.Modals) return;
+        window.Modals.confirm('Delete Item', `Delete ${item.name || 'this item'}?`, async () => {
+          try {
+            await API.delete(`/items/${item.id}`);
+            document.dispatchEvent(new CustomEvent('items:refresh'));
+            await refresh();
+          } catch (error) {
+            state.status.textContent = 'Delete failed: ' + (error && error.message ? error.message : String(error));
+          }
+        });
+      });
+      return el('div', { class: 'actions' }, [edit, remove]);
+    }
+
+    state.renderRows = renderRows;
+    return el('div', { class: 'table-wrapper' }, table);
+  }
+
+  async function render(container){
+    if (!el || !API) {
+      container.textContent = 'UI helpers unavailable.';
+      return;
+    }
+
+    const state = { items: [], vendors: [], editingId: null, status: el('div', { class: 'status-box' }) };
+
+    const title = el('h2', {}, 'Inventory');
+    const table = buildTable(state, refresh);
+    const form = buildForm(state, refresh);
+
+    container.replaceChildren(title, table, form, state.status);
+
+    async function refresh(){
+      try {
+        const [items, vendors] = await Promise.all([
+          API.get('/items'),
+          API.get('/vendors'),
+        ]);
+        state.items = asArray(items);
+        state.vendors = asArray(vendors);
+        if (state.syncVendors) state.syncVendors();
+        if (state.renderRows) state.renderRows();
+        state.status.textContent = `Loaded ${state.items.length} items.`;
+      } catch (error) {
+        state.status.textContent = 'Load failed: ' + (error && error.message ? error.message : String(error));
+      }
+    }
+
+    const onRefresh = () => refresh();
+    document.addEventListener('items:refresh', onRefresh);
+    container.addEventListener('DOMNodeRemoved', event => {
+      if (event.target === container) {
+        document.removeEventListener('items:refresh', onRefresh);
+      }
+    });
+
+    await refresh();
+  }
+
+  if (window.Cards && typeof window.Cards.register === 'function') {
+    window.Cards.register('inventory', { render });
+  }
+})();

--- a/core/ui/js/cards/manufacturing.js
+++ b/core/ui/js/cards/manufacturing.js
@@ -1,0 +1,227 @@
+(function(){
+  const { el, bindDisabledWithProGate } = window.DOM || {};
+  const API = window.API;
+
+  function asArray(value){
+    return Array.isArray(value) ? value : [];
+  }
+
+  function parseJson(text){
+    if (!text || !text.trim()) return {};
+    try {
+      const parsed = JSON.parse(text);
+      if (parsed && typeof parsed === 'object' && !Array.isArray(parsed)) {
+        return parsed;
+      }
+    } catch (error) {
+      throw new Error('Invalid JSON: ' + error.message);
+    }
+    throw new Error('Provide a JSON object.');
+  }
+
+  async function render(container){
+    if (!el || !API) {
+      container.textContent = 'UI helpers unavailable.';
+      return;
+    }
+
+    const state = {
+      items: [],
+      recipes: [],
+      selectedItemId: null,
+      recipeStatus: el('div', { class: 'status-box' }, 'Select a product to manage recipes.'),
+      batchStatus: el('div', { class: 'status-box' }, 'Ready to execute batch runs.'),
+    };
+
+    const title = el('h2', {}, 'Manufacturing');
+
+    const productSelect = el('select');
+    const recipeList = el('div', { class: 'recipe-list', style: { display: 'grid', gap: '12px' } });
+    const recipeEditor = el('textarea', { placeholder: 'Recipe JSON or notes' });
+    const saveRecipe = el('button', { type: 'button' }, 'Save Recipe');
+    const refreshRecipesBtn = el('button', { type: 'button', class: 'secondary' }, 'Refresh Recipes');
+
+    const recipeSection = el('section', {}, [
+      el('div', { class: 'section-title' }, 'Item Recipes'),
+      el('div', { class: 'form-grid' }, [
+        el('label', {}, ['Product', productSelect]),
+        el('label', {}, ['New Recipe', recipeEditor]),
+      ]),
+      el('div', { class: 'actions' }, [saveRecipe, refreshRecipesBtn]),
+      recipeList,
+      state.recipeStatus,
+    ]);
+
+    const inputsArea = el('textarea', { placeholder: 'Inputs JSON e.g. {"1": 2}' });
+    const outputsArea = el('textarea', { placeholder: 'Outputs JSON e.g. {"5": 1}' });
+    const noteInput = el('input', { placeholder: 'Optional note' });
+    const runButton = el('button', { type: 'button' }, 'Run Batch');
+    bindDisabledWithProGate(runButton, 'batch_run');
+
+    const batchSection = el('section', {}, [
+      el('div', { class: 'section-title' }, 'Batch Run'),
+      el('div', { class: 'form-grid' }, [
+        el('label', {}, ['Inputs', inputsArea]),
+        el('label', {}, ['Outputs', outputsArea]),
+        el('label', {}, ['Note', noteInput]),
+      ]),
+      runButton,
+      state.batchStatus,
+    ]);
+
+    const rfqContainer = el('div', { class: 'status-box' }, 'RFQ module loading…');
+    const rfqSection = el('section', {}, [
+      el('div', { class: 'section-title' }, 'Request for Quote'),
+      el('div', { class: 'badge-note' }, 'Generate vendor-ready RFQs (Pro feature).'),
+      rfqContainer,
+    ]);
+
+    container.replaceChildren(title, recipeSection, batchSection, rfqSection);
+
+    function renderRecipeRows(){
+      recipeList.innerHTML = '';
+      if (!state.recipes.length) {
+        recipeList.appendChild(el('div', { class: 'badge-note' }, 'No recipes stored for this item.'));
+        return;
+      }
+      state.recipes.forEach(recipe => {
+        const preview = el('pre', { class: 'status-box' }, recipe.label || '(empty)' );
+        const remove = el('button', { type: 'button', class: 'danger' }, 'Delete');
+        remove.addEventListener('click', () => {
+          if (!window.Modals) return;
+          window.Modals.confirm('Delete Recipe', 'Delete this recipe entry?', async () => {
+            try {
+              await API.delete(`/attachments/${recipe.id}`);
+              await loadRecipes();
+            } catch (error) {
+              state.recipeStatus.textContent = 'Delete failed: ' + (error && error.message ? error.message : String(error));
+            }
+          });
+        });
+        const entry = el('div', { class: 'card' }, [
+          el('div', { class: 'section-title' }, `Recipe #${recipe.id}`),
+          preview,
+          el('div', { class: 'badge-note' }, `Reader: ${recipe.reader_id}`),
+          el('div', { class: 'actions' }, [remove]),
+        ]);
+        recipeList.appendChild(entry);
+      });
+    }
+
+    function populateProducts(){
+      const items = asArray(state.items);
+      productSelect.innerHTML = '';
+      if (!items.length) {
+        productSelect.appendChild(el('option', { value: '' }, 'No items available'));
+        state.selectedItemId = null;
+        renderRecipeRows();
+        return;
+      }
+      items.forEach(item => {
+        const option = el('option', { value: String(item.id) }, `${item.name || 'Item'} (#${item.id})`);
+        productSelect.appendChild(option);
+      });
+      const match = items.find(item => item.id === state.selectedItemId) || items[0];
+      state.selectedItemId = match ? match.id : null;
+      productSelect.value = state.selectedItemId ? String(state.selectedItemId) : '';
+    }
+
+    async function loadItems(){
+      try {
+        const items = await API.get('/items');
+        state.items = asArray(items);
+        populateProducts();
+        if (state.selectedItemId) {
+          await loadRecipes();
+        } else {
+          state.recipeStatus.textContent = 'Create an item to define recipes.';
+        }
+      } catch (error) {
+        state.recipeStatus.textContent = 'Failed to load items: ' + (error && error.message ? error.message : String(error));
+      }
+    }
+
+    async function loadRecipes(){
+      if (!state.selectedItemId) return;
+      try {
+        state.recipeStatus.textContent = 'Loading recipes…';
+        const attachments = await API.get(`/attachments/item/${state.selectedItemId}`);
+        state.recipes = asArray(attachments).filter(entry => entry.reader_id === 'recipe');
+        renderRecipeRows();
+        state.recipeStatus.textContent = `Loaded ${state.recipes.length} recipe(s).`;
+      } catch (error) {
+        state.recipeStatus.textContent = 'Failed to load recipes: ' + (error && error.message ? error.message : String(error));
+      }
+    }
+
+    productSelect.addEventListener('change', async () => {
+      const value = productSelect.value;
+      state.selectedItemId = value ? Number(value) : null;
+      await loadRecipes();
+    });
+
+    refreshRecipesBtn.addEventListener('click', () => {
+      if (!state.selectedItemId) {
+        state.recipeStatus.textContent = 'Select an item first.';
+        return;
+      }
+      loadRecipes();
+    });
+
+    saveRecipe.addEventListener('click', async () => {
+      if (!state.selectedItemId) {
+        state.recipeStatus.textContent = 'Select an item first.';
+        return;
+      }
+      const content = recipeEditor.value.trim();
+      if (!content) {
+        state.recipeStatus.textContent = 'Enter recipe details before saving.';
+        return;
+      }
+      try {
+        // Validate JSON if provided but keep raw text
+        try {
+          parseJson(content);
+        } catch (_error) {
+          // allow non-JSON recipes; ignore validation error
+        }
+        await API.post(`/attachments/item/${state.selectedItemId}`, {
+          reader_id: 'recipe',
+          label: content,
+        });
+        recipeEditor.value = '';
+        state.recipeStatus.textContent = 'Recipe saved.';
+        await loadRecipes();
+      } catch (error) {
+        state.recipeStatus.textContent = 'Save failed: ' + (error && error.message ? error.message : String(error));
+      }
+    });
+
+    runButton.addEventListener('click', async () => {
+      state.batchStatus.textContent = 'Running batch…';
+      try {
+        const inputs = parseJson(inputsArea.value);
+        const outputs = parseJson(outputsArea.value);
+        const note = noteInput.value.trim() || null;
+        const result = await API.post('/inventory/run', { inputs, outputs, note });
+        if (result && result.locked) return;
+        state.batchStatus.textContent = 'Batch completed.';
+        document.dispatchEvent(new CustomEvent('items:refresh'));
+      } catch (error) {
+        state.batchStatus.textContent = 'Batch failed: ' + (error && error.message ? error.message : String(error));
+      }
+    });
+
+    if (window.Cards && window.Cards.rfq && typeof window.Cards.rfq.render === 'function') {
+      window.Cards.rfq.render(rfqContainer);
+    } else {
+      rfqContainer.textContent = 'RFQ module unavailable.';
+    }
+
+    await loadItems();
+  }
+
+  if (window.Cards && typeof window.Cards.register === 'function') {
+    window.Cards.register('manufacturing', { render });
+  }
+})();

--- a/core/ui/js/cards/rfq.js
+++ b/core/ui/js/cards/rfq.js
@@ -1,36 +1,14 @@
 (function(){
-  const TOKEN_KEY = 'BUS_SESSION_TOKEN';
-  let patched = false;
-  let lastRoot = null;
+  const { el, bindDisabledWithProGate } = window.DOM || {};
+  const API = window.API;
 
-  function getApi(){
-    const busApi = window.busApi || {};
-    const apiGet = typeof busApi.apiGet === 'function' ? busApi.apiGet : window.apiGet;
-    const apiPost = typeof busApi.apiPost === 'function' ? busApi.apiPost : window.apiPost;
-    return { apiGet, apiPost };
-  }
-
-  function el(tag, attrs, ...children){
-    const node = document.createElement(tag);
-    if (attrs){
-      Object.entries(attrs).forEach(([key, value]) => {
-        if (value === undefined || value === null) return;
-        if (key === 'class') node.className = value;
-        else if (key === 'for') node.htmlFor = value;
-        else node.setAttribute(key, value);
-      });
-    }
-    children.flat().forEach(child => {
-      if (child === undefined || child === null) return;
-      if (child instanceof Node) node.appendChild(child);
-      else node.appendChild(document.createTextNode(String(child)));
-    });
-    return node;
+  function asArray(value){
+    return Array.isArray(value) ? value : [];
   }
 
   function downloadBlob(blob, filename){
-    const url = URL.createObjectURL(blob);
     const link = document.createElement('a');
+    const url = URL.createObjectURL(blob);
     link.href = url;
     link.download = filename;
     document.body.appendChild(link);
@@ -39,219 +17,98 @@
     URL.revokeObjectURL(url);
   }
 
-  async function fetchBlob(path, body){
-    const res = await fetch(path, {
-      method: 'POST',
-      headers: { 'Content-Type': 'application/json' },
-      body: JSON.stringify(body || {}),
-    });
-    if (!res.ok){
-      let message = '';
-      try {
-        const text = await res.text();
-        if (text){
-          try {
-            const parsed = JSON.parse(text);
-            if (parsed && typeof parsed === 'object' && parsed.error) message = String(parsed.error);
-            else message = text;
-          } catch (_err){
-            message = text;
-          }
-        }
-      } catch (_err){
-        message = '';
-      }
-      if (!message) message = 'HTTP ' + res.status;
-      throw new Error(message);
-    }
-    return await res.blob();
-  }
-
-  function safeParseObject(text){
-    if (!text || !text.trim()) return {};
-    try {
-      const value = JSON.parse(text);
-      if (!value || typeof value !== 'object' || Array.isArray(value)){
-        throw new Error('Expected JSON object.');
-      }
-      return value;
-    } catch (error){
-      throw new Error('Invalid JSON: ' + error.message);
-    }
-  }
-
-  async function loadData(apiGet){
-    const vendors = await apiGet('/app/vendors').catch(() => []);
-    const items = await apiGet('/app/items').catch(() => []);
-    return {
-      vendors: Array.isArray(vendors) ? vendors : [],
-      items: Array.isArray(items) ? items : [],
-    };
-  }
-
-  function renderOptions(select, records, formatter){
-    select.innerHTML = '';
-    records.forEach(rec => {
-      const opt = document.createElement('option');
-      opt.value = String(rec.id);
-      opt.textContent = formatter(rec);
-      select.appendChild(opt);
-    });
-  }
-
   async function render(container){
-    const { apiGet, apiPost } = getApi();
-    if (typeof apiGet !== 'function' || typeof apiPost !== 'function'){
-      container.textContent = 'API helpers unavailable.';
+    if (!el || !API) {
+      container.textContent = 'UI helpers unavailable.';
       return;
     }
 
-    let data;
-    try {
-      data = await loadData(apiGet);
-    } catch (error){
-      container.textContent = 'Failed to load vendors/items: ' + error.message;
-      return;
+    const status = el('div', { class: 'status-box' }, 'Load vendors and items before generating RFQs.');
+    const vendorSelect = el('select', { multiple: true, size: 6 });
+    const itemSelect = el('select', { multiple: true, size: 8 });
+    const formatSelect = el('select', {}, [
+      el('option', { value: 'md' }, 'Markdown (.md)'),
+      el('option', { value: 'txt' }, 'Plain text (.txt)'),
+      el('option', { value: 'pdf' }, 'PDF (.pdf)'),
+    ]);
+    const generateButton = el('button', { type: 'button' }, 'Generate RFQ');
+    bindDisabledWithProGate(generateButton, 'rfq');
+
+    container.replaceChildren(
+      el('div', { class: 'form-grid' }, [
+        el('label', {}, ['Vendors', vendorSelect]),
+        el('label', {}, ['Items', itemSelect]),
+        el('label', {}, ['Format', formatSelect]),
+      ]),
+      generateButton,
+      status,
+    );
+
+    async function loadData(){
+      try {
+        status.textContent = 'Loading vendors and items…';
+        const [vendors, items] = await Promise.all([
+          API.get('/vendors'),
+          API.get('/items'),
+        ]);
+        vendorSelect.innerHTML = '';
+        asArray(vendors).forEach(vendor => {
+          vendorSelect.appendChild(el('option', { value: String(vendor.id) }, vendor.name || `Vendor #${vendor.id}`));
+        });
+        itemSelect.innerHTML = '';
+        asArray(items).forEach(item => {
+          const label = [item.sku, item.name || `Item #${item.id}`].filter(Boolean).join(' • ');
+          itemSelect.appendChild(el('option', { value: String(item.id) }, label));
+        });
+        status.textContent = 'Select vendors and items to generate RFQs.';
+      } catch (error) {
+        status.textContent = 'Failed to load data: ' + (error && error.message ? error.message : String(error));
+      }
     }
 
-    const status = el('pre', { class: 'muted', style: 'margin-top:8px; white-space:pre-wrap;' });
-    const vendorSelect = el('select', { multiple: '', size: String(Math.min(10, Math.max(3, data.vendors.length || 4))), style: 'min-width:220px;' });
-    const itemSelect = el('select', { multiple: '', size: String(Math.min(12, Math.max(4, data.items.length || 6))), style: 'min-width:280px;' });
-    const fmtSelect = el('select', { style: 'min-width:120px;' },
-      el('option', { value: 'md' }, 'md'),
-      el('option', { value: 'txt' }, 'txt'),
-      el('option', { value: 'pdf' }, 'pdf'),
-    );
-    const genBtn = el('button', { type: 'button' }, 'Generate RFQ');
-
-    const inputsArea = el('textarea', { placeholder: 'Inputs JSON e.g. {"1":2}', style: 'min-height:80px;width:100%;' });
-    const outputsArea = el('textarea', { placeholder: 'Outputs JSON e.g. {"3":1}', style: 'min-height:80px;width:100%;margin-top:8px;' });
-    const noteInput = el('input', { type: 'text', placeholder: 'Optional note', style: 'margin-top:8px;width:100%;' });
-    const runBtn = el('button', { type: 'button', style: 'margin-top:8px;' }, 'Run Inventory');
-
-    renderOptions(vendorSelect, data.vendors, rec => rec.name || ('Vendor #' + rec.id));
-    renderOptions(itemSelect, data.items, rec => [rec.sku || '', rec.name || ('Item #' + rec.id)].filter(Boolean).join(' ').trim());
-
-    const rfqBox = el('div', { class: 'rfq-box' },
-      el('h3', {}, 'RFQ'),
-      el('div', { style: 'display:flex;gap:12px;flex-wrap:wrap;' },
-        el('label', { style: 'display:flex;flex-direction:column;gap:4px;' }, 'Vendors', vendorSelect),
-        el('label', { style: 'display:flex;flex-direction:column;gap:4px;' }, 'Items', itemSelect),
-        el('label', { style: 'display:flex;flex-direction:column;gap:4px;align-self:flex-start;' }, 'Format', fmtSelect),
-      ),
-      genBtn,
-    );
-
-    const invBox = el('div', { class: 'rfq-inventory', style: 'margin-top:16px;' },
-      el('h3', {}, 'Inventory Run'),
-      inputsArea,
-      outputsArea,
-      noteInput,
-      runBtn,
-    );
-
-    container.replaceChildren(rfqBox, invBox, status);
-
-    genBtn.addEventListener('click', async () => {
-      const selectedItems = Array.from(itemSelect.selectedOptions).map(opt => Number(opt.value)).filter(n => !Number.isNaN(n));
-      const selectedVendors = Array.from(vendorSelect.selectedOptions).map(opt => Number(opt.value)).filter(n => !Number.isNaN(n));
-      if (!selectedItems.length){
-        status.textContent = 'Select at least one item.';
+    generateButton.addEventListener('click', async () => {
+      const selectedVendors = Array.from(vendorSelect.selectedOptions).map(option => Number(option.value)).filter(id => !Number.isNaN(id));
+      const selectedItems = Array.from(itemSelect.selectedOptions).map(option => Number(option.value)).filter(id => !Number.isNaN(id));
+      if (!selectedVendors.length || !selectedItems.length) {
+        status.textContent = 'Select at least one vendor and one item.';
         return;
       }
-      if (!selectedVendors.length){
-        status.textContent = 'Select at least one vendor.';
-        return;
-      }
-
-      const fmt = fmtSelect.value;
+      const fmt = formatSelect.value || 'md';
       status.textContent = 'Generating RFQ…';
-      genBtn.disabled = true;
       try {
-        const blob = await fetchBlob('/app/rfq/generate', { items: selectedItems, vendors: selectedVendors, fmt });
-        const ts = Math.floor(Date.now() / 1000);
-        const ext = fmt === 'pdf' ? 'pdf' : (fmt === 'txt' ? 'txt' : 'md');
-        downloadBlob(blob, `rfq-${ts}.${ext}`);
-        status.textContent = 'RFQ generated.';
-      } catch (error){
-        status.textContent = 'RFQ error: ' + error.message;
-      } finally {
-        genBtn.disabled = false;
+        const result = await API.post('/rfq/generate', {
+          vendors: selectedVendors,
+          items: selectedItems,
+          fmt,
+        });
+        if (result && result.locked) {
+          return;
+        }
+        if (result instanceof Blob) {
+          const ext = fmt === 'pdf' ? 'pdf' : (fmt === 'txt' ? 'txt' : 'md');
+          const filename = `rfq-${Date.now()}.${ext}`;
+          downloadBlob(result, filename);
+          status.textContent = `RFQ downloaded: ${filename}`;
+        } else {
+          status.textContent = 'Unexpected response.';
+        }
+      } catch (error) {
+        status.textContent = 'Generation failed: ' + (error && error.message ? error.message : String(error));
       }
     });
 
-    runBtn.addEventListener('click', async () => {
-      status.textContent = 'Running inventory…';
-      runBtn.disabled = true;
-      try {
-        const inputs = safeParseObject(inputsArea.value);
-        const outputs = safeParseObject(outputsArea.value);
-        const note = noteInput.value && noteInput.value.trim() ? noteInput.value.trim() : null;
-        const result = await apiPost('/app/inventory/run', { inputs, outputs, note });
-        status.textContent = JSON.stringify(result, null, 2);
-        document.dispatchEvent(new CustomEvent('items:refresh'));
-      } catch (error){
-        status.textContent = 'Inventory error: ' + error.message;
-      } finally {
-        runBtn.disabled = false;
+    await loadData();
+    document.addEventListener('vendors:refresh', loadData);
+    document.addEventListener('items:refresh', loadData);
+    container.addEventListener('DOMNodeRemoved', event => {
+      if (event.target === container) {
+        document.removeEventListener('vendors:refresh', loadData);
+        document.removeEventListener('items:refresh', loadData);
       }
     });
   }
 
-  async function mountRFQ(root){
-    if (!root) return;
-    lastRoot = root;
-    let container = root.querySelector('[data-rfq-root]');
-    if (!container){
-      container = document.createElement('div');
-      container.dataset.rfqRoot = '1';
-      container.style.marginTop = '16px';
-      container.style.paddingTop = '12px';
-      container.style.borderTop = '1px solid #26262e';
-      root.appendChild(container);
-    }
-    container.textContent = 'Loading RFQ…';
-    try {
-      await render(container);
-    } catch (error){
-      container.textContent = 'RFQ load error: ' + error.message;
-    }
+  if (window.Cards && typeof window.Cards.register === 'function') {
+    window.Cards.register('rfq', { render });
   }
-
-  function handleRefresh(){
-    if (lastRoot && lastRoot.isConnected){
-      mountRFQ(lastRoot);
-    }
-  }
-
-  function tryPatch(){
-    if (patched) return true;
-    const { apiGet, apiPost } = getApi();
-    const cards = window.busCards;
-    const hasToken = !!localStorage.getItem(TOKEN_KEY);
-    if (!cards || typeof cards.mountOrganizer !== 'function' || typeof apiGet !== 'function' || typeof apiPost !== 'function' || !hasToken){
-      return false;
-    }
-    const original = cards.mountOrganizer;
-    cards.mountOrganizer = async function(root){
-      await Promise.resolve(original(root));
-      try {
-        await mountRFQ(root);
-      } catch (error){
-        console.error('rfq mount failed', error);
-      }
-    };
-    document.addEventListener('items:refresh', handleRefresh);
-    patched = true;
-    return true;
-  }
-
-  function schedule(){
-    if (tryPatch()) return;
-    setTimeout(schedule, 200);
-  }
-
-  if (document.readyState === 'loading') document.addEventListener('DOMContentLoaded', schedule);
-  else schedule();
-  window.addEventListener('bus:token-ready', schedule);
 })();

--- a/core/ui/js/cards/settings.js
+++ b/core/ui/js/cards/settings.js
@@ -1,0 +1,89 @@
+(function(){
+  const { el } = window.DOM || {};
+  const API = window.API;
+
+  async function render(container){
+    if (!el || !API) {
+      container.textContent = 'UI helpers unavailable.';
+      return;
+    }
+
+    const title = el('h2', {}, 'Settings');
+    const licensePre = el('pre', { class: 'status-box', style: { minHeight: '160px' } }, 'Loading license…');
+    const featuresList = el('ul', { class: 'badge-note' });
+    const reloadButton = el('button', { type: 'button' }, 'Reload License');
+    const writesStatus = el('div', { class: 'status-box' }, 'Writes Enabled: true');
+
+    container.replaceChildren(
+      title,
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'License'),
+        reloadButton,
+        licensePre,
+        el('div', { class: 'section-title' }, 'Features'),
+        featuresList,
+      ]),
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'Writes Toggle'),
+        el('div', { class: 'badge-note' }, 'Controlled from the header. This value is read-only here.'),
+        writesStatus,
+      ]),
+    );
+
+    function updateWrites(){
+      const enabled = document.body.dataset.writesEnabled !== 'false';
+      writesStatus.textContent = `Writes Enabled: ${enabled}`;
+    }
+
+    function renderFeatures(license){
+      featuresList.innerHTML = '';
+      const features = (license && license.features) || {};
+      const entries = Object.keys(features);
+      if (!entries.length) {
+        featuresList.appendChild(el('li', {}, 'No feature flags present.'));
+        return;
+      }
+      entries.forEach(key => {
+        featuresList.appendChild(el('li', {}, `${key}: ${features[key] ? 'enabled' : 'disabled'}`));
+      });
+    }
+
+    function updateLicenseView(license){
+      licensePre.textContent = JSON.stringify(license || {}, null, 2);
+      renderFeatures(license || {});
+    }
+
+    reloadButton.addEventListener('click', async () => {
+      licensePre.textContent = 'Reloading…';
+      try {
+        const license = await API.loadLicense(true);
+        updateLicenseView(license);
+      } catch (error) {
+        licensePre.textContent = 'Reload failed: ' + (error && error.message ? error.message : String(error));
+      }
+    });
+
+    const onLicenseUpdated = event => updateLicenseView(event.detail);
+    document.addEventListener('license:updated', onLicenseUpdated);
+    document.addEventListener('writes:changed', updateWrites);
+
+    updateWrites();
+    try {
+      const license = await API.loadLicense();
+      updateLicenseView(license);
+    } catch (error) {
+      licensePre.textContent = 'Failed to load license: ' + (error && error.message ? error.message : String(error));
+    }
+
+    container.addEventListener('DOMNodeRemoved', event => {
+      if (event.target === container) {
+        document.removeEventListener('license:updated', onLicenseUpdated);
+        document.removeEventListener('writes:changed', updateWrites);
+      }
+    });
+  }
+
+  if (window.Cards && typeof window.Cards.register === 'function') {
+    window.Cards.register('settings', { render });
+  }
+})();

--- a/core/ui/js/cards/tasks.js
+++ b/core/ui/js/cards/tasks.js
@@ -1,0 +1,188 @@
+(function(){
+  const { el } = window.DOM || {};
+  const API = window.API;
+
+  function asArray(value){
+    return Array.isArray(value) ? value : [];
+  }
+
+  function buildForm(state, refresh){
+    const titleInput = el('input', { name: 'title', required: true, placeholder: 'Task title' });
+    const statusSelect = el('select', { name: 'status' }, [
+      el('option', { value: 'pending' }, 'Pending'),
+      el('option', { value: 'in_progress' }, 'In Progress'),
+      el('option', { value: 'done' }, 'Done'),
+    ]);
+    const dueInput = el('input', { name: 'due', type: 'date' });
+    const itemSelect = el('select', { name: 'item_id' });
+    const notesInput = el('textarea', { name: 'notes', placeholder: 'Notes' });
+    const submit = el('button', { type: 'submit' }, 'Add Task');
+    const cancel = el('button', { type: 'button', class: 'secondary' }, 'Cancel');
+
+    function updateItems(){
+      const items = asArray(state.items);
+      itemSelect.innerHTML = '';
+      itemSelect.appendChild(el('option', { value: '' }, '— No Item —'));
+      items.forEach(item => {
+        itemSelect.appendChild(el('option', { value: String(item.id) }, `${item.name || 'Item'} (#${item.id})`));
+      });
+    }
+
+    function reset(){
+      state.editingId = null;
+      titleInput.value = '';
+      statusSelect.value = 'pending';
+      dueInput.value = '';
+      itemSelect.value = '';
+      notesInput.value = '';
+      submit.textContent = 'Add Task';
+      cancel.style.display = 'none';
+    }
+
+    function fill(task){
+      state.editingId = task.id;
+      titleInput.value = task.title || '';
+      statusSelect.value = task.status || 'pending';
+      dueInput.value = task.due || '';
+      itemSelect.value = task.item_id ? String(task.item_id) : '';
+      notesInput.value = task.notes || '';
+      submit.textContent = 'Update Task';
+      cancel.style.display = 'inline-flex';
+    }
+
+    const form = el('form', {}, [
+      el('div', { class: 'section-title' }, state.editingId ? 'Edit Task' : 'Create Task'),
+      el('div', { class: 'form-grid' }, [
+        el('label', {}, ['Title', titleInput]),
+        el('label', {}, ['Status', statusSelect]),
+        el('label', {}, ['Due', dueInput]),
+        el('label', {}, ['Item', itemSelect]),
+      ]),
+      el('label', {}, ['Notes', notesInput]),
+      el('div', { class: 'actions' }, [submit, cancel]),
+    ]);
+
+    form.addEventListener('submit', async event => {
+      event.preventDefault();
+      if (!API) return;
+      const payload = {
+        title: titleInput.value.trim(),
+        status: statusSelect.value,
+        due: dueInput.value || null,
+        item_id: itemSelect.value ? Number(itemSelect.value) : null,
+        notes: notesInput.value.trim() || null,
+      };
+      if (!payload.title) return;
+      try {
+        if (state.editingId) {
+          await API.put(`/tasks/${state.editingId}`, payload);
+        } else {
+          await API.post('/tasks', payload);
+        }
+        reset();
+        await refresh();
+      } catch (error) {
+        state.status.textContent = 'Save failed: ' + (error && error.message ? error.message : String(error));
+      }
+    });
+
+    cancel.addEventListener('click', () => reset());
+
+    state.updateForm = fill;
+    state.resetForm = reset;
+    state.syncItems = updateItems;
+    updateItems();
+    reset();
+    cancel.style.display = 'none';
+    return form;
+  }
+
+  function buildTable(state, refresh){
+    const table = el('table');
+    const head = el('thead', {}, el('tr', {}, [
+      el('th', {}, 'Title'),
+      el('th', {}, 'Status'),
+      el('th', {}, 'Due'),
+      el('th', {}, 'Item'),
+      el('th', {}, 'Actions'),
+    ]));
+    const body = el('tbody');
+    table.appendChild(head);
+    table.appendChild(body);
+
+    function renderRows(){
+      body.innerHTML = '';
+      const items = new Map(asArray(state.items).map(item => [item.id, item]));
+      asArray(state.tasks).forEach(task => {
+        const related = items.get(task.item_id);
+        const row = el('tr', {}, [
+          el('td', {}, task.title || 'Untitled'),
+          el('td', {}, task.status || 'pending'),
+          el('td', {}, task.due || '—'),
+          el('td', {}, related ? `${related.name || 'Item'} (#${related.id})` : '—'),
+          el('td', {}, createActions(task)),
+        ]);
+        body.appendChild(row);
+      });
+    }
+
+    function createActions(task){
+      const edit = el('button', { type: 'button', class: 'secondary' }, 'Edit');
+      const remove = el('button', { type: 'button', class: 'danger' }, 'Delete');
+      edit.addEventListener('click', () => {
+        if (state.updateForm) state.updateForm(task);
+      });
+      remove.addEventListener('click', () => {
+        if (!window.Modals) return;
+        window.Modals.confirm('Delete Task', `Delete ${task.title || 'this task'}?`, async () => {
+          try {
+            await API.delete(`/tasks/${task.id}`);
+            await refresh();
+          } catch (error) {
+            state.status.textContent = 'Delete failed: ' + (error && error.message ? error.message : String(error));
+          }
+        });
+      });
+      return el('div', { class: 'actions' }, [edit, remove]);
+    }
+
+    state.renderRows = renderRows;
+    return el('div', { class: 'table-wrapper' }, table);
+  }
+
+  async function render(container){
+    if (!el || !API) {
+      container.textContent = 'UI helpers unavailable.';
+      return;
+    }
+
+    const state = { tasks: [], items: [], editingId: null, status: el('div', { class: 'status-box' }) };
+    const title = el('h2', {}, 'Tasks');
+    const table = buildTable(state, refresh);
+    const form = buildForm(state, refresh);
+
+    container.replaceChildren(title, table, form, state.status);
+
+    async function refresh(){
+      try {
+        const [tasks, items] = await Promise.all([
+          API.get('/tasks'),
+          API.get('/items'),
+        ]);
+        state.tasks = asArray(tasks);
+        state.items = asArray(items);
+        if (state.syncItems) state.syncItems();
+        if (state.renderRows) state.renderRows();
+        state.status.textContent = `Loaded ${state.tasks.length} task(s).`;
+      } catch (error) {
+        state.status.textContent = 'Load failed: ' + (error && error.message ? error.message : String(error));
+      }
+    }
+
+    await refresh();
+  }
+
+  if (window.Cards && typeof window.Cards.register === 'function') {
+    window.Cards.register('tasks', { render });
+  }
+})();

--- a/core/ui/js/cards/vendors.js
+++ b/core/ui/js/cards/vendors.js
@@ -1,0 +1,158 @@
+(function(){
+  const { el } = window.DOM || {};
+  const API = window.API;
+
+  function asArray(value){
+    return Array.isArray(value) ? value : [];
+  }
+
+  function buildForm(state, refresh){
+    const nameInput = el('input', { name: 'name', required: true, placeholder: 'Vendor name' });
+    const contactInput = el('input', { name: 'contact', placeholder: 'Contact details' });
+    const notesInput = el('textarea', { name: 'notes', placeholder: 'Notes' });
+    const submit = el('button', { type: 'submit' }, 'Add Vendor');
+    const cancel = el('button', { type: 'button', class: 'secondary' }, 'Cancel');
+
+    function reset(){
+      state.editingId = null;
+      nameInput.value = '';
+      contactInput.value = '';
+      notesInput.value = '';
+      submit.textContent = 'Add Vendor';
+      cancel.style.display = 'none';
+    }
+
+    function fill(vendor){
+      state.editingId = vendor.id;
+      nameInput.value = vendor.name || '';
+      contactInput.value = vendor.contact || '';
+      notesInput.value = vendor.notes || '';
+      submit.textContent = 'Update Vendor';
+      cancel.style.display = 'inline-flex';
+    }
+
+    const form = el('form', {}, [
+      el('div', { class: 'section-title' }, state.editingId ? 'Edit Vendor' : 'Create Vendor'),
+      el('div', { class: 'form-grid' }, [
+        el('label', {}, ['Name', nameInput]),
+        el('label', {}, ['Contact', contactInput]),
+      ]),
+      el('label', {}, ['Notes', notesInput]),
+      el('div', { class: 'actions' }, [submit, cancel]),
+    ]);
+
+    form.addEventListener('submit', async event => {
+      event.preventDefault();
+      if (!API) return;
+      const payload = {
+        name: nameInput.value.trim(),
+        contact: contactInput.value.trim() || null,
+        notes: notesInput.value.trim() || null,
+      };
+      if (!payload.name) return;
+      try {
+        if (state.editingId) {
+          await API.put(`/vendors/${state.editingId}`, payload);
+        } else {
+          await API.post('/vendors', payload);
+        }
+        reset();
+        await refresh();
+        document.dispatchEvent(new CustomEvent('vendors:refresh'));
+        document.dispatchEvent(new CustomEvent('items:refresh'));
+      } catch (error) {
+        state.status.textContent = 'Save failed: ' + (error && error.message ? error.message : String(error));
+      }
+    });
+
+    cancel.addEventListener('click', () => reset());
+
+    state.updateForm = fill;
+    state.resetForm = reset;
+    reset();
+    cancel.style.display = 'none';
+    return form;
+  }
+
+  function buildTable(state, refresh){
+    const table = el('table');
+    const head = el('thead', {}, el('tr', {}, [
+      el('th', {}, 'Name'),
+      el('th', {}, 'Contact'),
+      el('th', {}, 'Notes'),
+      el('th', {}, 'Actions'),
+    ]));
+    const body = el('tbody');
+    table.appendChild(head);
+    table.appendChild(body);
+
+    function renderRows(){
+      body.innerHTML = '';
+      asArray(state.vendors).forEach(vendor => {
+        const row = el('tr', {}, [
+          el('td', {}, vendor.name || 'Unnamed'),
+          el('td', {}, vendor.contact || '—'),
+          el('td', {}, vendor.notes || '—'),
+          el('td', {}, createActions(vendor)),
+        ]);
+        body.appendChild(row);
+      });
+    }
+
+    function createActions(vendor){
+      const edit = el('button', { type: 'button', class: 'secondary' }, 'Edit');
+      const remove = el('button', { type: 'button', class: 'danger' }, 'Delete');
+      edit.addEventListener('click', () => {
+        if (state.updateForm) state.updateForm(vendor);
+      });
+      remove.addEventListener('click', () => {
+        if (!window.Modals) return;
+        window.Modals.confirm('Delete Vendor', `Delete ${vendor.name || 'this vendor'}?`, async () => {
+          try {
+            await API.delete(`/vendors/${vendor.id}`);
+            await refresh();
+            document.dispatchEvent(new CustomEvent('vendors:refresh'));
+            document.dispatchEvent(new CustomEvent('items:refresh'));
+          } catch (error) {
+            state.status.textContent = 'Delete failed: ' + (error && error.message ? error.message : String(error));
+          }
+        });
+      });
+      return el('div', { class: 'actions' }, [edit, remove]);
+    }
+
+    state.renderRows = renderRows;
+    return el('div', { class: 'table-wrapper' }, table);
+  }
+
+  async function render(container){
+    if (!el || !API) {
+      container.textContent = 'UI helpers unavailable.';
+      return;
+    }
+
+    const state = { vendors: [], editingId: null, status: el('div', { class: 'status-box' }) };
+    const title = el('h2', {}, 'Vendors');
+    const table = buildTable(state, refresh);
+    const form = buildForm(state, refresh);
+
+    container.replaceChildren(title, table, form, state.status);
+
+    async function refresh(){
+      try {
+        const vendors = await API.get('/vendors');
+        state.vendors = asArray(vendors);
+        if (state.renderRows) state.renderRows();
+        state.status.textContent = `Loaded ${state.vendors.length} vendors.`;
+      } catch (error) {
+        state.status.textContent = 'Load failed: ' + (error && error.message ? error.message : String(error));
+      }
+    }
+
+    await refresh();
+  }
+
+  if (window.Cards && typeof window.Cards.register === 'function') {
+    window.Cards.register('vendors', { render });
+  }
+})();

--- a/core/ui/js/ui/dom.js
+++ b/core/ui/js/ui/dom.js
@@ -1,0 +1,96 @@
+(function(){
+  function $(selector, root){
+    return (root || document).querySelector(selector);
+  }
+
+  function createText(value){
+    return document.createTextNode(String(value));
+  }
+
+  function el(tag, attrs, children){
+    const node = document.createElement(tag);
+    const options = attrs || {};
+    Object.entries(options).forEach(([key, value]) => {
+      if (value === undefined || value === null) {
+        return;
+      }
+      if (key === 'class' || key === 'className') {
+        node.className = String(value);
+      } else if (key === 'text') {
+        node.textContent = String(value);
+      } else if (key === 'dataset' && typeof value === 'object') {
+        Object.entries(value).forEach(([dataKey, dataValue]) => {
+          if (dataValue === undefined || dataValue === null) return;
+          node.dataset[dataKey] = String(dataValue);
+        });
+      } else if (key === 'style' && typeof value === 'object') {
+        Object.assign(node.style, value);
+      } else if (key.startsWith('on') && typeof value === 'function') {
+        node.addEventListener(key.slice(2), value);
+      } else {
+        node.setAttribute(key, String(value));
+      }
+    });
+
+    const list = Array.isArray(children) ? children : (children !== undefined ? [children] : []);
+    list.forEach(child => {
+      if (child === undefined || child === null) {
+        return;
+      }
+      if (child instanceof Node) {
+        node.appendChild(child);
+      } else {
+        node.appendChild(createText(child));
+      }
+    });
+    return node;
+  }
+
+  function ensureBadge(button){
+    if (!button) return null;
+    const existing = button.querySelector(':scope > .pro-badge');
+    if (existing) return existing;
+    const badge = document.createElement('span');
+    badge.className = 'pro-badge';
+    badge.textContent = 'Pro Feature';
+    button.appendChild(badge);
+    return badge;
+  }
+
+  function removeBadge(button){
+    const badge = button && button.querySelector(':scope > .pro-badge');
+    if (badge) {
+      badge.remove();
+    }
+  }
+
+  function bindDisabledWithProGate(button, featureName){
+    if (!(button instanceof HTMLElement) || !featureName) {
+      return;
+    }
+    if (button.dataset.proGateBound === 'true') {
+      return;
+    }
+    button.dataset.proGateBound = 'true';
+
+    function refresh(){
+      const api = window.API;
+      const enabled = api && typeof api.feature === 'function' ? api.feature(featureName) : false;
+      if (!enabled) {
+        button.disabled = true;
+        button.dataset.pro = 'true';
+        ensureBadge(button);
+      } else {
+        button.disabled = false;
+        button.dataset.pro = 'false';
+        removeBadge(button);
+      }
+    }
+
+    document.addEventListener('license:updated', refresh);
+    refresh();
+    return { refresh };
+  }
+
+  window.DOM = { $, el, bindDisabledWithProGate };
+})();

--- a/core/ui/js/ui/modals.js
+++ b/core/ui/js/ui/modals.js
@@ -1,0 +1,106 @@
+(function(){
+  const { el } = window.DOM || {};
+
+  function factory(){
+    return typeof el === 'function' ? el : function(tag, attrs, children){
+      const node = document.createElement(tag);
+      if (attrs) {
+        Object.entries(attrs).forEach(([key, value]) => {
+          if (value === undefined || value === null) return;
+          if (key === 'class') node.className = String(value);
+          else node.setAttribute(key, String(value));
+        });
+      }
+      const list = Array.isArray(children) ? children : [children];
+      list.forEach(child => {
+        if (child === undefined || child === null) return;
+        if (child instanceof Node) node.appendChild(child);
+        else node.appendChild(document.createTextNode(String(child)));
+      });
+      return node;
+    };
+  }
+
+  const makeEl = factory();
+
+  function getRoot(){
+    return document.getElementById('modal-root');
+  }
+
+  function close(){
+    const root = getRoot();
+    if (root) {
+      root.innerHTML = '';
+    }
+    document.body.classList.remove('modal-open');
+  }
+
+  function render(title, content, actions){
+    const root = getRoot();
+    if (!root) return;
+    root.innerHTML = '';
+
+    const overlay = makeEl('div', { class: 'modal-overlay' });
+    const modal = makeEl('div', { class: 'modal' });
+    const heading = makeEl('h3', null, title || 'Notice');
+
+    let bodyContent;
+    if (content instanceof Node) {
+      bodyContent = content;
+    } else {
+      bodyContent = makeEl('p', null, content || '');
+    }
+
+    const buttons = makeEl('div', { class: 'modal-actions' });
+    (actions || []).forEach(action => {
+      const variant = action.variant || (action.danger ? 'danger' : '');
+      const classes = ['modal-btn'];
+      if (variant === 'secondary') classes.push('secondary');
+      if (variant === 'danger' || action.danger) classes.push('danger');
+      const button = makeEl('button', { type: 'button', class: classes.join(' ') }, action.label || 'OK');
+      button.addEventListener('click', () => {
+        try {
+          if (typeof action.onClick === 'function') {
+            action.onClick();
+          }
+        } finally {
+          if (!action.keepOpen) {
+            close();
+          }
+        }
+      });
+      buttons.appendChild(button);
+    });
+
+    modal.appendChild(heading);
+    modal.appendChild(bodyContent);
+    modal.appendChild(buttons);
+    overlay.appendChild(modal);
+
+    overlay.addEventListener('click', event => {
+      if (event.target === overlay) {
+        close();
+      }
+    });
+
+    root.appendChild(overlay);
+    document.body.classList.add('modal-open');
+  }
+
+  const Modals = {
+    alert(title, message){
+      render(title, message, [
+        { label: 'Close', variant: 'secondary' },
+      ]);
+    },
+    confirm(title, message, onYes){
+      render(title, message, [
+        { label: 'Cancel', variant: 'secondary' },
+        { label: 'Confirm', variant: 'danger', onClick: () => { if (typeof onYes === 'function') onYes(); } },
+      ]);
+    },
+    close,
+  };
+
+  window.Modals = Modals;
+})();

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -3,70 +3,51 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width,initial-scale=1.0">
-  <title>BUS Core — Local Dashboard</title>
-  <link rel="stylesheet" href="styles.css">
+  <title>BUS Core — Dashboard</title>
+  <link rel="stylesheet" href="css/app.css">
   <script src="js/token.js" defer></script>
 </head>
 <body>
-  <nav class="sidebar">
-    <h1>BUS Core</h1>
-    <ul>
-      <li><a href="#writes">Writes</a></li>
-      <li><a href="#organizer">Organizer</a></li>
-      <li><a href="#dev">Dev</a></li>
-    </ul>
-  </nav>
-  <main>
-    <details id="writes">
-      <summary>Writes</summary>
-      <div id="writes-card">Loading...</div>
-    </details>
-    <details id="organizer">
-      <summary>Organizer</summary>
-      <div id="organizer-card">Loading...</div>
-    </details>
-    <details id="dev">
-      <summary>Dev</summary>
-      <div id="dev-card">Loading...</div>
-    </details>
-  </main>
-  <script type="module">
-    import { mountWrites } from './js/cards/writes.js';
-    import { mountOrganizer } from './js/cards/organizer.js';
-    import { mountDev } from './js/cards/dev.js';
-
-    async function refreshCard(mountFn,id){
-      const root=document.getElementById(id);
-      if(!root) return;
-      try{
-        await mountFn(root);
-      }catch(error){
-        console.error(`${id} failed to load:`,error);
-        root.textContent='Error: '+error.message;
-      }
-    }
-
-    async function refreshAllCards(){
-      await Promise.all([
-        refreshCard(mountWrites,'writes-card'),
-        refreshCard(mountOrganizer,'organizer-card'),
-        refreshCard(mountDev,'dev-card')
-      ]);
-    }
-
-    async function handleTokenReady(){
-      try{
-        await refreshAllCards();
-      }catch(error){
-        console.error('Card refresh failed:',error);
-      }
-    }
-
-    document.addEventListener('bus:token-ready',()=>{ handleTokenReady(); });
-
-    if(localStorage.getItem('tgc_token')){
-      handleTokenReady();
-    }
-  </script>
+  <div class="app-shell">
+    <aside class="sidebar" aria-label="Primary">
+      <div class="sidebar-brand">BUS Core</div>
+      <nav class="sidebar-nav">
+        <button class="sidebar-tab" data-tab="inventory" type="button">Inventory</button>
+        <button class="sidebar-tab" data-tab="vendors" type="button">Vendors</button>
+        <button class="sidebar-tab" data-tab="manufacturing" type="button">Manufacturing</button>
+        <button class="sidebar-tab" data-tab="tasks" type="button">Tasks</button>
+        <button class="sidebar-tab" data-tab="backup" type="button">Backup</button>
+        <button class="sidebar-tab" data-tab="settings" type="button">Settings</button>
+      </nav>
+    </aside>
+    <div class="workspace">
+      <header class="app-header">
+        <div class="header-left">
+          <label class="writes-toggle">
+            <input type="checkbox" id="writes-toggle" checked>
+            <span class="toggle-indicator"></span>
+            <span class="toggle-label" id="writes-toggle-status">Writes Enabled</span>
+          </label>
+          <span class="license-badge" id="license-badge">License</span>
+        </div>
+        <div class="header-right">
+          <span class="app-version" id="app-version">v0.6</span>
+        </div>
+      </header>
+      <main id="main" class="main"></main>
+    </div>
+  </div>
+  <div id="modal-root"></div>
+  <script src="js/api.js"></script>
+  <script src="js/ui/dom.js"></script>
+  <script src="js/ui/modals.js"></script>
+  <script src="js/app.js"></script>
+  <script src="js/cards/inventory.js"></script>
+  <script src="js/cards/vendors.js"></script>
+  <script src="js/cards/manufacturing.js"></script>
+  <script src="js/cards/tasks.js"></script>
+  <script src="js/cards/backup.js"></script>
+  <script src="js/cards/settings.js"></script>
+  <script src="js/cards/rfq.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- rebuild the dashboard shell with a sidebar, header controls, modal root, and new stylesheet
- add shared client API, DOM, and modal utilities plus bootstrap logic for tabs and license display
- implement inventory, vendor, manufacturing, task, backup, settings, and RFQ cards with Pro feature gating and notes documentation

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd6cd90bc4832288032b86b883154d