### PR TITLE
Fix UI auth headers and assets

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -1831,6 +1831,14 @@ def _ensure_app() -> "FastAPI":
     return FastAPI()
 
 
+FAVICON_ICO_B64 = (
+    "AAABAAEAEBAAAAAAIACUAAAAFgAAAIlQTkcNChoKAAAADUlIRFIAAAAQAAAAEAgGAAAAH/P/YQAA"
+    "AFtJREFUeJyl0dEOgCAIheHTbb52PfffXbNChZMbm8L2MUT7AYDcEKA/yH1xkcfDQT6JKhImK8iw"
+    "kEWmxQyy7LBCUnPOkPRvj5DSziOkBERIGXgjFtAjGyD3tFNc0v3LPSUE0s8AAAAASUVORK5CYII="
+)
+FAVICON_ICO_BYTES = base64.b64decode(FAVICON_ICO_B64)
+
+
 def _mount_ui(_app: "FastAPI") -> None:
     ui_dir = _resolve_ui_dir()
     globals()["UI_DIR"] = ui_dir
@@ -1859,6 +1867,16 @@ def _mount_ui(_app: "FastAPI") -> None:
         _app.add_api_route(
             "/ui/index.html",
             _redirect,
+            methods=["GET"],
+            include_in_schema=False,
+        )
+    if not _has_get_route("/ui/favicon.ico"):
+        async def _favicon() -> Response:
+            return Response(content=FAVICON_ICO_BYTES, media_type="image/x-icon")
+
+        _app.add_api_route(
+            "/ui/favicon.ico",
+            _favicon,
             methods=["GET"],
             include_in_schema=False,
         )

--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -34,13 +34,12 @@ const tabs = {
 
 document.addEventListener('DOMContentLoaded', async () => {
   try {
-    sessionToken = await ensureToken();
-    updateTokenDisplay();
+    await ensureToken();
     console.log('TOKEN OK');
   } catch (e) {
     console.error('TOKEN FAIL', e);
   }
-  await init();
+  await init(); // init calls checkHealth(), etc., after token present
 });
 
 window.addEventListener('bus:token-ready', (event) => {

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -1,3 +1,4 @@
+// core/ui/js/cards/dev.js
 import { apiGet, apiPost, apiJson } from '../token.js';
 
 export function mountDev(container) {
@@ -15,9 +16,12 @@ export function mountDev(container) {
 
 async function wire() {
   document.getElementById('btn-ping').onclick = async () => {
-    const r = await apiGet('/health');         // sends token headers
-    document.getElementById('ping-res').textContent =
-      JSON.stringify({ status: r.status }, null, 2);
+    try {
+      const r = await apiGet('/health'); // headers injected
+      document.getElementById('ping-res').textContent = `status ${r.status}`;
+    } catch (e) {
+      document.getElementById('ping-res').textContent = 'error: ' + e;
+    }
   };
 
   document.getElementById('btn-writes').onclick = async () => {

--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -1,34 +1,47 @@
+// core/ui/js/token.js
+const KEY = 'bus.token';
+
 export function authHeaders() {
-  const t = localStorage.getItem('bus.token');
-  return t ? { 'X-Session-Token': t, 'Authorization': 'Bearer ' + t } : {};
+  const t = localStorage.getItem(KEY);
+  return t ? { 'X-Session-Token': t, 'Authorization': `Bearer ${t}` } : {};
 }
 
 export async function ensureToken() {
-  let t = localStorage.getItem('bus.token');
+  let t = localStorage.getItem(KEY);
   if (!t) {
     const r = await fetch('/session/token');
     if (!r.ok) throw new Error('token fetch failed: ' + r.status);
     const j = await r.json();
     t = j.token || j.value || j.session;
     if (!t) throw new Error('no token in response');
-    localStorage.setItem('bus.token', String(t));
+    localStorage.setItem(KEY, String(t));
   }
   window.dispatchEvent(new CustomEvent('bus:token-ready', { detail: { token: t } }));
   return t;
 }
 
+// Centralized request that always injects headers
+export async function request(input, init = {}) {
+  const t = localStorage.getItem(KEY) || await ensureToken();
+  const headers = new Headers(init.headers || {});
+  if (!headers.get('X-Session-Token')) headers.set('X-Session-Token', t);
+  if (!headers.get('Authorization')) headers.set('Authorization', `Bearer ${t}`);
+  return fetch(input, { ...init, headers });
+}
+
+// Convenience helpers (use request())
 export async function apiGet(path) {
-  return fetch(path, { method: 'GET', headers: authHeaders() });
+  return request(path, { method: 'GET' });
 }
-
 export async function apiPost(path, body) {
-  return fetch(path, {
+  const r = await request(path, {
     method: 'POST',
-    headers: { ...authHeaders(), 'Content-Type': 'application/json' },
+    headers: { 'Content-Type': 'application/json' },
     body: JSON.stringify(body ?? {})
-  }).then(r => r.json());
+  });
+  return r.json();
 }
-
 export async function apiJson(path) {
-  return fetch(path, { headers: authHeaders() }).then(r => r.json());
+  const r = await request(path, { method: 'GET' });
+  return r.json();
 }

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -4,7 +4,7 @@
   <meta charset="utf-8">
   <title>BUS Core</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
-  <link rel="icon" href="/ui/favicon.svg" />
+  <link rel="icon" href="/ui/favicon.ico" />
   <link rel="stylesheet" href="/ui/css/app.css">
   <style>
     :root { --bg:#1a1a1a; --fg:#eee; --accent:#0a84ff; --sidebar:#222; }


### PR DESCRIPTION
## Summary
- centralize UI token handling and header injection
- update dev card to use shared auth helpers and improved status display
- ensure app bootstrap waits for token and provide favicon ico asset
- serve the favicon via a FastAPI route so the UI can load `/ui/favicon.ico` without a binary checked in

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69001a8ec10883229fb7cff131e8a17a