### PR TITLE
ui(entry): enforce shell.html; redirect legacy /ui routes

### DIFF
--- a/core/ui/index.html
+++ b/core/ui/index.html
@@ -1,0 +1,1 @@
+<!doctype html><meta http-equiv="refresh" content="0; url=/ui/shell.html">

--- a/scripts/launch_buscore.ps1
+++ b/scripts/launch_buscore.ps1
@@ -77,31 +77,31 @@ try {
     }
 
     # --- enforce ESM entry and logging ---
-    $AppRoot    = Join-Path $env:LOCALAPPDATA "BUSCore\app\business_project-main"
-    $UiDir      = if ($env:BUS_UI_DIR) { $env:BUS_UI_DIR } else { $uiTarget }
-    $IndexHtml  = Join-Path $UiDir "index.html"
-    $LegacyHtml = Join-Path $UiDir "index_legacy.html"
-    $ShellHtml  = Join-Path $UiDir "shell.html"
+    $AppRoot = $appRoot
+    $UiDir   = if ($env:BUS_UI_DIR) { $env:BUS_UI_DIR } else { (Join-Path $AppRoot "core\ui") }
+    $Index   = Join-Path $UiDir "index.html"
+    $Shell   = Join-Path $UiDir "shell.html"
 
-    Write-Host "Serving UI from: $UiDir"
-    if (Test-Path $IndexHtml) {
+    Write-Host "[ui] Serving UI from: $UiDir"
+
+    if (Test-Path $Index) {
       try {
-        Rename-Item -Path $IndexHtml -NewName "index_legacy.html" -Force
-        Write-Host "Renamed legacy index.html → index_legacy.html"
+        Rename-Item -Path $Index -NewName "index_legacy.html" -Force
+        Write-Host "[ui] Archived legacy entry: index.html → index_legacy.html"
       } catch {
-        Write-Host "Rename failed or already renamed: $($_.Exception.Message)"
+        Write-Host "[ui] Archive skipped: $($_.Exception.Message)"
       }
     }
 
-    if (-not (Test-Path $ShellHtml)) {
-      Write-Error "Missing shell.html in $UiDir. Aborting to avoid serving legacy UI."
+    if (-not (Test-Path $Shell)) {
+      Write-Error "[ui] Missing shell.html in $UiDir. Aborting to avoid serving legacy UI."
       exit 1
     }
 
     $env:BUS_UI_DIR = $UiDir
     $EntryUrl = "http://127.0.0.1:8765/ui/shell.html"
-    Write-Host "Entry: shell.html → $EntryUrl"
-    # Start uvicorn if not running (preserve your existing start logic)
+    Write-Host "[ui] Entry enforced: /ui/shell.html"
+    Write-Host "[ui] Opening: $EntryUrl"
     # --- end enforce ---
 
     $uvicornCmd = "& `"$venvPython`" -m uvicorn app:app --host 127.0.0.1 --port 8765 --reload --log-level info"


### PR DESCRIPTION
## Summary
- enforce opening the UI through /ui/shell.html in the Windows launcher, archiving any legacy index.html fallback
- add a lightweight index.html stub that redirects to shell.html to guard against regenerated legacy entries

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68fe9a18ae288322bbecbebc350f455e