### PR TITLE
Ensure dev license reflects BUS_ROOT state

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -154,7 +154,7 @@ def require_token(req: Request):
 # Add these routes to app
 @app.get("/dev/license")
 def dev_license(request: Request):
-    # try to require a session if helpers exist, but don't crash in dev
+    # Try to require a session if helpers exist; don't crash in dev
     try:
         _load_session_token(request)  # or _require_session(request)
     except Exception:
@@ -163,11 +163,8 @@ def dev_license(request: Request):
     from core.utils.license_loader import _license_path, get_license
 
     lic = get_license(force_reload=True)
-    # Top-level fields for UI + debugging path
-    out = {k: v for k, v in lic.items() if not k.startswith("_")}
+    out = {k: v for k, v in lic.items()}
     out["path"] = str(_license_path())
-    if lic.get("_dev_error"):
-        out["dev_error"] = lic["_dev_error"]
     return out
 
 


### PR DESCRIPTION
## Summary
- ensure the license loader always reads from the BUS_ROOT license file in dev with BOM-safe parsing and normalized flags
- simplify the /dev/license endpoint to return the latest license data with its source path

## Testing
- not run


------
https://chatgpt.com/codex/tasks/task_e_6907f41ca798832280240da9b4d66557