### PR TITLE
Add transactions read endpoints and refresh home card data

### DIFF
--- a/core/ui/js/cards/home.js
+++ b/core/ui/js/cards/home.js
@@ -5,6 +5,8 @@ export function mountHome() {
   // stub data
   document.querySelector('[data-role="net-30"]').textContent = 'Net (Last 30 Days): $0.00';
   document.querySelector('[data-role="recent-transactions"] tbody').innerHTML = '';
+  // initial data load
+  if (typeof refreshHomeData === 'function') { refreshHomeData(); } else { try { refreshHomeData(); } catch(_) {} }
 }
 
 // ===== Expense modal wiring (MVP) =====
@@ -72,4 +74,90 @@ window.SMOKE.homeExpense = () => ({
   modalExists: !!document.querySelector('[data-role="expense-modal"]'),
   formExists:  !!document.querySelector('[data-role="expense-form"]'),
   canOpen:     (() => { openExpenseModal(); const open = expenseModal && !expenseModal.classList.contains('hidden'); closeExpenseModal(); return !!open; })(),
+});
+
+// ===== Home data refresh (summary + recent) =====
+// Lightweight local GET with session token; falls back to direct fetch of /session/token.
+async function _getSessionToken() {
+  if (window._BUS_TOKEN) return window._BUS_TOKEN;
+  try {
+    const t = await fetch('/session/token').then(r => r.json());
+    window._BUS_TOKEN = t.token;
+    return window._BUS_TOKEN;
+  } catch {
+    return null;
+  }
+}
+async function httpGetJson(path) {
+  try {
+    // Prefer app's apiGet if present
+    if (typeof window.apiGet === 'function') return await window.apiGet(path);
+    const tok = await _getSessionToken();
+    const res = await fetch(path, { headers: tok ? { 'X-Session-Token': tok } : {} });
+    if (!res.ok) throw new Error(res.status + ' ' + res.statusText);
+    return await res.json();
+  } catch (e) {
+    console.error('GET', path, e);
+    throw e;
+  }
+}
+function formatUSDFromCents(cents) {
+  const sign = cents < 0 ? '-' : '';
+  const abs = Math.abs(cents);
+  const dollars = Math.floor(abs / 100);
+  const pennies = (abs % 100).toString().padStart(2, '0');
+  return `${sign}$${dollars}.${pennies}`;
+}
+function renderRecentTable(items, filter) {
+  const tbody = document.querySelector('[data-role="recent-transactions"] tbody');
+  if (!tbody) return;
+  const rows = (items || [])
+    .filter(it => !filter || it.type === filter)
+    .map(it => {
+      const amt = formatUSDFromCents(it.amount_cents);
+      const note = (it.notes || '').replace(/\s+/g,' ').trim();
+      return `<tr data-type="${it.type}"><td>${it.date}</td><td>${it.type}</td><td>${amt}</td><td>${note}</td></tr>`;
+    })
+    .join('');
+  tbody.innerHTML = rows || '';
+}
+let _homeFilter = null; // 'revenue' | 'expense' | null
+async function refreshHomeData() {
+  // Summary (30d)
+  try {
+    const sum = await httpGetJson('/app/transactions/summary?window=30d');
+    const netEl = document.querySelector('[data-role="net-30"]');
+    if (netEl) netEl.textContent = `Net (Last 30 Days): ${formatUSDFromCents(sum.net_cents)}`;
+    // Donut placeholders: just write totals as text for now
+    const dIn = document.querySelector('[data-role="donut-in"]');
+    const dOut = document.querySelector('[data-role="donut-out"]');
+    if (dIn) dIn.textContent = `In: ${formatUSDFromCents(sum.in_cents)}`;
+    if (dOut) dOut.textContent = `Out: ${formatUSDFromCents(sum.out_cents)}`;
+  } catch (e) {
+    console.error('summary refresh failed', e);
+  }
+  // Recent items (limit 10; since optional)
+  try {
+    const today = new Date();
+    const cutoff = new Date(today.getTime() - 29*24*60*60*1000).toISOString().slice(0,10); // ~30d window inclusive
+    const recent = await httpGetJson(`/app/transactions?since=${cutoff}&limit=10`);
+    renderRecentTable(recent.items || [], _homeFilter);
+  } catch (e) {
+    console.error('recent refresh failed', e);
+  }
+}
+// Expose for other code (e.g., after save)
+window.refreshHomeData = refreshHomeData;
+
+// Donut click filter wiring
+document.addEventListener('click', (e) => {
+  const t = e.target;
+  if (t?.matches?.('[data-role="donut-in"]')) {
+    _homeFilter = _homeFilter === 'revenue' ? null : 'revenue';
+    refreshHomeData();
+  }
+  if (t?.matches?.('[data-role="donut-out"]')) {
+    _homeFilter = _homeFilter === 'expense' ? null : 'expense';
+    refreshHomeData();
+  }
 });


### PR DESCRIPTION
## Summary
- add GET /app/transactions and /app/transactions/summary endpoints that reuse a shared table bootstrap helper
- compute and return in/out/net cents over the requested window for summary requests
- refresh the home UI card by fetching summary + recent data, formatting USD, and wiring donut click filters

## Testing
- python -m compileall core/api/app_router.py

------
https://chatgpt.com/codex/tasks/task_e_690d0948f3f883228b5b6c037007f444