### PR TITLE
Ensure UI shell/app endpoints serve files

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -1888,18 +1888,24 @@ def _mount_ui(_app: "FastAPI") -> None:
 
     shell_path = ui_dir / "shell.html"
     if not _has_get_route("/ui/shell.html"):
+        def _shell_html() -> Response:
+            return _serve_file(shell_path)
+
         _app.add_api_route(
             "/ui/shell.html",
-            lambda: _serve_file(shell_path),
+            _shell_html,
             methods=["GET"],
             include_in_schema=False,
         )
 
     app_js_path = ui_dir / "app.js"
     if not _has_get_route("/ui/app.js"):
+        def _app_js() -> Response:
+            return _serve_file(app_js_path)
+
         _app.add_api_route(
             "/ui/app.js",
-            lambda: _serve_file(app_js_path),
+            _app_js,
             methods=["GET"],
             include_in_schema=False,
         )


### PR DESCRIPTION
## Summary
- ensure `/ui/shell.html` and `/ui/app.js` use dedicated FastAPI handlers that serve from the configured BUS_UI_DIR

## Testing
- python - <<'PY'
import os
os.environ['BUS_UI_DIR'] = 'core/ui'
from importlib import reload
import core.api.http as http
reload(http)
from fastapi.testclient import TestClient
client = TestClient(http.app)
print(client.get('/ui/shell.html').status_code)
print(client.get('/ui/app.js').status_code)
PY

------
https://chatgpt.com/codex/tasks/task_e_69014bb0ce74832291f872f9bee38a32