### PR TITLE
Support BUS_ROOT overrides for dev data paths

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -504,18 +504,28 @@ class InventoryRun(BaseModel):
     note: Optional[str] = None
 
 
-_LOCALAPPDATA = os.environ.get("LOCALAPPDATA", ".")
-BUS_ROOT = (Path(_LOCALAPPDATA) / "BUSCore").resolve()
-APP_DIR = BUS_ROOT / "app"
+_LOCALAPPDATA = Path(os.environ.get("LOCALAPPDATA", "."))
+_ENV_BUS_ROOT = os.environ.get("BUS_ROOT")
+if _ENV_BUS_ROOT:
+    BUS_ROOT = Path(_ENV_BUS_ROOT).expanduser().resolve()
+    APP_DIR = BUS_ROOT
+    DB_PATH = (APP_DIR / "app.db").resolve()
+    EXPORTS_DIR = APP_DIR / "exports"
+else:
+    _DEFAULT_BASE = (_LOCALAPPDATA / "BUSCore").resolve()
+    BUS_ROOT = (_DEFAULT_BASE / "app").resolve()
+    APP_DIR = BUS_ROOT
+    DB_PATH = (_DEFAULT_BASE / "_app.db").resolve()
+    EXPORTS_DIR = (_DEFAULT_BASE / "exports").resolve()
 DATA_DIR = APP_DIR / "data"
-EXPORTS_DIR = BUS_ROOT / "exports"
 JOURNAL_DIR = DATA_DIR / "journals"
-DB_PATH = (BUS_ROOT / "_app.db").resolve()
+IMPORTS_DIR = DATA_DIR / "imports"
 _LEGACY_DB_PATH = SA_DB_PATH.resolve()
 if _LEGACY_DB_PATH.exists() and _LEGACY_DB_PATH != DB_PATH:
     DB_PATH = _LEGACY_DB_PATH
-EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
-JOURNAL_DIR.mkdir(parents=True, exist_ok=True)
+for path in (DATA_DIR, JOURNAL_DIR, IMPORTS_DIR, EXPORTS_DIR):
+    path.mkdir(parents=True, exist_ok=True)
+DB_URL = f"sqlite:///{DB_PATH}"
 _TEMPLATE_ROOT = Path(__file__).resolve().parents[2] / "templates"
 
 

--- a/core/utils/license_loader.py
+++ b/core/utils/license_loader.py
@@ -25,8 +25,12 @@ def _baseline_license() -> Dict[str, Any]:
 
 
 def _license_path() -> Path:
-    local_app_data = os.environ.get("LOCALAPPDATA", ".")
-    root = Path(local_app_data).expanduser() / "BUSCore"
+    bus_root = os.environ.get("BUS_ROOT")
+    if bus_root:
+        root = Path(bus_root).expanduser()
+    else:
+        local_app_data = os.environ.get("LOCALAPPDATA", ".")
+        root = Path(local_app_data).expanduser() / "BUSCore"
     root.mkdir(parents=True, exist_ok=True)
     return root / "license.json"
 


### PR DESCRIPTION
## Summary
- update service data directory resolution to honor BUS_ROOT overrides while preserving existing AppData defaults
- ensure data, journals, and imports directories exist alongside new DB_URL constant
- prefer BUS_ROOT for license loading so Pro features can be tested within the repo folder

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_69069587f8fc8322983a3a0f9b91967f