### PR TITLE
feat: single-auth X-Session-Token

### DIFF
--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -1,5 +1,4 @@
-import { ensureToken } from "./js/token.js";
-import { apiGet, apiPost, apiJson } from "./js/token.js";
+import { ensureToken, apiGet, apiJson, apiGetJson } from "./js/token.js";
 import { mountWrites }    from "/ui/js/cards/writes.js";
 import { mountOrganizer } from "/ui/js/cards/organizer.js";
 import { mountBackup }    from "/ui/js/cards/backup.js";
@@ -91,8 +90,8 @@ function setupSessionBar() {
 
   wBtn.onclick = async () => {
     try {
-      const s = await apiJson('/dev/writes');
-      await apiPost('/dev/writes', { enabled: !s.enabled });
+      const s = await apiGetJson('/dev/writes');
+      await apiJson('/dev/writes', { enabled: !s.enabled });
       await refreshWrites();
       await renderView();
     } catch (err) {
@@ -109,7 +108,7 @@ function updateTokenDisplay() {
 
 async function refreshWrites() {
   try {
-    const s = await apiJson('/dev/writes');
+    const s = await apiGetJson('/dev/writes');
     const enabled = Boolean(s?.enabled);
     writesState = { enabled };
     if (wBadge) wBadge.textContent = enabled ? 'WRITES: ON' : 'WRITES: OFF';
@@ -124,7 +123,7 @@ async function refreshWrites() {
 
 async function refreshLicense() {
   try {
-    licenseInfo = await apiJson('/dev/license');
+    licenseInfo = await apiGetJson('/dev/license');
   } catch (err) {
     licenseInfo = null;
     console.error('license fetch failed', err);

--- a/core/ui/js/cards/dev.js
+++ b/core/ui/js/cards/dev.js
@@ -1,5 +1,5 @@
 // core/ui/js/cards/dev.js
-import { ensureToken, apiGet, apiPost, apiJson } from '../token.js';
+import { ensureToken, apiGet, apiJson, apiGetJson } from '../token.js';
 
 export function mountDev(container) {
   container.innerHTML = `
@@ -19,8 +19,8 @@ async function wire() {
   document.getElementById('btn-ping').onclick = window.pingPlugin;
 
   document.getElementById('btn-writes').onclick = async () => {
-    const s = await apiJson('/dev/writes');           // { enabled: boolean }
-    await apiPost('/dev/writes', { enabled: !s.enabled });
+    const s = await apiGetJson('/dev/writes');           // { enabled: boolean }
+    await apiJson('/dev/writes', { enabled: !s.enabled });
     updateWrites();
   };
 
@@ -28,7 +28,7 @@ async function wire() {
 }
 
 async function updateWrites() {
-  const s = await apiJson('/dev/writes');
+  const s = await apiGetJson('/dev/writes');
   document.getElementById('writes-state').textContent = s.enabled ? 'writes: ON' : 'writes: OFF';
 }
 

--- a/core/ui/js/cards/settings.js
+++ b/core/ui/js/cards/settings.js
@@ -1,4 +1,4 @@
-import { apiJson, apiPost } from '../token.js';
+import { apiJson, apiGetJson } from '../token.js';
 export async function mountSettings(el){
   el.innerHTML = `
     <h2>Settings</h2>
@@ -11,12 +11,12 @@ export async function mountSettings(el){
   const btn = el.querySelector('#writesBtn');
   const lab = el.querySelector('#writesLabel');
   async function sync(){
-    const s = await apiJson('/dev/writes');
+    const s = await apiGetJson('/dev/writes');
     lab.textContent = s.enabled ? 'enabled' : 'disabled';
   }
   btn.onclick = async ()=>{
-    const s = await apiJson('/dev/writes');
-    await apiPost('/dev/writes', { enabled: !s.enabled });
+    const s = await apiGetJson('/dev/writes');
+    await apiJson('/dev/writes', { enabled: !s.enabled });
     await sync();
   };
   await sync();

--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -25,22 +25,23 @@ export async function request(input, init = {}) {
   const token = await ensureToken();
   const headers = new Headers(init.headers || {});
   headers.set('X-Session-Token', token);
-  headers.set('Authorization', `Bearer ${token}`);
   const res = await fetch(input, { ...init, headers });
   if (res.status === 401) {
     localStorage.removeItem('bus.token');
     const t2 = await ensureToken();
     headers.set('X-Session-Token', t2);
-    headers.set('Authorization', `Bearer ${t2}`);
     return fetch(input, { ...init, headers });
   }
   return res;
 }
 
-export const apiGet  = (url) => request(url);
-export const apiJson = (url) => request(url).then(r => r.json());
-export const apiPost = (url, body) => request(url, {
+export const apiGet  = (url, init) => request(url, { method: 'GET', ...(init || {}) });
+export const apiPost = (url, body, init) => request(url, { method: 'POST', body, ...(init || {}) });
+export const apiJson = (url, obj, init) => request(url, {
   method: 'POST',
   headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify(body || {})
+  body: JSON.stringify(obj || {}),
+  ...(init || {})
 });
+export const apiGetJson = (url, init) => apiGet(url, init).then(res => res.json());
+export const apiJsonJson = (url, obj, init) => apiJson(url, obj, init).then(res => res.json());

--- a/core/version.py
+++ b/core/version.py
@@ -1,5 +1,5 @@
 """Version information for TGC Alpha Core."""
 
-VERSION = "v0.5.0"
+VERSION = "v0.6.1-single-auth"
 
 __all__ = ["VERSION"]

--- a/source of truth.txt
+++ b/source of truth.txt
@@ -1,0 +1,1 @@
+Auth: X-Session-Token only. Bearer removed.

--- a/tests/test_session_guard.py
+++ b/tests/test_session_guard.py
@@ -1,0 +1,110 @@
+import asyncio
+import json
+import sys
+from pathlib import Path
+
+import pytest
+from fastapi.testclient import TestClient
+from starlette.requests import Request
+
+ROOT = Path(__file__).resolve().parents[1]
+if str(ROOT) not in sys.path:
+    sys.path.insert(0, str(ROOT))
+
+from core.api import http
+from core.api.http import TOKEN_HEADER, _extract_token, _require_session
+
+
+def make_request(path: str = "/dev/writes", headers: dict[str, str] | None = None) -> Request:
+    raw_headers: list[tuple[bytes, bytes]] = []
+    if headers:
+        for key, value in headers.items():
+            raw_headers.append((key.lower().encode("latin-1"), value.encode("latin-1")))
+    scope = {
+        "type": "http",
+        "method": "GET",
+        "path": path,
+        "headers": raw_headers,
+    }
+    return Request(scope)
+
+
+def test_extract_token_present() -> None:
+    req = make_request(headers={TOKEN_HEADER: "abc123"})
+    assert _extract_token(req) == "abc123"
+
+
+def test_extract_token_missing() -> None:
+    req = make_request()
+    assert _extract_token(req) is None
+
+
+def test_require_session_missing_token() -> None:
+    req = make_request()
+    response = asyncio.run(_require_session(req))
+    assert response is not None
+    assert response.status_code == 401
+    assert json.loads(response.body.decode()) == {"error": "unauthorized"}
+
+
+def test_require_session_invalid_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    token = "invalid"
+    req = make_request(headers={TOKEN_HEADER: token})
+    monkeypatch.setattr(http, "validate_session_token", lambda _token: False)
+    response = asyncio.run(_require_session(req))
+    assert response is not None
+    assert response.status_code == 401
+    assert json.loads(response.body.decode()) == {"error": "unauthorized"}
+
+
+def test_require_session_valid_token(monkeypatch: pytest.MonkeyPatch) -> None:
+    token = "valid-token"
+    req = make_request(headers={TOKEN_HEADER: token})
+    monkeypatch.setattr(http, "validate_session_token", lambda candidate: candidate == token)
+    response = asyncio.run(_require_session(req))
+    assert response is None
+    assert getattr(req.state, "session") == token
+
+
+@pytest.fixture
+def test_client(monkeypatch: pytest.MonkeyPatch) -> TestClient:
+    monkeypatch.setattr(http, "SESSION_TOKEN", "fixture-token", raising=False)
+    monkeypatch.setattr(http, "_load_or_create_token", lambda: "fixture-token", raising=False)
+    with TestClient(http.APP) as client:
+        yield client
+
+
+def test_integration_routes_and_cors(test_client: TestClient) -> None:
+    token_resp = test_client.get("/session/token")
+    assert token_resp.status_code == 200
+    token = token_resp.json()["token"]
+    assert token == "fixture-token"
+
+    unauthorized_health = test_client.get("/health")
+    assert unauthorized_health.status_code == 401
+    assert unauthorized_health.json() == {"error": "unauthorized"}
+
+    unauthorized_writes = test_client.get("/dev/writes")
+    assert unauthorized_writes.status_code == 401
+    assert unauthorized_writes.json() == {"error": "unauthorized"}
+
+    headers = {TOKEN_HEADER: token}
+    health = test_client.get("/health", headers=headers)
+    assert health.status_code == 200
+
+    writes = test_client.get("/dev/writes", headers=headers)
+    assert writes.status_code == 200
+    body = writes.json()
+    assert "enabled" in body
+
+    options = test_client.options(
+        "/dev/writes",
+        headers={
+            "Origin": "http://example.com",
+            "Access-Control-Request-Method": "POST",
+            "Access-Control-Request-Headers": TOKEN_HEADER,
+        },
+    )
+    assert options.status_code == 200
+    allow_headers = options.headers.get("access-control-allow-headers", "")
+    assert TOKEN_HEADER.lower() in allow_headers.lower()


### PR DESCRIPTION
## Summary
- add a session guard middleware that enforces the X-Session-Token header and exposes the app as APP
- update the UI token helper and cards to send only the X-Session-Token header and reuse shared wrappers
- cover the new auth flow with unit and integration-style tests and refresh the release metadata

## Testing
- pytest tests/test_session_guard.py

------
https://chatgpt.com/codex/tasks/task_e_6902bb6f28b8832294db021c10a0d59a