### PR TITLE
Fix mounting of UI static files on FastAPI app

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -1917,7 +1917,7 @@ def _mount_ui(_app: "FastAPI") -> None:
             break
 
     if not mounted:
-        _app.mount("/ui", StaticFiles(directory=str(ui_dir), html=True), name="ui")
+        app.mount("/ui", StaticFiles(directory=str(ui_dir), html=True), name="ui")
 
 
 # materialize global `app` if missing, then ensure /ui mount


### PR DESCRIPTION
## Summary
- mount the UI static files on the primary FastAPI app so /ui assets resolve correctly

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69014f76726c8322939aa0575b11629d