### PR TITLE
ui(app): ESM dispatcher with left tabs; stubs; BOOT OK

### DIFF
--- a/core/ui/js/cards/backup.js
+++ b/core/ui/js/cards/backup.js
@@ -1,3 +1,1 @@
-export function mountBackup(container) {
-  container.innerHTML = `<div class="card"><h2>Backup</h2><p>Stub: Backup tools coming.</p></div>`;
-}
+export function mountBackup(c){ c.innerHTML=`<div class="card"><h2>Backup</h2><p>Stub.</p></div>`; }

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -1,17 +1,9 @@
-export function mountDev(container) {
-  container.innerHTML = `
-    <div class="card">
-      <h2>Dev Tools</h2>
-      <button onclick="pingPlugin()">Ping Plugin</button>
-      <pre id="ping-result"></pre>
-    </div>
-  `;
-  window.pingPlugin = async () => {
+export function mountDev(c){ c.innerHTML=`<div class="card"><h2>Dev</h2><button id="ping">Ping Plugin</button><pre id="out"></pre></div>`;
+  document.getElementById("ping").onclick = async () => {
     try {
-      const res = await fetch("/health", { headers: { "X-Session-Token": (await import("/ui/js/token.js")).ensureToken() } });
-      document.getElementById("ping-result").textContent = JSON.stringify(await res.json(), null, 2);
-    } catch (e) {
-      document.getElementById("ping-result").textContent = "Error: " + e;
-    }
+      const { ensureToken } = await import("/ui/js/token.js");
+      const res = await fetch("/health",{ headers:{ "X-Session-Token": await ensureToken() }});
+      document.getElementById("out").textContent = JSON.stringify(await res.json(),null,2);
+    } catch(e){ document.getElementById("out").textContent = "Error: "+e; }
   };
 }

--- a/core/ui/js/cards/inventory.js
+++ b/core/ui/js/cards/inventory.js
@@ -1,3 +1,1 @@
-export function mountInventory(container) {
-  container.innerHTML = `<div class="card"><h2>Inventory</h2><p>Stub: Inventory ops.</p></div>`;
-}
+export function mountInventory(c){ c.innerHTML=`<div class="card"><h2>Inventory</h2><p>Stub.</p></div>`; }

--- a/core/ui/js/cards/rfq.js
+++ b/core/ui/js/cards/rfq.js
@@ -1,3 +1,1 @@
-export function mountRfq(container) {
-  container.innerHTML = `<div class="card"><h2>RFQ</h2><p>Stub: Request for Quote (Pro feature).</p></div>`;
-}
+export function mountRfq(c){ c.innerHTML=`<div class="card"><h2>RFQ</h2><p>Stub.</p></div>`; }


### PR DESCRIPTION
## Summary
- replace the legacy tab handling with an ESM dispatcher that renders a sidebar layout and mounts cards via window.bus
- refresh writes toggle handling so the active card remounts after state changes
- add lightweight stub implementations for backup, inventory, rfq, and dev cards

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68feb106be4c8322be3b12afe467bff7