### PR TITLE
Ensure dev licensing uses repo paths

### DIFF
--- a/core/config/paths.py
+++ b/core/config/paths.py
@@ -22,3 +22,4 @@ IS_DEV = bool(os.environ.get("BUS_ROOT"))
 
 # Force repo UI in dev; keep previous default in prod
 UI_DIR = DEV_UI_DIR if IS_DEV else DEFAULT_UI_DIR
+UI_DIR.mkdir(parents=True, exist_ok=True)

--- a/core/utils/license_loader.py
+++ b/core/utils/license_loader.py
@@ -1,28 +1,48 @@
 from pathlib import Path
 import os, json
-from typing import Dict, Any
+from typing import Dict, Any, Tuple
+
+_DEFAULT = {"tier": "community", "features": {}, "plugins": {}}
+
 
 def _license_path() -> Path:
-    # Dev: BUS_ROOT; Prod: AppData
+    # Dev: BUS_ROOT\license.json ; Prod: %LOCALAPPDATA%\BUSCore\license.json
     if os.environ.get("BUS_ROOT"):
         return Path(os.environ["BUS_ROOT"]) / "license.json"
     return Path(os.environ["LOCALAPPDATA"]) / "BUSCore" / "license.json"
 
-def get_license(*, force_reload: bool | None = None) -> Dict[str, Any]:
-    # No cache in dev. Always reload when BUS_ROOT is set.
-    force_reload = True if os.environ.get("BUS_ROOT") else bool(force_reload)
-    path = _license_path()
-    data: Dict[str, Any] = {"tier": "community", "features": {}, "plugins": {}}
+
+def _read_json(path: Path) -> Tuple[Dict[str, Any], str | None]:
     try:
         with path.open("r", encoding="utf-8") as f:
-            raw = json.load(f)
-            if isinstance(raw, dict):
-                data.update(raw)
-    except Exception:
-        pass
+            data = json.load(f)
+            return data if isinstance(data, dict) else ({}, "not_a_dict")
+    except FileNotFoundError:
+        return {}, "not_found"
+    except json.JSONDecodeError as e:
+        return {}, f"json_error:{e.lineno}:{e.colno}"
+    except Exception as e:
+        return {}, f"error:{type(e).__name__}:{e}"
+
+
+def get_license(*, force_reload: bool | None = None) -> Dict[str, Any]:
+    # ALWAYS fresh in dev (BUS_ROOT set). No module-level cache.
+    force_reload = True if os.environ.get("BUS_ROOT") else bool(force_reload)
+    path = _license_path()
+    raw, err = _read_json(path)
+    data = {**_DEFAULT, **(raw if isinstance(raw, dict) else {})}
+    if err and os.environ.get("BUS_ROOT"):
+        data["_dev_error"] = err  # surfaced by /dev/license for debugging
     return data
 
+
 def feature_enabled(name: str) -> bool:
-    # Force fresh read so gates reflect current license file
+    # CRITICAL: force fresh read so gates reflect current file
     lic = get_license(force_reload=True)
-    return bool(lic.get("features", {}).get(name, False))
+    val = lic.get("features", {}).get(name)
+    if isinstance(val, bool):
+        return val
+    if isinstance(val, dict):
+        flag = val.get("enabled")
+        return bool(flag)
+    return bool(val)


### PR DESCRIPTION
## Summary
- ensure the license loader always reads the BUS_ROOT license file in dev and surfaces debug errors
- update the /dev/license endpoint to return only top-level fields plus the source path for diagnostics
- force the UI directory to come from the repo when BUS_ROOT is set and ensure the directory exists for mounting

## Testing
- pytest *(fails: ImportError: cannot import name 'load_core_config' from 'core.config')*


------
https://chatgpt.com/codex/tasks/task_e_6907f1b8b2ec83228f58fb231e57e0eb