### PR TITLE
Handle vendor duplicates and add inventory verb fallbacks

### DIFF
--- a/core/ui/js/cards/vendors.js
+++ b/core/ui/js/cards/vendors.js
@@ -92,7 +92,18 @@ export async function mountVendors(container) {
       await ensureToken();
       const payload = { name: m.name.trim() };
       if (m.contact && m.contact.trim()) payload.contact = m.contact.trim();
-      try { await apiPost('/app/vendors', payload); } catch {}
+      try {
+        await apiPost('/app/vendors', payload);
+      } catch (err) {
+        const status = err?.status || err?.code;
+        const message = String(err?.error || err?.message || '').toLowerCase();
+        if (status === 409 || message.includes('conflict') || message.includes('exists')) {
+          alert('Vendor already exists');
+          return;
+        }
+        alert(err?.message || err?.error || 'Unable to save vendor');
+        return;
+      }
     } else {
       const list = loadCustomers();
       list.push({


### PR DESCRIPTION
## Summary
- handle duplicate vendor submissions gracefully and avoid closing the modal on conflicts
- ensure inventory writes request a token and fall back through PUT/PATCH/POST for updates
- recalculate quantities via list lookup when adjust endpoints are missing and retry with multiple verbs

## Testing
- Not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690a9cfbab8483229fd4349fae7ae1c9