### PR TITLE
Add home screen skeleton and router hook

### DIFF
--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -1,12 +1,13 @@
 import { ensureToken } from "./js/token.js";
 import { mountBackupExport } from "./js/cards/backup.js";
 import * as ContactsCard from "./js/cards/vendors.js";
+import { mountHome } from "./js/cards/home.js";
 
 const mountContacts =
   ContactsCard.mountContacts || ContactsCard.mount || ContactsCard.default;
 
 const getRoute = () => {
-  const h = (location.hash || '#/tools').replace(/^#\/?/, '');
+  const h = (location.hash || '#/home').replace(/^#\/?/, '');
   const base = h.split(/[\/?]/)[0] || 'tools';
   return base;
 };
@@ -66,6 +67,10 @@ const onRouteChange = async () => {
   const route = getRoute();
   setActiveNav(route);
 
+  if (route === 'home' || route === '') {
+    mountHome();
+  }
+
   const isTools = (route === 'tools');
   showToolsTabs(isTools);
 
@@ -97,7 +102,7 @@ const safeRouteChange = () => {
 window.addEventListener('hashchange', safeRouteChange);
 window.addEventListener('load', safeRouteChange);
 
-if (!location.hash) location.replace('#/tools');
+if (!location.hash) location.hash = '#/home';
 
 document.addEventListener('DOMContentLoaded', async () => {
   try {

--- a/core/ui/js/cards/home.js
+++ b/core/ui/js/cards/home.js
@@ -1,0 +1,8 @@
+export function mountHome() {
+  const container = document.querySelector('[data-role="home-screen"]');
+  if (!container) return;
+  container.classList.remove('hidden');
+  // stub data
+  document.querySelector('[data-role="net-30"]').textContent = 'Net (Last 30 Days): $0.00';
+  document.querySelector('[data-role="recent-transactions"] tbody').innerHTML = '';
+}

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -68,6 +68,34 @@
         <span id="license-badge" data-role="license-badge">License: community</span>
       </header>
 
+      <!-- Home screen container -->
+      <div data-role="home-screen" class="card">
+        <div class="home-actions">
+          <button data-action="open-expense-modal" class="btn btn-red btn-large">Add Expense</button>
+          <button data-action="open-revenue-modal" class="btn btn-green btn-large">Add Revenue</button>
+        </div>
+
+        <div class="snapshot">
+          <div data-role="net-30">Net (Last 30 Days): $0.00</div>
+          <div class="donuts">
+            <div data-role="donut-in"></div>
+            <div data-role="donut-out"></div>
+          </div>
+        </div>
+
+        <div class="recent-table">
+          <table data-role="recent-transactions">
+            <thead><tr><th>Date</th><th>Type</th><th>Amount</th><th>Notes</th></tr></thead>
+            <tbody></tbody>
+          </table>
+          <a href="#/transactions">View all →</a>
+        </div>
+      </div>
+
+      <!-- Modals (empty shells) -->
+      <div data-role="expense-modal" class="modal hidden">…</div>
+      <div data-role="revenue-modal" class="modal hidden">…</div>
+
       <section data-route="tools">
         <!-- Tools page header tabs (scoped to Tools page only) -->
         <div data-role="tools-tabs-root" class="hidden">


### PR DESCRIPTION
## Summary
- add the home screen container and modal placeholders to the shell
- mount the home card when navigating to the #/home route
- provide a stub mountHome helper that populates placeholder data

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_690cf6a7e59c83229b82dc8f78d12c6a