### PR TITLE
Update UI auth helpers and dev tools

### DIFF
--- a/core/ui/js/cards/settings.js
+++ b/core/ui/js/cards/settings.js
@@ -1,4 +1,4 @@
-import { apiGet, apiPost } from '../token.js';
+import { apiJson, apiPost } from '../token.js';
 export async function mountSettings(el){
   el.innerHTML = `
     <h2>Settings</h2>
@@ -11,13 +11,13 @@ export async function mountSettings(el){
   const btn = el.querySelector('#writesBtn');
   const lab = el.querySelector('#writesLabel');
   async function sync(){
-    const s = await apiGet('/dev/writes');
+    const s = await apiJson('/dev/writes');
     lab.textContent = s.enabled ? 'enabled' : 'disabled';
   }
   btn.onclick = async ()=>{
-    const s = await apiGet('/dev/writes');
+    const s = await apiJson('/dev/writes');
     await apiPost('/dev/writes', { enabled: !s.enabled });
     await sync();
   };
-  sync();
+  await sync();
 }

--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -1,54 +1,39 @@
+export function authHeaders() {
+  const t = localStorage.getItem('bus.token');
+  return t ? { 'X-Session-Token': t, 'Authorization': 'Bearer ' + t } : {};
+}
+
 export async function ensureToken() {
   let t = localStorage.getItem('bus.token');
   if (!t) {
-    const r = await fetch('/session/token', { method: 'GET' });
+    const r = await fetch('/session/token');
     if (!r.ok) throw new Error('token fetch failed: ' + r.status);
     const j = await r.json();
-    t = j.token;
+    t = j.token || j.value || j.session;
     if (!t) throw new Error('no token in response');
-    localStorage.setItem('bus.token', t);
+    localStorage.setItem('bus.token', String(t));
   }
+  window.dispatchEvent(new CustomEvent('bus:token-ready', { detail: { token: t } }));
   return t;
 }
 
-export async function withAuth(init = {}) {
-  const t = await ensureToken();
-  const h = new Headers(init.headers || {});
-  if (!h.has('X-Session-Token')) h.set('X-Session-Token', t);
-  if (!h.has('Authorization'))   h.set('Authorization', `Bearer ${t}`);
-  return { ...init, headers: h };
+export async function apiGet(path) {
+  const r = await fetch(path, { headers: authHeaders() });
+  if (r.status === 401) { localStorage.removeItem('bus.token'); await ensureToken(); return apiGet(path); }
+  return r;
 }
 
-export async function apiGet(path) {
-  const res = await fetch(path, await withAuth());
-  if (res.status === 401) {
-    localStorage.removeItem('bus.token');
-    const retry = await fetch(path, await withAuth());
-    return parse(retry);
-  }
-  return parse(res);
+export async function apiJson(path) {
+  const r = await apiGet(path);
+  return r.json();
 }
 
 export async function apiPost(path, body) {
-  const init = await withAuth({
+  const r = await fetch(path, {
     method: 'POST',
-    headers: { 'Content-Type': 'application/json' },
-    body: body ? JSON.stringify(body) : undefined,
+    headers: { 'Content-Type': 'application/json', ...authHeaders() },
+    body: JSON.stringify(body ?? {})
   });
-  const res = await fetch(path, init);
-  if (res.status === 401) {
-    localStorage.removeItem('bus.token');
-    const retry = await fetch(path, await withAuth(init));
-    return parse(retry);
-  }
-  return parse(res);
-}
-
-async function parse(res) {
-  if (!res.ok) {
-    const text = await res.text().catch(() => '');
-    throw new Error(`HTTP ${res.status} ${res.statusText} :: ${text}`);
-  }
-  const ct = res.headers.get('content-type') || '';
-  return ct.includes('application/json') ? res.json() : res.text();
+  if (r.status === 401) { localStorage.removeItem('bus.token'); await ensureToken(); return apiPost(path, body); }
+  return r;
 }


### PR DESCRIPTION
## Summary
- replace the token helper with the new module-based auth utilities
- ensure the shell app waits for the session token, updates the header, and reuses the helper APIs
- update dev, settings, and domain cards to call the shared API helpers for authenticated requests

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_68ffebd0b2b88322b8df096053617035