### PR TITLE
Unify BUS root data paths and UI serving

### DIFF
--- a/core/api/app_router.py
+++ b/core/api/app_router.py
@@ -4,7 +4,6 @@ from __future__ import annotations
 
 import csv
 import json
-import os
 import time
 from datetime import date, datetime
 from io import BytesIO, StringIO
@@ -17,25 +16,15 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
+from core.api.http import APP_DIR
 from core.services.models import Attachment, Item, Task, Vendor, get_session
 from core.utils.license_loader import feature_enabled
 
 router = APIRouter(tags=["app"])
 
 
-def _resolve_data_dir() -> Path:
-    base = os.environ.get("LOCALAPPDATA")
-    if base:
-        root = Path(base).expanduser() / "BUSCore" / "app" / "data"
-    else:
-        root = Path("data")
-    root.mkdir(parents=True, exist_ok=True)
-    return root
-
-
-DATA_DIR = _resolve_data_dir()
-IMPORTS_DIR = DATA_DIR / "imports"
-JOURNAL_DIR = DATA_DIR / "journals"
+IMPORTS_DIR = APP_DIR / "data" / "imports"
+JOURNAL_DIR = APP_DIR / "data" / "journals"
 AUDIT_PATH = JOURNAL_DIR / "plugin_audit.jsonl"
 
 for directory in (IMPORTS_DIR, JOURNAL_DIR):

--- a/core/utils/license_loader.py
+++ b/core/utils/license_loader.py
@@ -29,13 +29,16 @@ def _license_path() -> Path:
     if bus_root:
         root = Path(bus_root).expanduser()
     else:
-        local_app_data = os.environ.get("LOCALAPPDATA", ".")
-        root = Path(local_app_data).expanduser() / "BUSCore"
-    root.mkdir(parents=True, exist_ok=True)
+        local_app_data = os.environ.get("LOCALAPPDATA")
+        if local_app_data:
+            root = Path(local_app_data).expanduser() / "BUSCore"
+        else:
+            root = Path.home() / "AppData" / "Local" / "BUSCore"
     return root / "license.json"
 
 
 def _write_license(path: Path, data: Dict[str, Any]) -> None:
+    path.parent.mkdir(parents=True, exist_ok=True)
     path.write_text(json.dumps(data, indent=2, sort_keys=True), encoding="utf-8")
 
 


### PR DESCRIPTION
## Summary
- centralize BUS_ROOT-aware directory resolution for application data, exports, and static UI paths
- expose the resolved paths via /dev/paths and share APP_DIR with downstream routers
- update license loader to honor BUS_ROOT while keeping legacy fallbacks

## Testing
- python -m compileall core/api/http.py core/api/app_router.py core/utils/license_loader.py

------
https://chatgpt.com/codex/tasks/task_e_69069883c0a883229f0792d7477e623c