### PR TITLE
Serve UI statics without auth

### DIFF
--- a/core/api/http.py
+++ b/core/api/http.py
@@ -122,10 +122,12 @@ def _check_state(state_b64: str) -> bool:
 
 app = FastAPI(title="BUS Core Alpha", version=VERSION)
 
+UI_DIR = Path(__file__).parent.parent / "ui"
+app.mount("/ui", StaticFiles(directory=UI_DIR, html=True), name="ui")
+
 EXPORTS_DIR = APP_DIR / "exports"
 EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
 
-app.mount("/ui", StaticFiles(directory=str(UI_DIR), html=True), name="ui")
 UI_STATIC_DIR = UI_DIR
 
 


### PR DESCRIPTION
## Summary
- mount the UI directory as static files directly after creating the FastAPI app so the shell and assets resolve

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_69081c907ca48322a919c7c61cead75b