### PR TITLE
Ensure FastAPI app bootstrap and reliable UI mounting

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -14,10 +14,11 @@ cryptography>=43.0.0  # AES-GCM + PBKDF2 fallback
 # The Notion module otherwise relies on the Python standard library.
 fastapi
 uvicorn[standard]
-pydantic
+pydantic>=2
+python-multipart
 sqlalchemy
 Send2Trash==1.8.2
 pywin32>=306; platform_system == "Windows"
 
-Jinja2>=3.1
+jinja2>=3.1
 reportlab>=4.2.0  # optional; only needed for fmt="pdf"


### PR DESCRIPTION
## Summary
- stop creating placeholder UI directories and export the configured BUS UI paths without mounting prematurely
- add a defensive bootstrap that resolves BUS_UI_DIR, materializes a FastAPI app, and mounts the /ui static files when available
- update requirements to include python-multipart and require pydantic>=2 while normalizing the Jinja dependency name

## Testing
- python -m compileall core/api/http.py

------
https://chatgpt.com/codex/tasks/task_e_68febe329ebc8322bf06cecaf5acf8c8