### PR TITLE
Ensure ping plugin uses authed health check

### DIFF
--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -32,12 +32,12 @@ async function updateWrites() {
     s.enabled ? 'writes: ON' : 'writes: OFF';
 }
 
-// keep inline onclick support but ensure headers are set
+// AUTHED Ping for inline onclick from shell.html
 window.pingPlugin = async () => {
   try {
-    const { ensureToken, request } = await import('/ui/js/token.js');
-    await ensureToken();                           // guarantee token in storage
-    const r = await request('/health', { method: 'GET' }); // injects both headers
+    const { ensureToken, apiGet } = await import('/ui/js/token.js'); // absolute path, no bundle confusion
+    await ensureToken();                               // guarantees token in localStorage
+    const r = await apiGet('/health');                 // injects X-Session-Token + Authorization
     console.log('ping status', r.status);
     const out = document.getElementById('ping-res');
     if (out) out.textContent = `status ${r.status}`;

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -33,6 +33,6 @@
   <main id="main">
     <div id="app"></div>
   </main>
-  <script type="module" src="/ui/app.js"></script>
+  <script type="module" src="/ui/app.js?v=pingfix2"></script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- replace the inline ping helper to import token utilities dynamically and call `apiGet('/health')`
- add a cache-busting query string to the shell module loader so the updated ping helper is picked up

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_69002f1a49d48322a5c78abf3d87ce9f