### PR TITLE
Install UI prelude to stabilize card registration

### DIFF
--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -1,5 +1,4 @@
-(window.registerCard || function(){ console.error('registerCard shim missing at load'); })
-('dev', function ({ API, Dom, Modals }) {
+registerCard('dev', function ({ API, Dom, Modals }) {
   const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
 
   function init() {}

--- a/core/ui/js/cards/organizer.js
+++ b/core/ui/js/cards/organizer.js
@@ -1,5 +1,4 @@
-(window.registerCard || function(){ console.error('registerCard shim missing at load'); })
-('organizer', function ({ API, Dom, Modals }) {
+registerCard('organizer', function ({ API, Dom, Modals }) {
   const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
 
   function showError(output, error){

--- a/core/ui/js/cards/writes.js
+++ b/core/ui/js/cards/writes.js
@@ -1,5 +1,4 @@
-(window.registerCard || function(){ console.error('registerCard shim missing at load'); })
-('writes', function ({ API, Dom, Modals }) {
+registerCard('writes', function ({ API, Dom, Modals }) {
   const el = Dom && typeof Dom.el === 'function' ? Dom.el : null;
 
   async function fetchState(statusNode, toggle){

--- a/core/ui/js/prelude.js
+++ b/core/ui/js/prelude.js
@@ -1,0 +1,12 @@
+// prelude.js — must load before any card
+(function () {
+  if (!window.__cardQueue) window.__cardQueue = [];
+  if (typeof window.registerCard !== 'function') {
+    window.registerCard = function (name, factory) {
+      window.__cardQueue.push([name, factory]);
+      if (window.__diag) console.log('[DIAG] prelude queued:', name);
+    };
+  }
+  if (!window.__diag) window.__diag = { log: m => console.log('[DIAG]', m) };
+  window.__diag.log('prelude installed');
+})();

--- a/core/ui/js/runtime.js
+++ b/core/ui/js/runtime.js
@@ -4,18 +4,24 @@
     if (state.deps) return;
     state.deps = deps;
     __diag && __diag.log('runtime.provideDeps');
+
+    // Replace prelude registerCard
     window.registerCard = function (name, factory) {
       if (!name || typeof factory !== 'function') return;
       __diag && __diag.log('runtime.registerCard: ' + name);
       state.cards[name] = factory(state.deps);
       window.Cards = state.cards;
     };
+
     var q = window.__cardQueue || [];
     __diag && __diag.log('runtime.drain size=' + q.length);
-    for (var i = 0; i < q.length; i++) { try { window.registerCard(q[i][0], q[i][1]); } catch(e){ console.error('Card init failed:', q[i][0], e); } }
+    for (var i = 0; i < q.length; i++) {
+      try { window.registerCard(q[i][0], q[i][1]); }
+      catch (e) { console.error('Card init failed:', q[i][0], e); }
+    }
     window.__cardQueue = [];
   }
-  function getCard(name){ return state.cards[name]; }
+  function getCard(name) { return state.cards[name]; }
   window.CardBus = { provideDeps: provideDeps, getCard: getCard };
   __diag && __diag.log('runtime loaded');
 })();

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -7,16 +7,8 @@
   <link rel="icon" type="image/svg+xml" href="favicon.svg">
   <link rel="alternate icon" href="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 64 64'%3E%3Crect x='6' y='6' width='52' height='52' rx='10' ry='10' fill='%23111'/%3E%3Cpath d='M18 40h12V24H18v16zm16 0h12V18H34v22z' fill='%23fff'/%3E%3C/svg%3E">
   <link rel="stylesheet" href="css/app.css">
-  <script>
-    (function(){
-      window.__diag = { log:(m)=>console.log('[DIAG]', m) };
-      __diag.log('HEAD: start');
-      var q = (window.__cardQueue = window.__cardQueue || []);
-      window.registerCard = function(name,factory){ q.push([name,factory]); __diag.log('shim queued: '+name); };
-      __diag.log('HEAD: shim installed');
-    })();
-  </script>
-  <script src="js/token.js" defer></script>
+  <script src="ui/js/prelude.js"></script>
+  <script src="js/token.js"></script>
 </head>
 <body>
   <div class="app-shell">
@@ -52,23 +44,13 @@
     </div>
   </div>
   <div id="modal-root"></div>
-  <script>__diag.log('BODY: before runtime');</script>
   <script src="ui/js/runtime.js"></script>
-  <script>__diag.log('BODY: after runtime');</script>
-
   <script src="ui/js/api.js"></script>
-  <script>__diag.log('BODY: after api');</script>
-
   <script src="ui/js/ui/dom.js"></script>
-  <script>__diag.log('BODY: after dom');</script>
-
   <script src="ui/js/ui/modals.js"></script>
-  <script>__diag.log('BODY: after modals');</script>
-
   <script src="ui/js/app.js"></script>
-  <script>__diag.log('BODY: after app');</script>
 
-  <!-- cards: no defer/async -->
+  <!-- cards -->
   <script src="ui/js/cards/inventory.js"></script>
   <script src="ui/js/cards/vendors.js"></script>
   <script src="ui/js/cards/manufacturing.js"></script>
@@ -79,6 +61,5 @@
   <script src="ui/js/cards/writes.js"></script>
   <script src="ui/js/cards/organizer.js"></script>
   <script src="ui/js/cards/dev.js"></script>
-  <script>__diag.log('BODY: after cards');</script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- add a prelude script that defines window.registerCard before any cards execute and initializes diagnostics
- update the runtime to adopt the queued registrations and expose logs while draining the queue
- load UI scripts in deterministic order without defer/async and remove shim wrappers from the writes, organizer, and dev cards

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fd9a06a5ac832296f5df329ee50f89