### PR TITLE
Ensure exported app serves /ui assets

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -1922,14 +1922,16 @@ def _mount_ui(_app: "FastAPI") -> None:
 
 # materialize global `app` if missing, then ensure /ui mount
 try:
-    app  # type: ignore  # noqa: F821
+    _app  # type: ignore  # noqa: F821
 except NameError:
-    app = _ensure_app()
+    _app = _ensure_app()
 try:
-    _mount_ui(app)
+    _mount_ui(_app)
 except Exception as _e:  # last resort: fail loud
     raise
 
 # ===== END UI + APP BOOTSTRAP =====
 
 __all__ = ["app", "UI_DIR", "UI_STATIC_DIR", "build_app", "create_app", "SESSION_TOKEN"]
+
+app = _app  # ensure uvicorn core.api.http:app serves the configured instance


### PR DESCRIPTION
## Summary
- ensure the UI mount logic uses the exported FastAPI application instance
- re-export the assembled FastAPI app so `uvicorn core.api.http:app` serves the mounted UI

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_6901512cc93083229fe94f2724b72827