### PR TITLE
Add contacts detail drawer and fallback table

### DIFF
--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -30,6 +30,21 @@
     .modal.open{display:flex}
     .modal .modal-backdrop{position:absolute;inset:0;background:rgba(0,0,0,0.5)}
     .modal .modal-dialog{position:relative;z-index:1}
+    .drawer{position:fixed;inset:0;display:flex;justify-content:flex-end;pointer-events:none;z-index:60;transition:visibility 0s linear .3s}
+    .drawer.hidden{visibility:hidden}
+    .drawer:not(.hidden){pointer-events:auto;visibility:visible;transition-delay:0s}
+    .drawer .drawer-backdrop{position:absolute;inset:0;background:rgba(0,0,0,0.6);opacity:1;transition:opacity .3s ease}
+    .drawer.hidden .drawer-backdrop{opacity:0}
+    .drawer-panel{position:relative;width:360px;max-width:90vw;background:#1f2126;color:#e6e6e6;box-shadow:-4px 0 16px rgba(0,0,0,0.4);transform:translateX(0);transition:transform .3s ease;display:flex;flex-direction:column}
+    .drawer.hidden .drawer-panel{transform:translateX(100%)}
+    .drawer-header{display:flex;align-items:center;justify-content:space-between;padding:16px;border-bottom:1px solid #2c2f36}
+    .drawer-body{padding:16px;overflow-y:auto;max-height:calc(100vh - 64px);display:flex;flex-direction:column;gap:12px}
+    .drawer-body .kv{display:flex;justify-content:space-between;gap:12px;font-size:13px;background:#23262b;padding:8px 12px;border-radius:8px}
+    .drawer-body .kv .k{color:#9ca3af;text-transform:uppercase;font-size:11px}
+    .drawer-body .kv .v{color:#e6e6e6;word-break:break-word}
+    .drawer-body .mt{margin:16px 0 4px;font-size:14px;color:#cbd5f5}
+    .drawer-body .list{list-style:none;margin:0;padding:0;display:flex;flex-direction:column;gap:6px}
+    .drawer-body .list li{background:#23262b;padding:8px 12px;border-radius:8px;font-size:13px}
   </style>
 </head>
 <body>
@@ -52,10 +67,40 @@
           <h2 style="margin:0;">Contacts</h2>
           <button type="button" data-action="open-contacts-modal">Add Contact</button>
         </div>
-        <p style="margin:0;color:#9ca3af;">Loading…</p>
+        <table data-role="contacts-table" class="table" style="width:100%;border-collapse:separate;border-spacing:0;background:#111318;border-radius:10px;overflow:hidden">
+          <thead>
+            <tr>
+              <th style="text-align:left;padding:10px;background:#1a1f2b">Type</th>
+              <th style="text-align:left;padding:10px;background:#1a1f2b">Contact</th>
+              <th style="text-align:left;padding:10px;background:#1a1f2b">Actions</th>
+            </tr>
+          </thead>
+          <tbody><!-- rows rendered by vendors.js --></tbody>
+        </table>
       </div>
     </div>
   </main>
+
+  <aside data-role="contacts-drawer" class="drawer hidden" aria-hidden="true" role="dialog" aria-labelledby="contact-drawer-title">
+    <div class="drawer-backdrop" data-action="close-contacts-drawer"></div>
+    <div class="drawer-panel">
+      <header class="drawer-header">
+        <h3 id="contact-drawer-title" style="margin:0;font-size:18px;color:#f8fafc">Contact</h3>
+        <button type="button" data-action="close-contacts-drawer" aria-label="Close" style="background:transparent;border:none;color:#9ca3af;font-size:24px;cursor:pointer;line-height:1">×</button>
+      </header>
+      <section class="drawer-body">
+        <div class="kv"><span class="k">Type</span><span class="v" data-field="type"></span></div>
+        <div class="kv"><span class="k">Name</span><span class="v" data-field="name"></span></div>
+        <div class="kv"><span class="k">Email</span><span class="v" data-field="email"></span></div>
+        <div class="kv vendor-only"><span class="k">Material</span><span class="v" data-field="material"></span></div>
+        <div class="kv"><span class="k">Lead time (days)</span><span class="v" data-field="lead_time_days"></span></div>
+        <div class="kv"><span class="k">Notes</span><span class="v" data-field="notes"></span></div>
+
+        <h4 class="mt">Linked items</h4>
+        <ul data-role="linked-items" class="list"><!-- populated by vendors.js --></ul>
+      </section>
+    </div>
+  </aside>
 
   <div id="contacts-modal"
        data-role="contacts-modal"


### PR DESCRIPTION
## Summary
- add the contacts table skeleton and drawer markup to the shell layout
- render contacts in the table, open the detail drawer on row or edit clicks, and fetch vendor-linked items with fallbacks

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690be572ade88322b83856760c487256