### PR TITLE
Disable legacy contact triggers

### DIFF
--- a/core/ui/js/cards/vendors.js
+++ b/core/ui/js/cards/vendors.js
@@ -482,6 +482,18 @@ export async function mountVendors(container) {
   closeDrawer();
 
   await renderContactsTable();
+
+  // Defensive: neutralize any legacy openers lingering in the DOM
+  document
+    .querySelectorAll(
+      '[data-action="contact-edit-legacy"], [data-action="open-contact"], [data-action="new-contact"], [data-action="new"]'
+    )
+    .forEach((btn) => {
+      const clone = btn.cloneNode(true);
+      clone.disabled = true;
+      clone.title = 'Replaced by new Contacts UI';
+      btn.replaceWith(clone);
+    });
   // --- END SPEC-1 BODY ---
 }
 function styleBtn(btn){


### PR DESCRIPTION
## Summary
- disable any lingering legacy contact action elements by replacing them with inert clones

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_690bf348e4dc832283c187ad682ed74a