### PR TITLE
fix(ui): atomic token + 401 retry for single-auth

### DIFF
--- a/core/ui/js/token.js
+++ b/core/ui/js/token.js
@@ -1,47 +1,64 @@
-// core/ui/js/token.js
-let inflight = null;
+// --- single-auth helpers: atomic token + retry on 401 ---
+
+let _tokenCache = null;        // string | null
+let _tokenPromise = null;      // Promise<string> | null
 
 export async function ensureToken() {
-  const cached = localStorage.getItem('bus.token');
-  if (cached) return cached;
-  if (!inflight) {
-    inflight = fetch('/session/token')
-      .then(r => {
-        if (!r.ok) throw new Error('token fetch failed: ' + r.status);
-        return r.json();
-      })
-      .then(j => {
-        if (!j?.token) throw new Error('token missing');
-        localStorage.setItem('bus.token', j.token);
-        window.dispatchEvent(new CustomEvent('bus:token-ready', { detail: { token: j.token } }));
-        return j.token;
-      })
-      .finally(() => { inflight = null; });
-  }
-  return inflight;
+  if (_tokenCache) return _tokenCache;
+  if (_tokenPromise) return _tokenPromise; // in-flight, await it
+
+  _tokenPromise = (async () => {
+    const r = await fetch('/session/token', { credentials: 'omit' });
+    if (!r.ok) throw new Error(`token fetch failed: ${r.status}`);
+    const j = await r.json();
+    _tokenCache = j.token;
+    _tokenPromise = null;
+    return _tokenCache;
+  })();
+
+  return _tokenPromise;
 }
 
-export async function request(input, init = {}) {
-  const token = await ensureToken();
+function clearToken() {
+  _tokenCache = null;
+  _tokenPromise = null;
+}
+
+async function withAuth(init = {}) {
+  const t = await ensureToken();
   const headers = new Headers(init.headers || {});
-  headers.set('X-Session-Token', token);
-  const res = await fetch(input, { ...init, headers });
-  if (res.status === 401) {
-    localStorage.removeItem('bus.token');
-    const t2 = await ensureToken();
-    headers.set('X-Session-Token', t2);
-    return fetch(input, { ...init, headers });
-  }
-  return res;
+  headers.set('X-Session-Token', t);      // single authority header
+  return { ...init, headers, credentials: 'omit' };
 }
 
+export async function request(url, init) {
+  // first attempt
+  let resp = await fetch(url, await withAuth(init || {}));
+  if (resp.status !== 401) return resp;
+
+  // single retry path: refresh token and resend
+  clearToken();
+  await ensureToken();
+  resp = await fetch(url, await withAuth(init || {}));
+  return resp;
+}
+
+// Convenience wrappers. Keep signatures stable.
 export const apiGet  = (url, init) => request(url, { method: 'GET', ...(init || {}) });
 export const apiPost = (url, body, init) => request(url, { method: 'POST', body, ...(init || {}) });
-export const apiJson = (url, obj, init) => request(url, {
-  method: 'POST',
-  headers: { 'Content-Type': 'application/json' },
-  body: JSON.stringify(obj || {}),
-  ...(init || {})
-});
-export const apiGetJson = (url, init) => apiGet(url, init).then(res => res.json());
+export const apiJson = (url, obj, init) =>
+  request(url, {
+    method: 'POST',
+    headers: { 'Content-Type': 'application/json' },
+    body: JSON.stringify(obj || {}),
+    ...(init || {})
+  });
+
+export const apiGetJson = async (url, init) => {
+  const r = await apiGet(url, init);
+  return r.json();
+};
+
+// --- end single-auth helpers ---
+
 export const apiJsonJson = (url, obj, init) => apiJson(url, obj, init).then(res => res.json());


### PR DESCRIPTION
## Summary
- replace the UI token helper with an atomic cache that re-fetches and retries once on 401 responses
- ensure only the X-Session-Token header is injected while omitting credentials and removing localStorage dependency

## Testing
- git grep -n "Authorization:" core/ui || true
- git grep -n "Bearer " core/ui || true
- git grep -n "document.cookie" core/ui || true
- git grep -n "fetch(.*dev/writes" core/ui || true

------
https://chatgpt.com/codex/tasks/task_e_6902c4dd27508322b6173783b57d65ec