### PR TITLE
Ensure registerCard shim loads before cards

### DIFF
--- a/core/ui/js/app.js
+++ b/core/ui/js/app.js
@@ -99,8 +99,9 @@
   }
 
   document.addEventListener('DOMContentLoaded', async () => {
+    __diag && __diag.log('app DOMContentLoaded');
     if (!window.API || !window.Dom || !window.Modals || !window.CardBus) {
-      console.error('Bootstrap deps missing');
+      console.error('deps missing');
       return;
     }
 
@@ -126,8 +127,9 @@
     let licenseData = null;
     try {
       licenseData = await window.API.loadLicense();
+      __diag && __diag.log('license loaded');
     } catch (error) {
-      console.error('License load failed', error);
+      console.error(error);
     }
 
     CardBus.provideDeps({ API: window.API, Dom: window.Dom, Modals: window.Modals });

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -1,4 +1,5 @@
-registerCard('dev', ({ API, Dom }) => {
+(window.registerCard || function(){ console.error('registerCard shim missing at load'); })
+('dev', function ({ API, Dom, Modals }) {
   const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
 
   function init() {}

--- a/core/ui/js/cards/organizer.js
+++ b/core/ui/js/cards/organizer.js
@@ -1,4 +1,5 @@
-registerCard('organizer', ({ API, Dom, Modals }) => {
+(window.registerCard || function(){ console.error('registerCard shim missing at load'); })
+('organizer', function ({ API, Dom, Modals }) {
   const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
 
   function showError(output, error){

--- a/core/ui/js/cards/writes.js
+++ b/core/ui/js/cards/writes.js
@@ -1,4 +1,5 @@
-registerCard('writes', ({ API, Dom }) => {
+(window.registerCard || function(){ console.error('registerCard shim missing at load'); })
+('writes', function ({ API, Dom, Modals }) {
   const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
 
   async function fetchState(statusNode, toggle){

--- a/core/ui/js/runtime.js
+++ b/core/ui/js/runtime.js
@@ -3,22 +3,19 @@
   function provideDeps(deps) {
     if (state.deps) return;
     state.deps = deps;
-    // Replace shim with real registerCard
+    __diag && __diag.log('runtime.provideDeps');
     window.registerCard = function (name, factory) {
       if (!name || typeof factory !== 'function') return;
+      __diag && __diag.log('runtime.registerCard: ' + name);
       state.cards[name] = factory(state.deps);
       window.Cards = state.cards;
     };
-    // Drain any queued cards from shim
     var q = window.__cardQueue || [];
-    for (var i = 0; i < q.length; i++) {
-      var pair = q[i];
-      try { window.registerCard(pair[0], pair[1]); } catch (e) { console.error('Card init failed:', pair[0], e); }
-    }
-    // Clear queue reference
+    __diag && __diag.log('runtime.drain size=' + q.length);
+    for (var i = 0; i < q.length; i++) { try { window.registerCard(q[i][0], q[i][1]); } catch(e){ console.error('Card init failed:', q[i][0], e); } }
     window.__cardQueue = [];
-    window.Cards = state.cards;
   }
-  function getCard(name) { return state.cards[name]; }
+  function getCard(name){ return state.cards[name]; }
   window.CardBus = { provideDeps: provideDeps, getCard: getCard };
+  __diag && __diag.log('runtime loaded');
 })();

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -8,10 +8,12 @@
   <link rel="alternate icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect x='6' y='6' width='52' height='52' rx='10' ry='10' fill='%23111'/%3E%3Cpath d='M18 40h12V24H18v16zm16 0h12V18H34v22z' fill='%23fff'/%3E%3C/svg%3E">
   <link rel="stylesheet" href="css/app.css">
   <script>
-    // Card queue shim so registerCard always exists
-    (function () {
+    (function(){
+      window.__diag = { log:(m)=>console.log('[DIAG]', m) };
+      __diag.log('HEAD: start');
       var q = (window.__cardQueue = window.__cardQueue || []);
-      window.registerCard = function (name, factory) { q.push([name, factory]); };
+      window.registerCard = function(name,factory){ q.push([name,factory]); __diag.log('shim queued: '+name); };
+      __diag.log('HEAD: shim installed');
     })();
   </script>
   <script src="js/token.js" defer></script>
@@ -50,13 +52,23 @@
     </div>
   </div>
   <div id="modal-root"></div>
+  <script>__diag.log('BODY: before runtime');</script>
   <script src="ui/js/runtime.js"></script>
-  <script src="ui/js/api.js"></script>
-  <script src="ui/js/ui/dom.js"></script>
-  <script src="ui/js/ui/modals.js"></script>
-  <script src="ui/js/app.js"></script>
+  <script>__diag.log('BODY: after runtime');</script>
 
-  <!-- cards -->
+  <script src="ui/js/api.js"></script>
+  <script>__diag.log('BODY: after api');</script>
+
+  <script src="ui/js/ui/dom.js"></script>
+  <script>__diag.log('BODY: after dom');</script>
+
+  <script src="ui/js/ui/modals.js"></script>
+  <script>__diag.log('BODY: after modals');</script>
+
+  <script src="ui/js/app.js"></script>
+  <script>__diag.log('BODY: after app');</script>
+
+  <!-- cards: no defer/async -->
   <script src="ui/js/cards/inventory.js"></script>
   <script src="ui/js/cards/vendors.js"></script>
   <script src="ui/js/cards/manufacturing.js"></script>
@@ -67,5 +79,6 @@
   <script src="ui/js/cards/writes.js"></script>
   <script src="ui/js/cards/organizer.js"></script>
   <script src="ui/js/cards/dev.js"></script>
+  <script>__diag.log('BODY: after cards');</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a diagnostic shim in the shell to guarantee registerCard exists before any card scripts execute
- update the runtime to drain queued cards with diagnostics and guard card modules against missing shims
- log application bootstrap order and provide CardBus dependencies after DOM ready

## Testing
- Not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fd98b0a310832292c1230550bb2abe