### PR TITLE
ui(shell): ESM-only entry (shell.html)

### DIFF
--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -1,33 +1,13 @@
-<!doctype html>
+<!DOCTYPE html>
 <html lang="en">
 <head>
-  <meta charset="utf-8">
+  <meta charset="UTF-8" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0"/>
   <title>BUS Core</title>
-  <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="stylesheet" href="/ui/css/app.css">
-  <style>
-    :root { --bg:#1a1a1a; --fg:#eee; --accent:#0066cc; --sidebar:#222; }
-    * { box-sizing: border-box; } body { margin:0; font:14px/1.5 system-ui; background:var(--bg); color:var(--fg); display:flex; height:100vh; }
-    #sidebar { width:200px; background:var(--sidebar); padding:16px 0; border-right:1px solid #333; }
-    #sidebar h1 { margin:0 0 20px 16px; font-size:16px; color:#aaa; }
-    .tab { padding:10px 16px; cursor:pointer; border-left:4px solid transparent; }
-    .tab.active { background:#333; border-left-color:var(--accent); font-weight:bold; }
-    .tab:hover:not(.active) { background:#2a2a2a; }
-    #main { flex:1; padding:20px; overflow:auto; }
-    .card { background:#242424; padding:16px; border-radius:8px; margin-bottom:16px; }
-    .card h2 { margin-top:0; color:var(--accent); }
-    button { background:var(--accent); color:#fff; border:0; padding:8px 12px; border-radius:4px; cursor:pointer; }
-    pre { background:#111; padding:12px; border-radius:4px; overflow:auto; font-size:13px; }
-  </style>
+  <link rel="stylesheet" href="/ui/css/app.css" />
 </head>
 <body>
-  <nav id="sidebar">
-    <h1>BUS Core</h1>
-    <div class="tab active" data-tab="writes">Writes</div>
-    <div class="tab" data-tab="tools">Tools</div>
-    <div class="tab" data-tab="dev">Dev</div>
-  </nav>
-  <main id="main"><div id="app"></div></main>
+  <div id="app"></div>
   <script type="module" src="/ui/app.js"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- simplify the UI shell to render only the app container
- load the UI shell via the ESM `/ui/app.js` entry point
- keep the base stylesheet linked through `/ui/css/app.css`

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68feb01a0c608322bf624167414e2d1a