### PR TITLE
Refactor contacts modal and disable legacy edit

### DIFF
--- a/core/ui/js/cards/vendors.js
+++ b/core/ui/js/cards/vendors.js
@@ -73,50 +73,13 @@ export async function mountVendors(container) {
   const tbody = document.createElement('tbody');
   table.append(thead, tbody);
 
-  // Modal
-  const modal = createModal();
-  document.body.appendChild(modal.root);
-
-  modal.onSubmit = async (m) => {
-    if ((m._kind || mode) === 'vendor') {
-      await ensureToken();
-      const payload = { name: m.name.trim() };
-      if (m.contact && m.contact.trim()) payload.contact = m.contact.trim();
-      try {
-        await apiPost('/app/vendors', payload);
-      } catch (err) {
-        const status = err?.status || err?.code;
-        const message = String(err?.error || err?.message || '').toLowerCase();
-        if (status === 409 || message.includes('conflict') || message.includes('exists')) {
-          alert('Vendor already exists');
-          return;
-        }
-        alert(err?.message || err?.error || 'Unable to save vendor');
-        return;
-      }
-    } else {
-      const list = loadCustomers();
-      list.push({
-        id: `c-${crypto.randomUUID()}`,
-        name: m.name.trim(),
-        contact: (m.contact || '').trim() || null,
-        email: (m.email || '').trim() || null,
-        phone: (m.phone || '').trim() || null,
-        notes: (m.notes || '').trim() || null
-      });
-      saveCustomers(list);
-    }
-    modal.close();
-    await loadAndRender();
-  };
-
   container.append(header, table);
 
   const contactsModal = document.querySelector('[data-role="contacts-modal"]');
   const contactsForm = contactsModal?.querySelector('[data-role="contacts-form"]');
   const contactsSaveBtn = contactsModal?.querySelector('[data-role="contacts-save"]');
   const contactsOpenBtn = document.querySelector('[data-action="open-contacts-modal"]');
-  const contactsCloseBtn = contactsModal?.querySelector('[data-action="close-contacts-modal"]');
+  const contactsCloseButtons = contactsModal ? Array.from(contactsModal.querySelectorAll('[data-action="close-contacts-modal"]')) : [];
   const vendorOnlyWrap = contactsModal?.querySelector('[data-visible-when="vendor"]');
 
   function updateVendorOnly() {
@@ -132,6 +95,16 @@ export async function mountVendors(container) {
     }
     contactsSaveBtn.disabled = !!busy;
     contactsSaveBtn.textContent = busy ? 'Saving…' : contactsSaveBtn.dataset._orig;
+  }
+
+  function disableLegacyEditButton(btn) {
+    if (!btn) return null;
+    const clone = btn.cloneNode(true);
+    clone.disabled = true;
+    clone.dataset.action = 'contact-edit';
+    clone.title = 'Edit coming soon';
+    btn.replaceWith(clone);
+    return clone;
   }
 
   function openContactsModal(preset = {}) {
@@ -150,7 +123,6 @@ export async function mountVendors(container) {
     updateVendorOnly();
     contactsModal.classList.remove('hidden');
     contactsModal.classList.add('open');
-    document.body.classList.add('modal-open');
     contactsForm.elements.name?.focus();
   }
 
@@ -158,13 +130,6 @@ export async function mountVendors(container) {
     if (!contactsModal) return;
     contactsModal.classList.add('hidden');
     contactsModal.classList.remove('open');
-    const otherOpen = Array.from(document.querySelectorAll('.modal')).some((el) => {
-      if (el === contactsModal) return false;
-      return getComputedStyle(el).display !== 'none';
-    });
-    if (!otherOpen) {
-      document.body.classList.remove('modal-open');
-    }
   }
 
   contactsOpenBtn?.addEventListener('click', () => openContactsModal({ type: mode }));
@@ -178,10 +143,12 @@ export async function mountVendors(container) {
     contactsModal.dataset.contactsOverlayBound = '1';
   }
 
-  if (contactsCloseBtn && !contactsCloseBtn.dataset.contactsCloseBound) {
-    contactsCloseBtn.addEventListener('click', () => closeContactsModal());
-    contactsCloseBtn.dataset.contactsCloseBound = '1';
-  }
+  contactsCloseButtons.forEach((btn) => {
+    if (!btn.dataset.contactsCloseBound) {
+      btn.addEventListener('click', () => closeContactsModal());
+      btn.dataset.contactsCloseBound = '1';
+    }
+  });
 
   if (contactsModal && !contactsModal.dataset.contactsEscBound) {
     const escHandler = (event) => {
@@ -287,32 +254,36 @@ export async function mountVendors(container) {
             <button class="del">Delete</button>
           </div>
         </td>`;
-      tr.querySelectorAll('button').forEach(styleBtn);
-
-      tr.querySelector('.edit').onclick = () => {
-        if (r._local) {
-          modal.open({ ...r._full, _kind: 'customer' });
-        } else {
-          // vendors: only name/contact allowed. If edit not supported server-side, disable edit.
-          modal.open({ id: r.id, name: r.name, contact: r.contact || '', _kind: 'vendor' });
+      let editBtn = tr.querySelector('.edit');
+      if (editBtn) {
+        editBtn = disableLegacyEditButton(editBtn);
+        if (editBtn) {
+          styleBtn(editBtn);
+          editBtn.style.cursor = 'not-allowed';
+          editBtn.onmouseenter = null;
+          editBtn.onmouseleave = null;
         }
-      };
+      }
 
-      tr.querySelector('.del').onclick = async () => {
-        if (!confirm(`Delete ${r.name}?`)) return;
-        if (r._local) {
-          const list = loadCustomers().filter(x => x.id !== r.id);
-          saveCustomers(list);
-          renderRows(vendors, list);
-        } else {
-          // Only attempt if DELETE exists; ignore 404
-          try {
-            await ensureToken();
-            await apiDelete(`/app/vendors/${r.id}`);
-          } catch {}
-          await loadAndRender();
-        }
-      };
+      const delBtn = tr.querySelector('.del');
+      if (delBtn) {
+        styleBtn(delBtn);
+        delBtn.onclick = async () => {
+          if (!confirm(`Delete ${r.name}?`)) return;
+          if (r._local) {
+            const list = loadCustomers().filter(x => x.id !== r.id);
+            saveCustomers(list);
+            renderRows(vendors, list);
+          } else {
+            // Only attempt if DELETE exists; ignore 404
+            try {
+              await ensureToken();
+              await apiDelete(`/app/vendors/${r.id}`);
+            } catch {}
+            await loadAndRender();
+          }
+        };
+      }
 
       tbody.appendChild(tr);
     }
@@ -333,68 +304,4 @@ function styleBtn(btn){
   btn.onmouseenter = () => btn.style.background = '#2a3146';
   btn.onmouseleave = () => btn.style.background = '#23293a';
 }
-function createModal(){
-  const root = document.createElement('div');
-  root.style.position='fixed'; root.style.inset='0'; root.style.display='none';
-  root.style.alignItems='center'; root.style.justifyContent='center';
-  root.style.background='rgba(0,0,0,0.55)'; root.style.zIndex='999';
-  const panel=document.createElement('div');
-  panel.style.background='#0f1115'; panel.style.border='1px solid #2b3246';
-  panel.style.borderRadius='12px'; panel.style.padding='16px';
-  panel.style.minWidth='420px'; panel.style.maxWidth='560px';
-  panel.addEventListener('click', e=>e.stopPropagation());
-
-  const title=document.createElement('h3'); title.textContent='Contact'; title.style.margin='0 0 10px 0';
-
-  const form=document.createElement('form'); form.style.display='grid'; form.style.gridTemplateColumns='1fr 1fr'; form.style.gap='10px';
-  const fields=[
-    { key:'name', label:'Name', type:'text', required:true },
-    { key:'contact', label:'Contact', type:'text', required:false },
-    { key:'email', label:'Email', type:'email', required:false },
-    { key:'phone', label:'Phone', type:'text', required:false },
-    { key:'notes', label:'Notes', type:'textarea', required:false, span:true }
-  ];
-  const inputs={};
-  for(const field of fields){
-    const { key, label, type, required, span } = field;
-    const wrap=document.createElement('label'); wrap.style.display='grid'; wrap.style.gap='6px'; wrap.style.fontSize='12px';
-    wrap.textContent=label;
-    const input=type==='textarea'?document.createElement('textarea'):document.createElement('input');
-    if(type!=='textarea'){ input.type=type; }
-    input.name=key; input.required=!!required;
-    input.style.background='#111318'; input.style.color='#e5e7eb'; input.style.border='1px solid #2b3246';
-    input.style.borderRadius='10px'; input.style.padding='8px'; input.style.width='100%'; input.style.boxSizing='border-box';
-    if(type==='textarea'){ input.style.minHeight='80px'; input.style.resize='vertical'; }
-    if(span){ wrap.style.gridColumn='1 / -1'; }
-    inputs[key]=input; wrap.appendChild(input); form.appendChild(wrap);
-  }
-
-  const actions=document.createElement('div'); actions.style.display='flex'; actions.style.gap='10px'; actions.style.justifyContent='flex-end'; actions.style.marginTop='10px';
-  const cancel=document.createElement('button'); cancel.type='button'; cancel.textContent='Cancel'; styleBtn(cancel);
-  const save=document.createElement('button'); save.type='submit'; save.textContent='Save'; styleBtn(save);
-  actions.append(cancel,save);
-  // span actions across form columns and place inside the form
-  actions.style.gridColumn='1 / -1';
-  form.append(actions);
-  panel.append(title,form); root.appendChild(panel);
-
-  const api={
-    root,
-    open(data){ api._current=data||{_kind:'vendor'}; for(const k in inputs){ inputs[k].value=data?.[k]??''; } root.style.display='flex'; setTimeout(()=>document.addEventListener('keydown', escCloser)); },
-    close(){ root.style.display='none'; document.removeEventListener('keydown', escCloser); },
-    onSubmit:null
-  };
-  function escCloser(e){ if(e.key==='Escape') api.close(); }
-  root.addEventListener('click', ()=>api.close());
-  cancel.addEventListener('click', ()=>api.close());
-  form.addEventListener('submit', async (e)=>{
-    e.preventDefault();
-    const model={ ...api._current };
-    for(const k in inputs){ model[k]=inputs[k].value; }
-    if(!model.name || !model.name.trim()) return;
-    if(typeof api.onSubmit==='function'){ await api.onSubmit(model); }
-  });
-  return api;
-}
-
 export default mountVendors;

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -59,6 +59,7 @@
     <div class="modal-dialog modal-content">
       <header class="modal-header">
         <h2 id="contacts-modal-title">Add Contact</h2>
+        <button type="button" data-action="close-contacts-modal" aria-label="Close">×</button>
       </header>
 
       <form data-role="contacts-form" class="modal-body">


### PR DESCRIPTION
## Summary
- align the Contacts modal structure with the Add Item scaffold and add a matching close control
- remove the legacy inline contacts modal implementation and wire the new modal open/close logic
- disable legacy edit actions so the old form cannot reopen while keeping delete flows intact

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690bd19149648322ba2eb566796a5ae1