### PR TITLE
Implement runtime card bus for deterministic UI initialization

### DIFF
--- a/core/ui/js/api.js
+++ b/core/ui/js/api.js
@@ -175,5 +175,5 @@
     },
   };
 
-  window.API = API;
+  window.API = window.API || API;
 })();

--- a/core/ui/js/app.js
+++ b/core/ui/js/app.js
@@ -1,64 +1,18 @@
 (function(){
-  const existing = (window.Cards && typeof window.Cards === 'object') ? window.Cards : {};
-  const registry = existing.registry && typeof existing.registry === 'object' ? existing.registry : {};
+  const initializedCards = new WeakSet();
 
-  const Cards = Object.assign(existing, {
-    registry,
-    active: existing.active || null,
-    register(name, module){
-      if (!name || typeof module !== 'object' || typeof module.render !== 'function') {
-        console.warn('Card registration skipped for', name);
-        return;
-      }
-      this.registry[name] = module;
-      this[name] = module;
-      if (typeof module.init === 'function') {
-        try {
-          module.init();
-        } catch (error) {
-          console.error('Card init failed:', name, error);
+  if (!window.Cards || typeof window.Cards.register !== 'function') {
+    window.Cards = {
+      register(name, module){
+        if (!name || !module || typeof module.render !== 'function') {
+          console.warn('Card registration skipped for', name);
+          return;
+        }
+        if (typeof window.registerCard === 'function') {
+          window.registerCard(name, () => module);
         }
       }
-    },
-    async render(name){
-      const main = document.getElementById('main');
-      if (!main) return;
-      this.active = name;
-      main.innerHTML = '';
-      const cardContainer = document.createElement('div');
-      cardContainer.className = 'card';
-      main.appendChild(cardContainer);
-      const card = this.registry[name];
-      if (!card || typeof card.render !== 'function') {
-        cardContainer.textContent = 'Module unavailable.';
-        return;
-      }
-      try {
-        await Promise.resolve(card.render(cardContainer));
-      } catch (error) {
-        cardContainer.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
-        console.error('Card render failed:', name, error);
-      }
-    },
-  });
-
-  window.Cards = Cards;
-
-  function helpersReady(){
-    let ok = true;
-    if (!window.API) {
-      console.error('Missing helper: API');
-      ok = false;
-    }
-    if (!window.Dom) {
-      console.error('Missing helper: Dom');
-      ok = false;
-    }
-    if (!window.Modals) {
-      console.error('Missing helper: Modals');
-      ok = false;
-    }
-    return ok;
+    };
   }
 
   function updateLicenseBadge(license){
@@ -79,27 +33,6 @@
     document.dispatchEvent(new CustomEvent('writes:changed', { detail: { enabled } }));
   }
 
-  function initTabs(){
-    const buttons = Array.from(document.querySelectorAll('.sidebar-tab'));
-    function activate(name){
-      buttons.forEach(button => {
-        const isActive = button.dataset.tab === name;
-        button.classList.toggle('active', isActive);
-      });
-      if (name) {
-        Cards.render(name);
-      }
-    }
-    buttons.forEach(button => {
-      button.addEventListener('click', event => {
-        event.preventDefault();
-        const { tab } = button.dataset;
-        activate(tab);
-      });
-    });
-    return { buttons, activate };
-  }
-
   function initVersion(){
     const node = document.getElementById('app-version');
     if (!node) return;
@@ -107,18 +40,67 @@
     node.textContent = value;
   }
 
-  async function bootstrapLicense(){
+  function ensureCardInit(name, card){
+    if (!card || typeof card.init !== 'function' || initializedCards.has(card)) {
+      return;
+    }
     try {
-      const license = await window.API.loadLicense();
-      updateLicenseBadge(license);
+      card.init();
     } catch (error) {
-      updateLicenseBadge(null);
+      console.error('Card init failed:', name, error);
+    } finally {
+      initializedCards.add(card);
     }
   }
 
-  document.addEventListener('DOMContentLoaded', () => {
-    if (!helpersReady()) {
-      console.error('UI initialization halted due to missing helpers.');
+  async function renderCard(name, main){
+    if (!main || !window.CardBus) {
+      return;
+    }
+    main.innerHTML = '';
+    const container = document.createElement('div');
+    container.className = 'card';
+    main.appendChild(container);
+    const card = window.CardBus.getCard(name);
+    if (!card || typeof card.render !== 'function') {
+      container.textContent = 'Module unavailable.';
+      return;
+    }
+    ensureCardInit(name, card);
+    try {
+      await Promise.resolve(card.render(container));
+    } catch (error) {
+      container.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
+      console.error('Card render failed:', name, error);
+    }
+  }
+
+  function initTabs(main){
+    const buttons = Array.from(document.querySelectorAll('.sidebar-tab'));
+    async function activate(name){
+      buttons.forEach(button => {
+        const isActive = button.dataset.tab === name;
+        button.classList.toggle('active', isActive);
+      });
+      if (name) {
+        await renderCard(name, main);
+      }
+    }
+    buttons.forEach(button => {
+      button.addEventListener('click', event => {
+        event.preventDefault();
+        const { tab } = button.dataset || {};
+        if (tab) {
+          activate(tab);
+        }
+      });
+    });
+    return { buttons, activate };
+  }
+
+  document.addEventListener('DOMContentLoaded', async () => {
+    if (!window.API || !window.Dom || !window.Modals || !window.CardBus) {
+      console.error('Bootstrap deps missing');
       return;
     }
 
@@ -141,12 +123,41 @@
       updateLicenseBadge(event.detail);
     });
 
-    bootstrapLicense();
+    let licenseData = null;
+    try {
+      licenseData = await window.API.loadLicense();
+    } catch (error) {
+      console.error('License load failed', error);
+    } finally {
+      window.CardBus.provideDeps({ API: window.API, Dom: window.Dom, Modals: window.Modals });
+    }
 
-    const tabs = initTabs();
-    const defaultTab = Cards.inventory ? 'inventory' : Object.keys(Cards.registry)[0];
-    if (defaultTab) {
-      tabs.activate(defaultTab);
+    if (licenseData) {
+      updateLicenseBadge(licenseData);
+    } else {
+      updateLicenseBadge(null);
+    }
+
+    const main = document.getElementById('main');
+    if (!main) {
+      return;
+    }
+
+    const tabs = initTabs(main);
+
+    const defaultCard = window.CardBus.getCard('inventory');
+    if (defaultCard && typeof defaultCard.render === 'function') {
+      tabs.activate('inventory');
+      return;
+    }
+
+    const available = Object.keys(window.Cards || {}).filter(name => {
+      const card = window.CardBus.getCard(name);
+      return card && typeof card.render === 'function';
+    });
+
+    if (available.length > 0) {
+      tabs.activate(available[0]);
     } else {
       console.warn('No cards registered.');
     }

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -1,53 +1,44 @@
-(function(){
-  function register(){
-    if (!window.API || !window.Dom || !window.Modals) {
-      console.error('Card missing API helpers: dev');
+registerCard('dev', ({ API, Dom }) => {
+  const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
+
+  function init() {}
+
+  async function render(container){
+    if (!container) return;
+    if (!el) {
+      container.textContent = 'UI helpers unavailable.';
       return;
     }
 
-    const { el } = window.Dom;
-    const API = window.API;
+    const title = el('h2', {}, 'Developer Tools');
+    const description = el('div', { class: 'badge-note' }, 'Ping local plugin endpoints for debugging.');
+    const pingButton = el('button', { type: 'button' }, 'Ping Plugin');
+    const output = el('pre', { class: 'status-box', style: { minHeight: '140px' } }, 'Awaiting action.');
 
-    function init() {}
+    pingButton.addEventListener('click', async () => {
+      output.textContent = 'Pinging…';
+      if (!API) {
+        output.textContent = 'API unavailable.';
+        return;
+      }
+      try {
+        const data = await API.get('/dev/ping_plugin');
+        output.textContent = JSON.stringify(data || {}, null, 2);
+      } catch (error) {
+        output.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
+      }
+    });
 
-    async function render(container){
-      if (!container) return;
-
-      const title = el('h2', {}, 'Developer Tools');
-      const description = el('div', { class: 'badge-note' }, 'Ping local plugin endpoints for debugging.');
-      const pingButton = el('button', { type: 'button' }, 'Ping Plugin');
-      const output = el('pre', { class: 'status-box', style: { minHeight: '140px' } }, 'Awaiting action.');
-
-      pingButton.addEventListener('click', async () => {
-        output.textContent = 'Pinging…';
-        try {
-          const data = await API.get('/dev/ping_plugin');
-          output.textContent = JSON.stringify(data || {}, null, 2);
-        } catch (error) {
-          output.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
-        }
-      });
-
-      container.replaceChildren(
-        title,
-        description,
-        el('section', {}, [
-          el('div', { class: 'section-title' }, 'Diagnostics'),
-          el('div', { class: 'actions' }, [pingButton]),
-          output,
-        ]),
-      );
-    }
-
-    const module = { init, render };
-    if (window.Cards && typeof window.Cards.register === 'function') {
-      window.Cards.register('dev', module);
-    }
+    container.replaceChildren(
+      title,
+      description,
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'Diagnostics'),
+        el('div', { class: 'actions' }, [pingButton]),
+        output,
+      ]),
+    );
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', register);
-  } else {
-    register();
-  }
-})();
+  return { init, render };
+});

--- a/core/ui/js/cards/organizer.js
+++ b/core/ui/js/cards/organizer.js
@@ -1,141 +1,135 @@
-(function(){
-  function register(){
-    if (!window.API || !window.Dom || !window.Modals) {
-      console.error('Card missing API helpers: organizer');
+registerCard('organizer', ({ API, Dom, Modals }) => {
+  const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
+
+  function showError(output, error){
+    if (output) {
+      output.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
+    }
+  }
+
+  function init() {}
+
+  async function render(container){
+    if (!container) return;
+    if (!el) {
+      container.textContent = 'UI helpers unavailable.';
       return;
     }
 
-    const { el } = window.Dom;
-    const API = window.API;
-    const Modals = window.Modals;
+    const startInput = el('input', { type: 'text', placeholder: 'Start folder', style: { minWidth: '320px' } });
+    const quarantineInput = el('input', { type: 'text', placeholder: 'Quarantine folder (optional)', style: { minWidth: '320px' } });
+    const duplicatesButton = el('button', { type: 'button' }, 'Duplicates -> Plan');
+    const renameButton = el('button', { type: 'button' }, 'Normalize -> Plan');
+    const planInput = el('input', { type: 'text', placeholder: 'Plan ID', style: { minWidth: '320px' } });
+    const previewButton = el('button', { type: 'button', class: 'secondary' }, 'Preview Plan');
+    const commitButton = el('button', { type: 'button' }, 'Commit Plan');
+    const status = el('pre', { class: 'status-box', style: { minHeight: '180px' } }, 'Awaiting action.');
 
-    function showError(output, error){
-      output.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
+    async function withStatus(task){
+      status.textContent = 'Working…';
+      try {
+        const result = await task();
+        status.textContent = JSON.stringify(result || {}, null, 2);
+        return result;
+      } catch (error) {
+        showError(status, error);
+        throw error;
+      }
     }
 
-    function init() {}
-
-    async function render(container){
-      if (!container) return;
-
-      const startInput = el('input', { type: 'text', placeholder: 'Start folder', style: { minWidth: '320px' } });
-      const quarantineInput = el('input', { type: 'text', placeholder: 'Quarantine folder (optional)', style: { minWidth: '320px' } });
-      const duplicatesButton = el('button', { type: 'button' }, 'Duplicates -> Plan');
-      const renameButton = el('button', { type: 'button' }, 'Normalize -> Plan');
-      const planInput = el('input', { type: 'text', placeholder: 'Plan ID', style: { minWidth: '320px' } });
-      const previewButton = el('button', { type: 'button', class: 'secondary' }, 'Preview Plan');
-      const commitButton = el('button', { type: 'button' }, 'Commit Plan');
-      const status = el('pre', { class: 'status-box', style: { minHeight: '180px' } }, 'Awaiting action.');
-
-      async function withStatus(task){
-        status.textContent = 'Working…';
-        try {
-          const result = await task();
-          status.textContent = JSON.stringify(result || {}, null, 2);
-          return result;
-        } catch (error) {
-          showError(status, error);
-          throw error;
+    duplicatesButton.addEventListener('click', async () => {
+      const startPath = startInput.value.trim();
+      if (!startPath) {
+        if (Modals && typeof Modals.alert === 'function') {
+          Modals.alert('Organizer', 'Provide a start folder.');
         }
+        return;
       }
+      try {
+        const result = await withStatus(() => API.post('/organizer/duplicates/plan', {
+          start_path: startPath,
+          quarantine_dir: quarantineInput.value.trim() || null,
+        }));
+        if (result && result.plan_id) {
+          planInput.value = result.plan_id;
+        }
+      } catch (error) {
+        // handled by withStatus
+      }
+    });
 
-      duplicatesButton.addEventListener('click', async () => {
-        const startPath = startInput.value.trim();
-        if (!startPath) {
+    renameButton.addEventListener('click', async () => {
+      const startPath = startInput.value.trim();
+      if (!startPath) {
+        if (Modals && typeof Modals.alert === 'function') {
           Modals.alert('Organizer', 'Provide a start folder.');
-          return;
         }
-        try {
-          const result = await withStatus(() => API.post('/organizer/duplicates/plan', {
-            start_path: startPath,
-            quarantine_dir: quarantineInput.value.trim() || null,
-          }));
-          if (result && result.plan_id) {
-            planInput.value = result.plan_id;
-          }
-        } catch (error) {
-          // handled by withStatus
+        return;
+      }
+      try {
+        const result = await withStatus(() => API.post('/organizer/rename/plan', {
+          start_path: startPath,
+        }));
+        if (result && result.plan_id) {
+          planInput.value = result.plan_id;
         }
-      });
+      } catch (error) {
+        // handled by withStatus
+      }
+    });
 
-      renameButton.addEventListener('click', async () => {
-        const startPath = startInput.value.trim();
-        if (!startPath) {
-          Modals.alert('Organizer', 'Provide a start folder.');
-          return;
-        }
-        try {
-          const result = await withStatus(() => API.post('/organizer/rename/plan', {
-            start_path: startPath,
-          }));
-          if (result && result.plan_id) {
-            planInput.value = result.plan_id;
-          }
-        } catch (error) {
-          // handled by withStatus
-        }
-      });
-
-      function ensurePlanId(){
-        const value = planInput.value.trim();
-        if (!value) {
+    function ensurePlanId(){
+      const value = planInput.value.trim();
+      if (!value) {
+        if (Modals && typeof Modals.alert === 'function') {
           Modals.alert('Organizer', 'Set a plan ID before continuing.');
-          return null;
         }
-        return value;
+        return null;
       }
-
-      previewButton.addEventListener('click', async () => {
-        const planId = ensurePlanId();
-        if (!planId) return;
-        try {
-          await withStatus(() => API.post(`/plans/${encodeURIComponent(planId)}/preview`, {}));
-        } catch (error) {
-          // handled by withStatus
-        }
-      });
-
-      commitButton.addEventListener('click', async () => {
-        const planId = ensurePlanId();
-        if (!planId) return;
-        try {
-          await withStatus(() => API.post(`/plans/${encodeURIComponent(planId)}/commit`, {}));
-        } catch (error) {
-          // handled by withStatus
-        }
-      });
-
-      container.replaceChildren(
-        el('h2', {}, 'Organizer'),
-        el('div', { class: 'badge-note' }, 'Create, preview, and commit organizer plans.'),
-        el('section', {}, [
-          el('div', { class: 'section-title' }, 'Create plan'),
-          el('div', { class: 'form-grid' }, [
-            el('label', {}, ['Start folder', startInput]),
-            el('label', {}, ['Quarantine folder', quarantineInput]),
-          ]),
-          el('div', { class: 'actions' }, [duplicatesButton, renameButton]),
-        ]),
-        el('section', {}, [
-          el('div', { class: 'section-title' }, 'Manage plan'),
-          el('div', { class: 'form-grid' }, [
-            el('label', {}, ['Plan ID', planInput]),
-          ]),
-          el('div', { class: 'actions' }, [previewButton, commitButton]),
-        ]),
-        status,
-      );
+      return value;
     }
 
-    const module = { init, render };
-    if (window.Cards && typeof window.Cards.register === 'function') {
-      window.Cards.register('organizer', module);
-    }
+    previewButton.addEventListener('click', async () => {
+      const planId = ensurePlanId();
+      if (!planId) return;
+      try {
+        await withStatus(() => API.post(`/plans/${encodeURIComponent(planId)}/preview`, {}));
+      } catch (error) {
+        // handled by withStatus
+      }
+    });
+
+    commitButton.addEventListener('click', async () => {
+      const planId = ensurePlanId();
+      if (!planId) return;
+      try {
+        await withStatus(() => API.post(`/plans/${encodeURIComponent(planId)}/commit`, {}));
+      } catch (error) {
+        // handled by withStatus
+      }
+    });
+
+    container.replaceChildren(
+      el('h2', {}, 'Organizer'),
+      el('div', { class: 'badge-note' }, 'Create, preview, and commit organizer plans.'),
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'Create plan'),
+        el('div', { class: 'form-grid' }, [
+          el('label', {}, ['Start folder', startInput]),
+          el('label', {}, ['Quarantine folder', quarantineInput]),
+        ]),
+        el('div', { class: 'actions' }, [duplicatesButton, renameButton]),
+      ]),
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'Manage plan'),
+        el('div', { class: 'form-grid' }, [
+          el('label', {}, ['Plan ID', planInput]),
+        ]),
+        el('div', { class: 'actions' }, [previewButton, commitButton]),
+      ]),
+      status,
+    );
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', register);
-  } else {
-    register();
-  }
-})();
+  return { init, render };
+});

--- a/core/ui/js/cards/writes.js
+++ b/core/ui/js/cards/writes.js
@@ -1,116 +1,103 @@
-(function(){
-  function register(){
-    if (!window.API || !window.Dom || !window.Modals) {
-      console.error('Card missing API helpers: writes');
+registerCard('writes', ({ API, Dom }) => {
+  const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
+
+  async function fetchState(statusNode, toggle){
+    if (!statusNode || !API) return;
+    statusNode.textContent = 'Loading…';
+    try {
+      const data = await API.get('/dev/writes');
+      if (toggle) {
+        toggle.checked = Boolean(data && data.enabled);
+      }
+      statusNode.textContent = JSON.stringify(data || {}, null, 2);
+    } catch (error) {
+      statusNode.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
+    }
+  }
+
+  async function updateState(enabled, statusNode, toggle){
+    if (!statusNode || !API) {
+      return;
+    }
+    statusNode.textContent = 'Updating…';
+    try {
+      const data = await API.post('/dev/writes', { enabled });
+      statusNode.textContent = JSON.stringify(data || {}, null, 2);
+      const headerToggle = document.getElementById('writes-toggle');
+      if (headerToggle) {
+        headerToggle.checked = enabled;
+        headerToggle.dispatchEvent(new Event('change'));
+      } else {
+        document.dispatchEvent(new CustomEvent('writes:changed', { detail: { enabled } }));
+      }
+    } catch (error) {
+      statusNode.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
+      if (toggle) {
+        toggle.checked = !enabled;
+      }
+    } finally {
+      await fetchState(statusNode, toggle);
+    }
+  }
+
+  function init() {}
+
+  async function render(container){
+    if (!container) return;
+    if (!el) {
+      container.textContent = 'UI helpers unavailable.';
       return;
     }
 
-    const { el } = window.Dom;
-    const API = window.API;
+    const title = el('h2', {}, 'Writes Control');
+    const description = el('div', { class: 'badge-note' }, 'Toggle local API writes for diagnostics and development.');
+    const toggle = el('input', { type: 'checkbox', id: 'writes-card-toggle' });
+    const toggleLabel = el('label', { class: 'writes-card-toggle', for: 'writes-card-toggle' }, [
+      toggle,
+      el('span', { class: 'toggle-label' }, 'Enable writes via API'),
+    ]);
+    const refreshButton = el('button', { type: 'button', class: 'secondary' }, 'Refresh State');
+    const status = el('pre', { class: 'status-box', style: { minHeight: '160px' } }, 'Loading…');
 
-    async function fetchState(statusNode, toggle){
-      if (!statusNode) return;
-      statusNode.textContent = 'Loading…';
-      try {
-        const data = await API.get('/dev/writes');
-        if (toggle) {
-          toggle.checked = Boolean(data && data.enabled);
-        }
-        statusNode.textContent = JSON.stringify(data || {}, null, 2);
-      } catch (error) {
-        statusNode.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
-      }
-    }
-
-    async function updateState(enabled, statusNode, toggle){
-      if (!statusNode) {
+    const headerSync = event => {
+      if (!event || !event.detail || toggle.dataset.pending === 'true') {
         return;
       }
-      statusNode.textContent = 'Updating…';
-      try {
-        const data = await API.post('/dev/writes', { enabled });
-        statusNode.textContent = JSON.stringify(data || {}, null, 2);
-        const headerToggle = document.getElementById('writes-toggle');
-        if (headerToggle) {
-          headerToggle.checked = enabled;
-          headerToggle.dispatchEvent(new Event('change'));
-        } else {
-          document.dispatchEvent(new CustomEvent('writes:changed', { detail: { enabled } }));
-        }
-      } catch (error) {
-        statusNode.textContent = 'Error: ' + (error && error.message ? error.message : String(error));
-        if (toggle) {
-          toggle.checked = !enabled;
-        }
-      } finally {
-        await fetchState(statusNode, toggle);
+      toggle.checked = Boolean(event.detail.enabled);
+    };
+
+    refreshButton.addEventListener('click', () => fetchState(status, toggle));
+    toggle.addEventListener('change', () => {
+      toggle.dataset.pending = 'true';
+      updateState(toggle.checked, status, toggle).finally(() => {
+        toggle.dataset.pending = 'false';
+      });
+    });
+
+    document.addEventListener('writes:changed', headerSync);
+
+    container.replaceChildren(
+      title,
+      description,
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'Control'),
+        toggleLabel,
+        el('div', { class: 'actions' }, [refreshButton]),
+      ]),
+      el('section', {}, [
+        el('div', { class: 'section-title' }, 'State'),
+        status,
+      ]),
+    );
+
+    await fetchState(status, toggle);
+
+    container.addEventListener('DOMNodeRemoved', event => {
+      if (event.target === container) {
+        document.removeEventListener('writes:changed', headerSync);
       }
-    }
-
-    function init() {}
-
-    async function render(container){
-      if (!container) return;
-
-      const title = el('h2', {}, 'Writes Control');
-      const description = el('div', { class: 'badge-note' }, 'Toggle local API writes for diagnostics and development.');
-      const toggle = el('input', { type: 'checkbox', id: 'writes-card-toggle' });
-      const toggleLabel = el('label', { class: 'writes-card-toggle', for: 'writes-card-toggle' }, [
-        toggle,
-        el('span', { class: 'toggle-label' }, 'Enable writes via API'),
-      ]);
-      const refreshButton = el('button', { type: 'button', class: 'secondary' }, 'Refresh State');
-      const status = el('pre', { class: 'status-box', style: { minHeight: '160px' } }, 'Loading…');
-
-      const headerSync = event => {
-        if (!event || !event.detail || toggle.dataset.pending === 'true') {
-          return;
-        }
-        toggle.checked = Boolean(event.detail.enabled);
-      };
-
-      refreshButton.addEventListener('click', () => fetchState(status, toggle));
-      toggle.addEventListener('change', () => {
-        toggle.dataset.pending = 'true';
-        updateState(toggle.checked, status, toggle).finally(() => {
-          toggle.dataset.pending = 'false';
-        });
-      });
-
-      document.addEventListener('writes:changed', headerSync);
-
-      container.replaceChildren(
-        title,
-        description,
-        el('section', {}, [
-          el('div', { class: 'section-title' }, 'Control'),
-          toggleLabel,
-          el('div', { class: 'actions' }, [refreshButton]),
-        ]),
-        el('section', {}, [
-          el('div', { class: 'section-title' }, 'State'),
-          status,
-        ]),
-      );
-
-      await fetchState(status, toggle);
-
-      container.addEventListener('DOMNodeRemoved', event => {
-        if (event.target === container) {
-          document.removeEventListener('writes:changed', headerSync);
-        }
-      });
-    }
-
-    const module = { init, render };
-    if (window.Cards && typeof window.Cards.register === 'function') {
-      window.Cards.register('writes', module);
-    }
+    });
   }
 
-  if (document.readyState === 'loading') {
-    document.addEventListener('DOMContentLoaded', register);
-  } else {
-    register();
-  }
-})();
+  return { init, render };
+});

--- a/core/ui/js/runtime.js
+++ b/core/ui/js/runtime.js
@@ -1,0 +1,30 @@
+(function () {
+  const state = {
+    deps: null,
+    queue: [],
+    cards: {}
+  };
+  function ready() { return !!state.deps; }
+  function provideDeps(deps) {
+    if (state.deps) return;
+    state.deps = deps;
+    // Drain queue
+    for (const [name, factory] of state.queue) {
+      state.cards[name] = factory(state.deps);
+    }
+    state.queue.length = 0;
+    window.Cards = state.cards;
+  }
+  function registerCard(name, factory) {
+    if (!name || typeof factory !== 'function') return;
+    if (ready()) {
+      state.cards[name] = factory(state.deps);
+      window.Cards = state.cards;
+    } else {
+      state.queue.push([name, factory]);
+    }
+  }
+  function getCard(name) { return state.cards[name]; }
+  window.CardBus = { provideDeps, registerCard, getCard };
+  window.registerCard = registerCard; // convenience for cards
+})();

--- a/core/ui/js/ui/dom.js
+++ b/core/ui/js/ui/dom.js
@@ -92,7 +92,9 @@
     return { refresh };
   }
 
-  window.Dom = { $, el, bindDisabledWithProGate };
+  const helpers = { $, el, bindDisabledWithProGate };
+  window.Dom = window.Dom || helpers;
+  Object.assign(window.Dom, helpers);
   // Maintain backwards compatibility with any legacy code paths that still
   // reference the old uppercase namespace.
   window.DOM = window.Dom;

--- a/core/ui/js/ui/modals.js
+++ b/core/ui/js/ui/modals.js
@@ -102,5 +102,6 @@
     close,
   };
 
-  window.Modals = Modals;
+  window.Modals = window.Modals || {};
+  Object.assign(window.Modals, Modals);
 })();

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -43,19 +43,22 @@
     </div>
   </div>
   <div id="modal-root"></div>
-  <script src="js/api.js"></script>
-  <script src="js/ui/dom.js"></script>
-  <script src="js/ui/modals.js"></script>
-  <script src="js/app.js"></script>
-  <script src="js/cards/inventory.js"></script>
-  <script src="js/cards/vendors.js"></script>
-  <script src="js/cards/manufacturing.js"></script>
-  <script src="js/cards/tasks.js"></script>
-  <script src="js/cards/backup.js"></script>
-  <script src="js/cards/settings.js"></script>
-  <script src="js/cards/rfq.js"></script>
-  <script src="js/cards/writes.js"></script>
-  <script src="js/cards/organizer.js"></script>
-  <script src="js/cards/dev.js"></script>
+  <script src="ui/js/runtime.js"></script>
+  <script src="ui/js/api.js"></script>
+  <script src="ui/js/ui/dom.js"></script>
+  <script src="ui/js/ui/modals.js"></script>
+  <script src="ui/js/app.js"></script>
+
+  <!-- cards -->
+  <script src="ui/js/cards/inventory.js"></script>
+  <script src="ui/js/cards/vendors.js"></script>
+  <script src="ui/js/cards/manufacturing.js"></script>
+  <script src="ui/js/cards/tasks.js"></script>
+  <script src="ui/js/cards/backup.js"></script>
+  <script src="ui/js/cards/settings.js"></script>
+  <script src="ui/js/cards/rfq.js"></script>
+  <script src="ui/js/cards/writes.js"></script>
+  <script src="ui/js/cards/organizer.js"></script>
+  <script src="ui/js/cards/dev.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a runtime card bus that queues registrations until dependencies are provided
- bootstrap the dashboard on DOMContentLoaded, wire helper dependencies once, and update writes/organizer/dev cards to use the bus
- expose UI helpers on window, reorder shell scripts to load helpers before cards, and preserve the SVG favicon

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68fd7fe274088322bd906b25f0889b67