### PR TITLE
Fix UI entry script path and expose license endpoint

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -345,8 +345,9 @@ def dev_set_writes(body: WritesBody):
     return {"enabled": get_writes_enabled()}
 
 
-@protected.get("/dev/license")
-def dev_get_license_info():
+@APP.get("/dev/license")
+def dev_get_license_info(request: Request):
+    require_token(request)
     return get_license()
 
 

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -36,6 +36,6 @@
   </div>
   <div id="modal-root"></div>
   <script type="module" src="/ui/js/token.js"></script>
-  <script type="module" src="/ui/js/app.js"></script>
+  <script type="module" src="/ui/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- point shell.html at the existing /ui/app.js ESM entry so the UI loads correctly
- register /dev/license on the main FastAPI app while enforcing the existing session-token check

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_68fe28e0bd388322a72c8468e11453d1