### PR TITLE
fix: align UI static mount path handling

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -147,9 +147,11 @@ async def dev_writes_set(req: Request, body: dict):
 
 
 # Static UI mount
-UI_DIR = Path(os.environ.get("BUS_UI_DIR", Path(__file__).parent.parent / "ui")).resolve()
-UI_STATIC_DIR = UI_DIR
-app.mount("/ui", StaticFiles(directory=str(UI_DIR), html=True), name="ui")
+UI_DIR: Path = Path(
+    os.environ.get("BUS_UI_DIR", Path(__file__).parent.parent / "ui")
+).resolve()
+UI_STATIC_DIR: Path = UI_DIR
+app.mount("/ui", StaticFiles(directory=str(UI_STATIC_DIR), html=True), name="ui")
 
 
 @app.get("/ui", include_in_schema=False)


### PR DESCRIPTION
## Summary
- add explicit Path annotations for the UI directory constants in `core/api/http.py`
- ensure the `/ui` StaticFiles mount uses the shared `UI_STATIC_DIR`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690299e9dce8832284b870b7cec81659