### PR TITLE
fix(ui): enforce ESM entry via shell.html, redirect legacy index.html

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -190,6 +190,13 @@ except Exception as e:  # pragma: no cover - best effort logging
     print(f"[ui] mount failed: {e}")
 
 
+@APP.get("/ui", include_in_schema=False)
+@APP.get("/ui/", include_in_schema=False)
+@APP.get("/ui/index.html", include_in_schema=False)
+def ui_redirect():
+    return RedirectResponse(url="/ui/shell.html", status_code=307)
+
+
 @APP.middleware("http")
 async def ui_nocache_headers(request: Request, call_next):
     response = await call_next(request)

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -6,9 +6,8 @@
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="stylesheet" href="/ui/css/app.css">
   <style>
-    :root { --bg: #1a1a1a; --fg: #eee; --accent: #0066cc; --sidebar: #222; }
-    * { box-sizing: border-box; }
-    body { margin:0; font:14px/1.5 system-ui; background:var(--bg); color:var(--fg); display:flex; height:100vh; }
+    :root { --bg:#1a1a1a; --fg:#eee; --accent:#0066cc; --sidebar:#222; }
+    * { box-sizing: border-box; } body { margin:0; font:14px/1.5 system-ui; background:var(--bg); color:var(--fg); display:flex; height:100vh; }
     #sidebar { width:200px; background:var(--sidebar); padding:16px 0; border-right:1px solid #333; }
     #sidebar h1 { margin:0 0 20px 16px; font-size:16px; color:#aaa; }
     .tab { padding:10px 16px; cursor:pointer; border-left:4px solid transparent; }
@@ -17,8 +16,7 @@
     #main { flex:1; padding:20px; overflow:auto; }
     .card { background:#242424; padding:16px; border-radius:8px; margin-bottom:16px; }
     .card h2 { margin-top:0; color:var(--accent); }
-    button { background:var(--accent); color:white; border:none; padding:8px 12px; border-radius:4px; cursor:pointer; }
-    button:hover { opacity:0.9; }
+    button { background:var(--accent); color:#fff; border:0; padding:8px 12px; border-radius:4px; cursor:pointer; }
     pre { background:#111; padding:12px; border-radius:4px; overflow:auto; font-size:13px; }
   </style>
 </head>
@@ -29,9 +27,7 @@
     <div class="tab" data-tab="tools">Tools</div>
     <div class="tab" data-tab="dev">Dev</div>
   </nav>
-  <main id="main">
-    <div id="app"></div>
-  </main>
+  <main id="main"><div id="app"></div></main>
   <script type="module" src="/ui/app.js"></script>
 </body>
 </html>

--- a/scripts/smoke_ui.ps1
+++ b/scripts/smoke_ui.ps1
@@ -1,0 +1,12 @@
+$ErrorActionPreference = "Stop"
+$base = "http://127.0.0.1:8765"
+# token check
+$token = (Invoke-WebRequest -UseBasicParsing -Method GET "$base/health").Headers["X-Session-Token"]
+Write-Host "Token header present: " ([bool]$token)
+# shell entry 200
+$r = Invoke-WebRequest -UseBasicParsing "$base/ui/shell.html"
+if ($r.StatusCode -ne 200) { throw "shell.html not served" }
+# app.js loads as module
+$r2 = Invoke-WebRequest -UseBasicParsing "$base/ui/app.js"
+if (-not $r2.Content.Contains("export ") -and -not $r2.Content.Contains("import ")) { throw "app.js not ESM" }
+Write-Host "Smoke OK"


### PR DESCRIPTION
Prevents legacy page from loading; launcher renames legacy index and opens /ui/shell.html; FastAPI redirects /ui* → shell; no schema or API changes; ESM-only; passes smoke.

------
https://chatgpt.com/codex/tasks/task_e_68fe80836e048322ac8a46b66c49dbe8