### PR TITLE
Implement Step 1 UI and workflow updates

### DIFF
--- a/core/ui/js/cards/backup.js
+++ b/core/ui/js/cards/backup.js
@@ -1,3 +1,50 @@
-export function mountBackup(container){
-  container.innerHTML = `<div class="card"><h2>Backup</h2><p>Stub: Backup tools coming.</p></div>`;
+import { ensureToken } from '../api.js';
+
+export function mountBackup(container) {
+  if (container) {
+    container.innerHTML = `
+      <div class="card">
+        <button type="button" data-action="export-backup">Export</button>
+        <small class="muted">Downloads current app.db (or fallback endpoint).</small>
+      </div>
+    `;
+  }
+  mountBackupExport();
 }
+
+export function mountBackupExport() {
+  const btn = document.querySelector('[data-action="export-backup"]');
+  if (!btn || btn.dataset.backupBound) return;
+  btn.dataset.backupBound = '1';
+
+  btn.addEventListener('click', async () => {
+    try {
+      const token = await ensureToken();
+      const tryDownload = async (url, filename) => {
+        const res = await fetch(url, {
+          headers: { 'X-Session-Token': token },
+        });
+        if (!res.ok) return false;
+        const blob = await res.blob();
+        const link = document.createElement('a');
+        const href = URL.createObjectURL(blob);
+        link.href = href;
+        link.download = filename;
+        document.body.appendChild(link);
+        link.click();
+        link.remove();
+        URL.revokeObjectURL(href);
+        return true;
+      };
+
+      if (await tryDownload('/app/backup', 'app-backup.db')) return;
+      if (await tryDownload('/app.db', 'app.db')) return;
+      alert('No backup endpoint found.');
+    } catch (err) {
+      console.error('backup export failed', err);
+      alert('Could not export backup.');
+    }
+  });
+}
+
+export default mountBackup;

--- a/core/ui/js/cards/organizer.js
+++ b/core/ui/js/cards/organizer.js
@@ -1,8 +1,164 @@
-export function mountOrganizer(container) {
-  container.innerHTML = `
-    <section>
-      <h2>Organizer</h2>
-      <p>Stub card. Implement scan/preview/commit flows later.</p>
-    </section>
-  `;
+const LS_KEY = 'tasks.v1';
+
+const load = () => {
+  try {
+    const raw = localStorage.getItem(LS_KEY);
+    if (!raw) return [];
+    const parsed = JSON.parse(raw);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+};
+
+const save = (arr) => {
+  localStorage.setItem(LS_KEY, JSON.stringify(arr || []));
+};
+
+let tasksBound = false;
+let tableBodyRef = null;
+let titleInputRef = null;
+let statusInputRef = null;
+
+function buildRow(task, idx) {
+  const tr = document.createElement('tr');
+
+  const titleCell = document.createElement('td');
+  const titleField = document.createElement('input');
+  titleField.type = 'text';
+  titleField.value = task.title || '';
+  titleField.dataset.idx = String(idx);
+  titleField.dataset.field = 'title';
+  titleCell.appendChild(titleField);
+
+  const statusCell = document.createElement('td');
+  const statusField = document.createElement('select');
+  statusField.dataset.idx = String(idx);
+  statusField.dataset.field = 'status';
+  ['todo', 'doing', 'done'].forEach((value) => {
+    const opt = document.createElement('option');
+    opt.value = value;
+    opt.textContent = value;
+    if (task.status === value) opt.selected = true;
+    statusField.appendChild(opt);
+  });
+  statusCell.appendChild(statusField);
+
+  const actionCell = document.createElement('td');
+  const delBtn = document.createElement('button');
+  delBtn.type = 'button';
+  delBtn.dataset.action = 'task-del';
+  delBtn.dataset.idx = String(idx);
+  delBtn.textContent = 'Delete';
+  actionCell.appendChild(delBtn);
+
+  tr.append(titleCell, statusCell, actionCell);
+  return tr;
 }
+
+function refreshTable() {
+  if (!tableBodyRef) return;
+  const list = load();
+  tableBodyRef.innerHTML = '';
+  list.forEach((task, idx) => {
+    tableBodyRef.appendChild(buildRow(task, idx));
+  });
+}
+
+function addTask() {
+  const title = (titleInputRef?.value || '').trim();
+  const status = statusInputRef?.value || 'todo';
+  if (!title) return;
+  const list = load();
+  list.push({ title, status });
+  save(list);
+  if (titleInputRef) titleInputRef.value = '';
+  refreshTable();
+}
+
+function updateTask(idx, field, value) {
+  const list = load();
+  const i = Number(idx);
+  if (!Number.isFinite(i) || !list[i]) return;
+  list[i][field] = value;
+  save(list);
+}
+
+function deleteTask(idx) {
+  const list = load();
+  const i = Number(idx);
+  if (!Number.isFinite(i) || !list[i]) return;
+  list.splice(i, 1);
+  save(list);
+  refreshTable();
+}
+
+export function mountOrganizer(container) {
+  const scope = container instanceof HTMLElement ? container : document;
+
+  if (container instanceof HTMLElement && !container.querySelector('[data-role="tasks-table"]')) {
+    container.innerHTML = `
+      <div class="card" data-role="tasks-card">
+        <div class="toolbar" style="display:flex;gap:8px;align-items:center;margin-bottom:12px;">
+          <input type="text" data-role="task-title-input" placeholder="New task title" style="flex:1;min-width:160px;">
+          <select data-role="task-status-input">
+            <option value="todo">todo</option>
+            <option value="doing">doing</option>
+            <option value="done">done</option>
+          </select>
+          <button type="button" data-action="task-add">Add Task</button>
+        </div>
+        <table class="table" data-role="tasks-table">
+          <thead><tr><th>Title</th><th>Status</th><th>Actions</th></tr></thead>
+          <tbody></tbody>
+        </table>
+      </div>
+    `;
+  }
+
+  tableBodyRef = scope.querySelector('[data-role="tasks-table"] tbody');
+  titleInputRef = scope.querySelector('[data-role="task-title-input"]');
+  statusInputRef = scope.querySelector('[data-role="task-status-input"]');
+  if (!tableBodyRef) return;
+
+  refreshTable();
+
+  const addBtn = scope.querySelector('[data-action="task-add"]');
+  if (addBtn && !addBtn.dataset.taskAddBound) {
+    addBtn.addEventListener('click', addTask);
+    addBtn.dataset.taskAddBound = '1';
+  }
+
+  if (!tasksBound) {
+    document.addEventListener('input', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const { idx, field } = target.dataset || {};
+      if (idx == null || field == null) return;
+      updateTask(idx, field, target.value);
+    });
+
+    document.addEventListener('change', (event) => {
+      const target = event.target;
+      if (!(target instanceof HTMLElement)) return;
+      const { idx, field } = target.dataset || {};
+      if (idx == null || field == null) return;
+      updateTask(idx, field, target.value);
+    });
+
+    document.addEventListener('click', (event) => {
+      const el = event.target instanceof HTMLElement ? event.target : null;
+      if (!el) return;
+      const delBtn = el.closest('[data-action="task-del"]');
+      if (delBtn) {
+        const { idx } = delBtn.dataset || {};
+        if (idx != null) deleteTask(idx);
+        return;
+      }
+    });
+
+    tasksBound = true;
+  }
+}
+
+export default mountOrganizer;

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -26,6 +26,12 @@
     button{background:var(--accent);color:#fff;border:none;padding:8px 12px;border-radius:6px;cursor:pointer}
     button:hover{opacity:.9}
     pre{background:#111;padding:12px;border-radius:6px;overflow:auto;font-size:12px}
+    .hidden{display:none!important}
+    .top-bar{display:flex;align-items:center;justify-content:flex-end;margin-bottom:16px;gap:12px}
+    .tabs{display:flex;gap:8px;margin-bottom:16px}
+    .tabs button{background:#2b2f36;color:#e6e6e6;border:1px solid #363b44;padding:8px 14px;border-radius:10px;cursor:pointer}
+    .tabs button.active{background:var(--accent);border-color:var(--accent);color:#fff}
+    .tab-panel{display:flex;flex-direction:column;gap:16px}
     .modal.hidden{display:none}
     .modal.open{display:flex}
     .modal .modal-backdrop{position:absolute;inset:0;background:rgba(0,0,0,0.5)}
@@ -62,22 +68,70 @@
   </nav>
   <main id="main">
     <div id="app">
-      <div class="card" data-view="contacts">
-        <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;">
-          <h2 style="margin:0;">Contacts</h2>
-          <button type="button" data-action="open-contacts-modal">Add Contact</button>
+      <header class="top-bar">
+        <span id="license-badge" data-role="license-badge">License: community</span>
+      </header>
+
+      <nav class="tabs" data-role="main-tabs">
+        <button data-tab="manufacturing" class="active">Manufacturing</button>
+        <button data-tab="tasks">Tasks</button>
+        <button data-tab="backup">Backup</button>
+      </nav>
+
+      <section data-tab-panel="manufacturing" class="tab-panel">
+        <div class="card">
+          <form data-role="mfg-run-form">
+            <div class="field">
+              <label for="mfg-notes">Notes</label>
+              <input id="mfg-notes" name="notes" type="text" placeholder="Run notes (optional)">
+            </div>
+            <button type="submit" data-role="mfg-run-btn">Run Manufacturing</button>
+            <small data-role="mfg-hint" class="muted">Disabled if backend returns 501.</small>
+          </form>
         </div>
-        <table data-role="contacts-table" class="table" style="width:100%;border-collapse:separate;border-spacing:0;background:#111318;border-radius:10px;overflow:hidden">
-          <thead>
-            <tr>
-              <th style="text-align:left;padding:10px;background:#1a1f2b">Type</th>
-              <th style="text-align:left;padding:10px;background:#1a1f2b">Contact</th>
-              <th style="text-align:left;padding:10px;background:#1a1f2b">Actions</th>
-            </tr>
-          </thead>
-          <tbody><!-- rows rendered by vendors.js --></tbody>
-        </table>
-      </div>
+
+        <div class="card" data-view="contacts">
+          <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;">
+            <h2 style="margin:0;">Contacts</h2>
+            <button type="button" data-action="open-contacts-modal">Add Contact</button>
+          </div>
+          <table data-role="contacts-table" class="table" style="width:100%;border-collapse:separate;border-spacing:0;background:#111318;border-radius:10px;overflow:hidden">
+            <thead>
+              <tr>
+                <th style="text-align:left;padding:10px;background:#1a1f2b">Type</th>
+                <th style="text-align:left;padding:10px;background:#1a1f2b">Contact</th>
+                <th style="text-align:left;padding:10px;background:#1a1f2b">Actions</th>
+              </tr>
+            </thead>
+            <tbody><!-- rows rendered by vendors.js --></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section data-tab-panel="tasks" class="tab-panel hidden">
+        <div class="card" data-role="tasks-card">
+          <div class="toolbar" style="display:flex;gap:8px;align-items:center;margin-bottom:12px;">
+            <input type="text" data-role="task-title-input" placeholder="New task title" style="flex:1;min-width:160px;">
+            <select data-role="task-status-input">
+              <option value="todo">todo</option>
+              <option value="doing">doing</option>
+              <option value="done">done</option>
+            </select>
+            <button type="button" data-action="task-add">Add Task</button>
+          </div>
+          <table class="table" data-role="tasks-table" style="width:100%;border-collapse:separate;border-spacing:0;background:#111318;border-radius:10px;overflow:hidden">
+            <thead><tr><th>Title</th><th>Status</th><th>Actions</th></tr></thead>
+            <tbody></tbody>
+          </table>
+        </div>
+      </section>
+
+      <section data-tab-panel="backup" class="tab-panel hidden">
+        <div class="card">
+          <button type="button" data-action="export-backup">Export</button>
+          <small class="muted">Downloads current app.db (or fallback endpoint).</small>
+        </div>
+      </section>
     </div>
   </main>
 


### PR DESCRIPTION
## Summary
- add a license badge, manufacturing/tasks/backup tabs, and dedicated backup export button to the shell layout
- bootstrap the new tabs, license fetch, manufacturing stub, backup export, and local tasks board on app startup
- support inventory item types, improved adjust fallbacks, and vendor de-duplication when adding contacts

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690becfa0de48322b6c393d09f3e66ae