### PR TITLE
fix: unify UI auth helper and await token before boot

### DIFF
--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -34,8 +34,13 @@ const tabs = {
 };
 
 document.addEventListener('DOMContentLoaded', async () => {
-  try { await ensureToken(); } catch {}
-  await init();
+  try {
+    await ensureToken();        // wait for session token first
+    await init();               // existing init logic unchanged
+    console.log('BOOT OK');
+  } catch (e) {
+    console.error('BOOT FAIL', e);
+  }
 });
 
 window.addEventListener('bus:token-ready', (event) => {

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -4,6 +4,7 @@ import { ensureToken, apiGet, apiPost, apiJson } from '../token.js';
 export function mountDev(container) {
   container.innerHTML = `
     <div class="card">
+      <h2>Dev Tools</h2>
       <button id="btn-ping" class="btn">Ping Plugin</button>
       <pre id="ping-res" class="log"></pre>
       <div style="margin-top:12px">
@@ -18,7 +19,7 @@ async function wire() {
   document.getElementById('btn-ping').onclick = window.pingPlugin;
 
   document.getElementById('btn-writes').onclick = async () => {
-    const s = await apiJson('/dev/writes');    // {enabled:boolean}
+    const s = await apiJson('/dev/writes');           // { enabled: boolean }
     await apiPost('/dev/writes', { enabled: !s.enabled });
     updateWrites();
   };
@@ -28,23 +29,19 @@ async function wire() {
 
 async function updateWrites() {
   const s = await apiJson('/dev/writes');
-  document.getElementById('writes-state').textContent =
-    s.enabled ? 'writes: ON' : 'writes: OFF';
+  document.getElementById('writes-state').textContent = s.enabled ? 'writes: ON' : 'writes: OFF';
 }
 
-// AUTHED Ping for inline onclick from shell.html
+// global for shell.html onclick compatibility
 window.pingPlugin = async () => {
+  const out = document.getElementById('ping-res');
   try {
     await ensureToken();
-    const r = await apiGet('/health');
-    const out = document.getElementById('ping-res');
-    if (out) out.textContent = `status ${r.status}`;
-    console.log('ping status', r.status);
-    return r.status;
+    const res = await apiGet('/health');
+    out && (out.textContent = `status ${res.status}`);
+    return res.status;
   } catch (e) {
-    const out = document.getElementById('ping-res');
-    if (out) out.textContent = 'error: ' + e;
-    console.error('ping failed', e);
+    out && (out.textContent = 'error: ' + e);
     return 0;
   }
 };


### PR DESCRIPTION
## Summary
- replace the UI token helper with a retrying request wrapper that always adds both auth headers
- wait for the session token before running app initialization and harden the dev tools card
- route domain card network calls through the shared helper to ensure consistent headers

## Testing
- not run (UI change only)


------
https://chatgpt.com/codex/tasks/task_e_69029f3aee2c8322b207c6c900f8e28b