### PR TITLE
Unify BUS_ROOT paths and resolve API router cycle

### DIFF
--- a/core/api/app_router.py
+++ b/core/api/app_router.py
@@ -16,18 +16,16 @@ from pydantic import BaseModel
 from sqlalchemy.exc import IntegrityError
 from sqlalchemy.orm import Session
 
-from core.api.http import APP_DIR
+from core.config.paths import APP_DIR, DATA_DIR, JOURNALS_DIR, IMPORTS_DIR
 from core.services.models import Attachment, Item, Task, Vendor, get_session
 from core.utils.license_loader import feature_enabled
 
 router = APIRouter(tags=["app"])
 
 
-IMPORTS_DIR = APP_DIR / "data" / "imports"
-JOURNAL_DIR = APP_DIR / "data" / "journals"
-AUDIT_PATH = JOURNAL_DIR / "plugin_audit.jsonl"
+AUDIT_PATH = JOURNALS_DIR / "plugin_audit.jsonl"
 
-for directory in (IMPORTS_DIR, JOURNAL_DIR):
+for directory in (DATA_DIR, JOURNALS_DIR, IMPORTS_DIR):
     directory.mkdir(parents=True, exist_ok=True)
 
 
@@ -192,7 +190,7 @@ def journal_mutate(db: Session, action: str, payload: Dict[str, object]) -> None
         "action": action,
         **payload,
     }
-    journal_path = JOURNAL_DIR / "bulk_import.jsonl"
+    journal_path = JOURNALS_DIR / "bulk_import.jsonl"
     with journal_path.open("a", encoding="utf-8") as handle:
         handle.write(json.dumps(entry, ensure_ascii=False) + "\n")
 

--- a/core/config/paths.py
+++ b/core/config/paths.py
@@ -1,0 +1,26 @@
+from pathlib import Path
+import os
+
+_local_appdata = os.environ.get("LOCALAPPDATA")
+if _local_appdata:
+    _default_root = Path(_local_appdata) / "BUSCore" / "app"
+else:
+    _default_root = Path.home() / "AppData" / "Local" / "BUSCore" / "app"
+
+BUS_ROOT = Path(os.environ.get("BUS_ROOT") or _default_root).resolve()
+
+APP_DIR = BUS_ROOT
+DATA_DIR = APP_DIR / "data"
+JOURNALS_DIR = DATA_DIR / "journals"
+IMPORTS_DIR = DATA_DIR / "imports"
+
+for d in (DATA_DIR, JOURNALS_DIR, IMPORTS_DIR):
+    d.mkdir(parents=True, exist_ok=True)
+
+DB_PATH = APP_DIR / "app.db"
+DB_URL = f"sqlite:///{DB_PATH}"
+
+# Prefer repo UI when BUS_ROOT points to project root
+DEV_UI_DIR = APP_DIR / "core" / "ui"
+DEFAULT_UI_DIR = APP_DIR / "ui"
+UI_DIR = DEV_UI_DIR if DEV_UI_DIR.joinpath("shell.html").exists() else DEFAULT_UI_DIR

--- a/core/utils/license_loader.py
+++ b/core/utils/license_loader.py
@@ -3,10 +3,11 @@
 from __future__ import annotations
 
 import json
-import os
 from copy import deepcopy
 from pathlib import Path
 from typing import Any, Dict
+
+from core.config.paths import APP_DIR
 
 DEFAULT_TIER = "community"
 DEFAULT_FEATURES: Dict[str, bool] = {
@@ -25,16 +26,7 @@ def _baseline_license() -> Dict[str, Any]:
 
 
 def _license_path() -> Path:
-    bus_root = os.environ.get("BUS_ROOT")
-    if bus_root:
-        root = Path(bus_root).expanduser()
-    else:
-        local_app_data = os.environ.get("LOCALAPPDATA")
-        if local_app_data:
-            root = Path(local_app_data).expanduser() / "BUSCore"
-        else:
-            root = Path.home() / "AppData" / "Local" / "BUSCore"
-    return root / "license.json"
+    return APP_DIR / "license.json"
 
 
 def _write_license(path: Path, data: Dict[str, Any]) -> None:


### PR DESCRIPTION
## Summary
- add `core/config/paths.py` as the single source of truth for BUS_ROOT-derived directories, database path, and UI selection
- update HTTP startup to consume the new paths module, mount the UI directory, expose a `/dev/paths` debug endpoint, and include `app_router` after the FastAPI app is created
- switch the bulk import router and license loader to use BUS_ROOT-aware directories so preview, audit, and license files stay inside the configured root

## Testing
- python -m compileall core/config/paths.py core/api/http.py core/api/app_router.py core/utils/license_loader.py

------
https://chatgpt.com/codex/tasks/task_e_690786ce0adc8322b9693e0d8be44b2d