### PR TITLE
Fix POST /app/transactions routing

### DIFF
--- a/core/api/app_router.py
+++ b/core/api/app_router.py
@@ -68,7 +68,7 @@ def create_app_vendor(
     return {"id": vendor.id, "name": vendor.name}
 
 
-@router.post("/app/transactions")
+@router.post("/transactions")
 def add_transaction(
     data: Dict[str, Any],
     db: Session = Depends(get_db),


### PR DESCRIPTION
## Summary
- correct the transactions endpoint route so it is available at `/app/transactions`

## Testing
- not run (not requested)


------
https://chatgpt.com/codex/tasks/task_e_690d057a52648322b66ae4dc50e44afd