### PR TITLE
Ensure UI static endpoints and authenticated ping requests

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -1881,6 +1881,29 @@ def _mount_ui(_app: "FastAPI") -> None:
             include_in_schema=False,
         )
 
+    def _serve_file(path: Path):
+        if not path.exists():
+            raise HTTPException(status_code=404)
+        return FileResponse(str(path))
+
+    shell_path = ui_dir / "shell.html"
+    if not _has_get_route("/ui/shell.html"):
+        _app.add_api_route(
+            "/ui/shell.html",
+            lambda: _serve_file(shell_path),
+            methods=["GET"],
+            include_in_schema=False,
+        )
+
+    app_js_path = ui_dir / "app.js"
+    if not _has_get_route("/ui/app.js"):
+        _app.add_api_route(
+            "/ui/app.js",
+            lambda: _serve_file(app_js_path),
+            methods=["GET"],
+            include_in_schema=False,
+        )
+
     mounted = False
     for route in getattr(_app, "routes", []):
         if getattr(route, "path", None) == "/ui" and getattr(route, "app", None) is not None:

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -35,17 +35,16 @@ async function updateWrites() {
 // AUTHED Ping for inline onclick from shell.html
 window.pingPlugin = async () => {
   try {
-    const { ensureToken, apiGet } = await import('/ui/js/token.js'); // absolute path, no bundle confusion
-    await ensureToken();                               // guarantees token in localStorage
-    const r = await apiGet('/health');                 // injects X-Session-Token + Authorization
-    console.log('ping status', r.status);
+    await ensureToken();
+    const r = await apiGet('/health');
     const out = document.getElementById('ping-res');
     if (out) out.textContent = `status ${r.status}`;
+    console.log('ping status', r.status);
     return r.status;
   } catch (e) {
-    console.error('ping failed', e);
     const out = document.getElementById('ping-res');
     if (out) out.textContent = 'error: ' + e;
+    console.error('ping failed', e);
     return 0;
   }
 };

--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -1,5 +1,10 @@
 const KEY = 'bus.token';
 
+export function authHeaders() {
+  const t = localStorage.getItem(KEY);
+  return t ? { 'X-Session-Token': t, 'Authorization': `Bearer ${t}` } : {};
+}
+
 export async function ensureToken() {
   let t = localStorage.getItem(KEY);
   if (!t) {


### PR DESCRIPTION
## Summary
- mount the UI directory and add explicit routes for /ui/shell.html and /ui/app.js
- extend the token helper to reuse authenticated fetch wrappers
- route ping-related actions through the authenticated helpers and await the token on boot

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901350f37d08322b9ee90381ad29eca