### PR TITLE
Gohabsgo

### DIFF
--- a/04_SECURITY_TRUST_AND_OPERATIONS.md
+++ b/04_SECURITY_TRUST_AND_OPERATIONS.md
@@ -19,6 +19,9 @@ Core trust is not only about preventing compromise. It is also about preserving 
 - RID/path-token resolution (`core/reader/ids.py`) is treated as part of the local-file trust boundary and now uses compatibility-aware hardening (new-write `local:v2:<sig32>:<payload>`, old-read legacy support).
 - B324 in `core/reader/ids.py` is resolved via real hardening (stronger active RID signature construction and strict fail-closed validation), without suppression-based handling.
 - Commit-path enforcement is tightened so present RID fields are authoritative for resolution and invalid RID values do not silently downgrade to raw-path fallback.
+- Sandbox transform execution is now a fixed-command boundary: subprocess argv is limited to BUS Core-owned runner arguments, while `plugin_id`, `fn`, and transform payload move through stdin JSON only and malformed stdin is rejected in the runner.
+- Restore/import preview metadata in the admin UI is now rendered with DOM text nodes rather than dynamic `innerHTML`, so path/schema/count values are treated as text and not markup.
+- Local open/validate, import/export preview/commit, and plugin UI asset paths now resolve through explicit allowed roots before filesystem access or OS-open behavior.
 
 | Concern | Status | Enforced by | Scope | Notes |
 | --- | --- | --- | --- | --- |
@@ -108,6 +111,13 @@ This is the core trust boundary as implemented today: local runtime first, bound
 | Finance mutations | Canonical | `/app/finance/expense`, `/app/finance/refund` | Explicit token + `require_writes` | Owner commit is not currently part of this domain policy. |
 | Config and policy writes | Canonical | `/app/config`, `/policy`, `/settings/google`, `/settings/reader`, `/plans*`, `/plugins/{pid}/enable` | `/app/config` has explicit token + `require_writes`; other admin routes are protected router + write gate where applicable | Owner commit is not universal across these admin writes. |
 | Open local path / restart server | Canonical | `/open/local`, `/server/restart` | Protected router + `require_writes` | Performs OS-visible side effects. |
+
+### Path and subprocess boundaries
+
+- Sandbox transform subprocess execution is constrained to a fixed BUS Core-owned command (`sys.executable -m core.runtime.sandbox_runner`); dynamic transform fields are not allowed in argv.
+- Import preview/commit accepts only paths that resolve under `EXPORTS_DIR`; staged uploads are written under the same canonical exports root.
+- Local validate/open accepts only paths that resolve under configured `local_fs` roots; resolved safe paths are the only values passed to Explorer, `os.startfile`, or `xdg-open`.
+- Plugin UI asset resolution is constrained to `PLUGIN_UI_BASES/<plugin>/ui` roots and must remain in-root after normalization.
 
 ## Adapters and integrations
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@
 ## [Unreleased]
 
 ### Fixed
+- Hardened sandbox transform execution so subprocess argv is fixed to BUS Core-owned arguments only and dynamic transform data is passed through stdin JSON with controlled malformed-request handling.
+- Hardened the legacy compatibility router so route dispatch is allowlisted and prototype-safe, with unknown or malicious-looking routes falling back safely to `/home`.
+- Replaced admin restore/import preview `innerHTML` rendering with text-safe DOM construction so preview metadata is rendered as text rather than reinterpreted as markup.
+- Added shared safe path resolution for import/export, local-open, local-validate, and plugin UI asset paths so user-controlled path values must resolve under explicit allowed roots before filesystem or OS-open use.
 - Fixed Manufacturing stock display so recipe input/output rows show current on-hand inventory values instead of `—`.
 - Aligned Manufacturing stock rendering with Inventory's item display helper.
 - Fixed item-entry workflow so adding a vendor from the item form preserves current item fields.
@@ -42,6 +46,7 @@
 - Added a narrow `verified_ready` promotion helper that writes `verified_ready` only when `hash_verified`, `extracted`, and `exe_verified` all agree on version/channel/hash/path data and the cached ZIP, extracted version directory, and extracted EXE still exist inside the confined update-cache roots.
 
 ### Changed
+- Bumped `INTERNAL_VERSION` from `1.1.0.6` to `1.1.0.7` for the pre-PR security hardening governance/docs pass without changing public `VERSION`.
 - Bumped `INTERNAL_VERSION` from `1.1.0.5` to `1.1.0.6` for the Manufacturing/Inventory UI correctness patch without changing public `VERSION`.
 - Bumped `INTERNAL_VERSION` from `1.1.0.4` to `1.1.0.5` for security-tooling workflow governance without changing public `VERSION`.
 - Required signed manifests for the default `/app/update/stage` service path while leaving read-only `/app/update/check` unsigned-manifest compatibility unchanged.
@@ -117,6 +122,7 @@
 - Aligned release/update documentation and README wording with actual behavior: Lighthouse remains the default manifest URL, checksum metadata may be published, and the app does not verify checksum, signature, publisher, or artifact size before surfacing `download_url`.
 
 ### Tests
+- Added focused regression coverage for sandbox command construction, legacy router dispatch, admin preview rendering, and path traversal/outside-root rejection.
 - Passed `node --check core/ui/js/cards/manufacturing.js`.
 - Passed `node --check core/ui/js/cards/inventory.js`.
 - Passed `node --check core/ui/js/lib/item-display.js`.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,12 @@
 
 ## [Unreleased]
 
+### Fixed
+- Fixed Manufacturing stock display so recipe input/output rows show current on-hand inventory values instead of `—`.
+- Aligned Manufacturing stock rendering with Inventory's item display helper.
+- Fixed item-entry workflow so adding a vendor from the item form preserves current item fields.
+- Added in-form vendor creation flow that returns to the item form and selects the newly created vendor.
+
 ### Added
 - Added `.github/workflows/security-audit.yml` with Bandit source scanning, Medium/High Bandit CI failure, Low-severity advisory reporting, and advisory `pip-audit` evidence against `requirements.txt`.
 - Added tracked governance summary for the completed security hardening pass: route-local guard consistency, Docker loopback default, loopback-only CORS, signed-manifest update staging, active security-audit workflow, and the local post-hardening OWASP 2025 reassessment. The OWASP report itself remains a local ignored report and is not release evidence on its own.
@@ -36,6 +42,7 @@
 - Added a narrow `verified_ready` promotion helper that writes `verified_ready` only when `hash_verified`, `extracted`, and `exe_verified` all agree on version/channel/hash/path data and the cached ZIP, extracted version directory, and extracted EXE still exist inside the confined update-cache roots.
 
 ### Changed
+- Bumped `INTERNAL_VERSION` from `1.1.0.5` to `1.1.0.6` for the Manufacturing/Inventory UI correctness patch without changing public `VERSION`.
 - Bumped `INTERNAL_VERSION` from `1.1.0.4` to `1.1.0.5` for security-tooling workflow governance without changing public `VERSION`.
 - Required signed manifests for the default `/app/update/stage` service path while leaving read-only `/app/update/check` unsigned-manifest compatibility unchanged.
 - Bumped `INTERNAL_VERSION` from `1.1.0.3` to `1.1.0.4` for update-staging signed-manifest enforcement without changing public `VERSION`.
@@ -110,6 +117,12 @@
 - Aligned release/update documentation and README wording with actual behavior: Lighthouse remains the default manifest URL, checksum metadata may be published, and the app does not verify checksum, signature, publisher, or artifact size before surfacing `download_url`.
 
 ### Tests
+- Passed `node --check core/ui/js/cards/manufacturing.js`.
+- Passed `node --check core/ui/js/cards/inventory.js`.
+- Passed `node --check core/ui/js/lib/item-display.js`.
+- Passed `git diff --check -- core/ui/js/lib/item-display.js core/ui/js/cards/inventory.js core/ui/js/cards/manufacturing.js`.
+- Smoke was reported green for this focused UI correctness patch.
+- UI contract audit was not completed: `scripts/ui_contract_audit.ps1` currently fails to parse at line 103, and `scripts/ui_contract_audit.sh` currently fails under bash because CRLF leaves `set: pipefail\r: invalid option name`.
 - Added focused update-policy and manifest-validation coverage for allowed/rejected channels, stable backward compatibility, non-stable channel isolation, invalid metadata rejection, declared metadata retention, and the localhost/private-host error-code contract.
 - Added targeted RID security coverage in `tests/test_reader_rid_security.py` for legacy compatibility, v2 resolution, malformed/tampered rejection, and mixed legacy/v2 commit-reader flows.
 - Added Phase D validation coverage asserting the Home dashboard keeps explicit placeholder disclosure while it still depends on `/app/transactions*` stub routes.

--- a/SOT.md
+++ b/SOT.md
@@ -82,6 +82,8 @@
 
 * Security hardening that changes boundary behavior must be mirrored into `CHANGELOG.md`, `SOT.md`, and affected governance/security docs to prevent policy drift.
 
+* Current hardening posture also treats sandbox command construction, admin preview DOM rendering, and import/local path resolution as boundary-sensitive surfaces: sandbox subprocess argv must remain BUS Core-owned and fixed, untrusted preview metadata must render as text, and user-influenced filesystem paths must resolve under explicit allowed roots before use.
+
 * `scripts/validate_change_trace.py` is the hard traceability guard: if code/control surfaces change, both `CHANGELOG.md` and `core/version.py` MUST be in the same diff, and `INTERNAL_VERSION` MUST be bumped for meaningful repo changes.
 
 * `.github/workflows/security-audit.yml` is the canonical security-tooling workflow. It runs Bandit against `core`, `tgc`, `scripts`, and `launcher.py`; Medium/High findings fail CI while Low findings remain visible advisory output. It also runs `pip-audit` against `requirements.txt` in advisory mode until BUS Core has a fully pinned/locked audit input.

--- a/TGC-COMPLIANCE.md
+++ b/TGC-COMPLIANCE.md
@@ -14,9 +14,9 @@
 ## 3. Compliance status
 - Status: COMPLIANT
 - Source audit report: `tgc-ops/indexes/daily-estate-compliance-report.md`
-- Source audit UTC: 2026-04-29T13:09:16.5520646Z
+- Source audit UTC: 2026-04-30T13:10:17.2085836Z
 - Last projected by: Codex Local Automation
-- Projection date UTC: 2026-04-29T13:32:25.3832155Z
+- Projection date UTC: 2026-04-30T13:32:14.0507410Z
 
 ## 4. Baseline checks
 - README: YES

--- a/core/api/http.py
+++ b/core/api/http.py
@@ -124,6 +124,7 @@ from core.appdb.models import Base
 from core.appdb.paths import ui_dir
 from core.appdata.paths import db_path_for_mode, resolve_bus_mode
 from core.runtime.instance_lock import acquire_db_owner_lock
+from core.utils.pathsafe import PathSafetyError, resolve_path_under_roots
 
 if os.name == "nt":  # pragma: no cover - windows specific
     from core.broker.pipes import NamedPipeServer
@@ -733,10 +734,9 @@ def _resolve_plugin_ui_path(plugin_id: str, resource: str) -> Path | None:
             continue
         if not ui_root_resolved.exists() or not ui_root_resolved.is_dir():
             continue
-        candidate = (ui_root_resolved / safe_resource).resolve(strict=False)
         try:
-            candidate.relative_to(ui_root_resolved)
-        except ValueError:
+            candidate = resolve_path_under_roots(safe_resource, [ui_root_resolved])
+        except PathSafetyError:
             continue
         if candidate.exists() and candidate.is_file():
             return candidate
@@ -1444,14 +1444,30 @@ def _decode_local_id(local_id: str) -> str:
 def _allowed_local_path(path: str) -> bool:
     """Return True if the path is within the configured local roots."""
 
+    try:
+        _resolve_allowed_local_path(path)
+    except HTTPException:
+        return False
+    return True
+
+
+def _configured_local_roots() -> list[Path]:
     broker = _broker()
     try:
         settings = broker._catalog._providers["local_fs"]._settings()  # type: ignore[attr-defined]
-        roots = [os.path.abspath(p) for p in settings.get("local_roots", [])]
+        return [Path(p) for p in settings.get("local_roots", []) if isinstance(p, str) and p.strip()]
     except Exception:
-        roots = []
-    ap = os.path.abspath(path)
-    return any(os.path.commonpath([ap, root]) == root for root in roots)
+        return []
+
+
+def _resolve_allowed_local_path(path: str) -> Path:
+    try:
+        return resolve_path_under_roots(path, _configured_local_roots())
+    except PathSafetyError as exc:
+        if exc.code == "path_empty":
+            raise HTTPException(status_code=400, detail="bad_local_path") from exc
+        raise HTTPException(status_code=403, detail="path_not_allowed") from exc
+
 
 
 def _list_windows_drives() -> List[Dict[str, Any]]:
@@ -2153,12 +2169,15 @@ def local_available_drives() -> Dict[str, Any]:
 
 @protected.get("/local/validate_path", response_model=None)
 def local_validate_path(path: str = Query(..., min_length=1)) -> Dict[str, Any]:
-    abs_path = os.path.abspath(path)
-    if not os.path.exists(abs_path):
-        return {"ok": False, "reason": "not_found", "path": abs_path}
-    if not os.path.isdir(abs_path):
-        return {"ok": False, "reason": "not_directory", "path": abs_path}
-    return {"ok": True, "path": abs_path}
+    try:
+        resolved_path = _resolve_allowed_local_path(path)
+    except HTTPException:
+        return {"ok": False, "reason": "path_not_allowed"}
+    if not resolved_path.exists():
+        return {"ok": False, "reason": "not_found", "path": str(resolved_path)}
+    if not resolved_path.is_dir():
+        return {"ok": False, "reason": "not_directory", "path": str(resolved_path)}
+    return {"ok": True, "path": str(resolved_path)}
 
 
 @protected.post("/open/local", response_model=None)
@@ -2171,18 +2190,17 @@ def open_local(
     if not item_id or not isinstance(item_id, str) or not item_id.startswith("local:"):
         raise HTTPException(status_code=400, detail="missing_local_id")
 
-    path = _decode_local_id(item_id)
-    if not _allowed_local_path(path):
-        raise HTTPException(status_code=403, detail="path_not_allowed")
+    resolved_path = _resolve_allowed_local_path(_decode_local_id(item_id))
+    resolved_path_str = str(resolved_path)
 
     try:
         if os.name == "nt":
-            if os.path.isfile(path):
-                subprocess.Popen(["explorer", "/select,", path])
+            if resolved_path.is_file():
+                subprocess.Popen(["explorer", "/select,", resolved_path_str])
             else:
-                os.startfile(path)  # type: ignore[attr-defined]
+                os.startfile(resolved_path_str)  # type: ignore[attr-defined]
         else:
-            subprocess.Popen(["xdg-open", path])
+            subprocess.Popen(["xdg-open", resolved_path_str])
     except Exception as exc:  # pragma: no cover - platform specific
         raise HTTPException(status_code=500, detail="open_failed") from exc
 

--- a/core/runtime/sandbox.py
+++ b/core/runtime/sandbox.py
@@ -63,8 +63,10 @@ def run_transform(plugin_id: str, fn: str, payload: Dict[str, Any], *, timeout: 
         sandbox_payload = {
             "plugin_id": plugin_id,
             "fn": fn,
-            "input": payload.get("input") or {},
-            "limits": payload.get("limits") or {},
+            "payload": {
+                "input": payload.get("input") or {},
+                "limits": payload.get("limits") or {},
+            },
         }
         try:
             proc = subprocess.run(  # nosec B603 - argv is fixed by _sandbox_command()

--- a/core/runtime/sandbox.py
+++ b/core/runtime/sandbox.py
@@ -24,11 +24,34 @@ import os
 import subprocess
 import sys
 import tempfile
+import math
 from typing import Any, Dict
 
 
 class SandboxError(RuntimeError):
     ...
+
+
+_MIN_SANDBOX_TIMEOUT_SECONDS = 0.5
+_MAX_SANDBOX_TIMEOUT_SECONDS = 30.0
+_MAX_SANDBOX_STDOUT_BYTES = 1024 * 1024
+_MAX_SANDBOX_ERROR_DETAIL_CHARS = 4096
+
+
+def _coerce_timeout(timeout: float) -> float:
+    try:
+        numeric_timeout = float(timeout)
+    except (TypeError, ValueError) as exc:
+        raise SandboxError("sandbox_invalid_timeout") from exc
+    if not math.isfinite(numeric_timeout):
+        raise SandboxError("sandbox_invalid_timeout")
+    return min(max(numeric_timeout, _MIN_SANDBOX_TIMEOUT_SECONDS), _MAX_SANDBOX_TIMEOUT_SECONDS)
+
+
+def _sandbox_command() -> list[str]:
+    # Keep argv fixed so request or plugin data cannot influence executable selection
+    # or command-line parsing. Dynamic operation data stays in stdin JSON only.
+    return [sys.executable, "-m", "core.runtime.sandbox_runner"]
 
 
 def run_transform(plugin_id: str, fn: str, payload: Dict[str, Any], *, timeout: float = 5.0) -> Dict[str, Any]:
@@ -37,32 +60,32 @@ def run_transform(plugin_id: str, fn: str, payload: Dict[str, Any], *, timeout: 
     with tempfile.TemporaryDirectory(prefix="bus_sandbox_") as tmp:
         env = os.environ.copy()
         env["BUS_SANDBOX_DIR"] = tmp
-        cmd = [
-            sys.executable,
-            "-m",
-            "core.runtime.sandbox_runner",
-            "--plugin",
-            plugin_id,
-            "--fn",
-            fn,
-        ]
+        sandbox_payload = {
+            "plugin_id": plugin_id,
+            "fn": fn,
+            "input": payload.get("input") or {},
+            "limits": payload.get("limits") or {},
+        }
         try:
-            proc = subprocess.run(
-                cmd,
-                input=json.dumps(payload).encode("utf-8"),
+            proc = subprocess.run(  # nosec B603 - argv is fixed by _sandbox_command()
+                _sandbox_command(),
+                input=json.dumps(sandbox_payload).encode("utf-8"),
                 capture_output=True,
-                timeout=max(timeout, 0.5),
+                timeout=_coerce_timeout(timeout),
                 check=False,
+                shell=False,
                 cwd=tmp,
                 env=env,
             )
         except subprocess.TimeoutExpired as exc:
             raise SandboxError(f"sandbox_timeout:{plugin_id}:{fn}") from exc
         if proc.returncode != 0:
-            detail = proc.stderr.decode("utf-8", errors="ignore").strip()
+            detail = proc.stderr.decode("utf-8", errors="ignore").strip()[:_MAX_SANDBOX_ERROR_DETAIL_CHARS]
             raise SandboxError(
                 f"sandbox_error:{plugin_id}:{fn}:{proc.returncode}:{detail}",
             )
+        if len(proc.stdout) > _MAX_SANDBOX_STDOUT_BYTES:
+            raise SandboxError("sandbox_output_too_large")
         stdout = proc.stdout.decode("utf-8")
         try:
             result = json.loads(stdout or "{}")

--- a/core/runtime/sandbox_runner.py
+++ b/core/runtime/sandbox_runner.py
@@ -43,17 +43,26 @@ def _load_plugin(plugin_id: str) -> PluginV2:
     raise RuntimeError(f"plugin_not_found:{plugin_id}:{last_exc}")
 
 
-def main(argv: list[str] | None = None) -> int:
+def _parse_request(argv: list[str] | None) -> tuple[str, str, Dict[str, Any]]:
+    payload = json.loads(sys.stdin.read() or "{}")
+    plugin_id = payload.get("plugin_id")
+    fn = payload.get("fn")
+    if isinstance(plugin_id, str) and isinstance(fn, str):
+        return plugin_id, fn, payload
+
     parser = argparse.ArgumentParser(description="Sandbox runner")
     parser.add_argument("--plugin", required=True)
     parser.add_argument("--fn", required=True)
     args = parser.parse_args(argv)
+    return args.plugin, args.fn, payload
 
-    payload = json.loads(sys.stdin.read() or "{}")
-    plugin = _load_plugin(args.plugin)
+
+def main(argv: list[str] | None = None) -> int:
+    plugin_id, fn, payload = _parse_request(argv)
+    plugin = _load_plugin(plugin_id)
     input_data: Dict[str, Any] = payload.get("input") or {}
     limits = payload.get("limits") or {}
-    proposal = plugin.plan_transform(args.fn, input_data, limits=limits)
+    proposal = plugin.plan_transform(fn, input_data, limits=limits)
     output = {"proposal": proposal}
     sys.stdout.write(json.dumps(output))
     return 0

--- a/core/runtime/sandbox_runner.py
+++ b/core/runtime/sandbox_runner.py
@@ -19,7 +19,6 @@
 
 from __future__ import annotations
 
-import argparse
 import importlib
 import json
 import sys
@@ -43,22 +42,30 @@ def _load_plugin(plugin_id: str) -> PluginV2:
     raise RuntimeError(f"plugin_not_found:{plugin_id}:{last_exc}")
 
 
-def _parse_request(argv: list[str] | None) -> tuple[str, str, Dict[str, Any]]:
-    payload = json.loads(sys.stdin.read() or "{}")
-    plugin_id = payload.get("plugin_id")
-    fn = payload.get("fn")
-    if isinstance(plugin_id, str) and isinstance(fn, str):
-        return plugin_id, fn, payload
+def _parse_request() -> tuple[str, str, Dict[str, Any]]:
+    try:
+        request = json.loads(sys.stdin.read() or "{}")
+    except json.JSONDecodeError as exc:
+        raise ValueError("sandbox_invalid_request") from exc
+    if not isinstance(request, dict):
+        raise ValueError("sandbox_invalid_request")
 
-    parser = argparse.ArgumentParser(description="Sandbox runner")
-    parser.add_argument("--plugin", required=True)
-    parser.add_argument("--fn", required=True)
-    args = parser.parse_args(argv)
-    return args.plugin, args.fn, payload
+    plugin_id = request.get("plugin_id")
+    fn = request.get("fn")
+    payload = request.get("payload")
+    if not isinstance(plugin_id, str) or not isinstance(fn, str) or not isinstance(payload, dict):
+        raise ValueError("sandbox_invalid_request")
+    return plugin_id, fn, payload
 
 
 def main(argv: list[str] | None = None) -> int:
-    plugin_id, fn, payload = _parse_request(argv)
+    del argv
+    try:
+        plugin_id, fn, payload = _parse_request()
+    except ValueError as exc:
+        sys.stderr.write(str(exc))
+        return 2
+
     plugin = _load_plugin(plugin_id)
     input_data: Dict[str, Any] = payload.get("input") or {}
     limits = payload.get("limits") or {}

--- a/core/ui/js/cards/admin.js
+++ b/core/ui/js/cards/admin.js
@@ -28,6 +28,36 @@ function fmtTs(ts) {
   }
 }
 
+function buildPreviewRow(label, value) {
+  const row = document.createElement('div');
+  const strong = document.createElement('strong');
+  strong.textContent = `${label}:`;
+  row.append(strong, ` ${value}`);
+  return row;
+}
+
+function renderPreview(previewBox, path, schemaVersion, counts) {
+  const title = document.createElement('div');
+  title.className = 'admin-preview-title';
+  title.textContent = 'Table counts:';
+
+  const list = document.createElement('ul');
+  list.className = 'admin-preview-list';
+
+  for (const [key, value] of Object.entries(counts || {})) {
+    const item = document.createElement('li');
+    item.textContent = `${key}: ${value}`;
+    list.appendChild(item);
+  }
+
+  previewBox.replaceChildren(
+    buildPreviewRow('Path', path),
+    buildPreviewRow('Schema version', schemaVersion ?? 'unknown'),
+    title,
+    list,
+  );
+}
+
 export function mountAdmin(container) {
   if (!container) return;
 
@@ -138,14 +168,7 @@ export function mountAdmin(container) {
       lastPreviewPath = path;
       restoreStatus.textContent = 'Preview ok';
       const counts = res.table_counts || {};
-      previewBox.innerHTML = `
-        <div><strong>Path:</strong> ${path}</div>
-        <div><strong>Schema version:</strong> ${res.schema_version ?? 'unknown'}</div>
-        <div class="admin-preview-title">Table counts:</div>
-        <ul class="admin-preview-list">
-          ${Object.entries(counts).map(([k, v]) => `<li>${k}: ${v}</li>`).join('')}
-        </ul>
-      `;
+      renderPreview(previewBox, path, res.schema_version, counts);
       previewBox.classList.remove('hidden');
     } catch (err) {
       console.error('preview failed', err);

--- a/core/ui/js/cards/inventory.js
+++ b/core/ui/js/cards/inventory.js
@@ -5,6 +5,7 @@ import { apiGetJson, apiPost, apiPut, apiDelete, ensureToken } from '../api.js';
 import * as canonical from '../api/canonical.js';
 import { fromBaseQty, fromBaseUnitPrice, fmtQty, fmtMoney } from '../lib/units.js';
 import { unitOptionsList, dimensionForUnit, DIM_DEFAULTS_IMPERIAL, DIM_DEFAULTS_METRIC } from '../lib/units.js';
+import { formatOnHandDisplay } from '../lib/item-display.js';
 
 const UNIT_OPTIONS = {
   length: ['mm', 'cm', 'm'],
@@ -138,41 +139,6 @@ function toast(message, tone = 'ok') {
     el.classList.add('inventory-toast--hide');
     setTimeout(() => el.remove(), 300);
   }, 2000);
-}
-
-function quantityValueOnly(source) {
-  const toNumeric = (value) => {
-    if (value == null || typeof value === 'object') return null;
-    const match = String(value).match(/-?\d+(?:\.\d+)?/);
-    if (!match) return null;
-    const parsed = Number(match[0]);
-    return Number.isFinite(parsed) ? parsed : null;
-  };
-  if (source == null) return null;
-  if (typeof source !== 'object') return toNumeric(source);
-  return toNumeric(source.qty ?? source.quantity ?? source.value);
-}
-
-function formatOnHandDisplay(item) {
-  const stockOnHandValue = quantityValueOnly(item?.stock_on_hand_display);
-  if (stockOnHandValue != null && stockOnHandValue !== '') {
-    return String(stockOnHandValue);
-  }
-  if (item?.quantity_decimal != null) {
-    return String(item.quantity_decimal);
-  }
-  const quantityDisplayValue = quantityValueOnly(item?.quantity_display);
-  if (quantityDisplayValue != null && quantityDisplayValue !== '') {
-    return String(quantityDisplayValue);
-  }
-  const quantityValue = quantityValueOnly(item?.quantity);
-  if (quantityValue != null && quantityValue !== '') {
-    return String(quantityValue);
-  }
-  if (item?.qty != null && item.qty !== '') {
-    return String(item.qty);
-  }
-  return '—';
 }
 
 function renderTable(state) {
@@ -1098,7 +1064,12 @@ export function openItemModal(item = null) {
   vendorEmptyOpt.value = '';
   vendorEmptyOpt.textContent = '—';
   vendorSelect.appendChild(vendorEmptyOpt);
-  vendorInputWrap.appendChild(vendorSelect);
+  const addVendorBtn = document.createElement('button');
+  addVendorBtn.type = 'button';
+  addVendorBtn.className = 'btn small';
+  addVendorBtn.textContent = 'Add Vendor';
+  vendorInputWrap.classList.add('field-input-row');
+  vendorInputWrap.append(vendorSelect, addVendorBtn);
   vendorRow.appendChild(vendorInputWrap);
 
   const typeRow = document.createElement('div');
@@ -1168,13 +1139,17 @@ export function openItemModal(item = null) {
   fName.querySelector('input')?.focus();
   initAddItemFormDefaults();
 
+  let selectedVendorId = item?.vendor_id ? String(item.vendor_id) : '';
+  let vendorOptions = [];
+
   const populateVendors = (vendorsList, selectedId = null) => {
+    vendorOptions = Array.isArray(vendorsList) ? vendorsList : [];
     vendorSelect.textContent = '';
     const baseOpt = document.createElement('option');
     baseOpt.value = '';
     baseOpt.textContent = '—';
     vendorSelect.appendChild(baseOpt);
-    vendorsList.forEach(v => {
+    vendorOptions.forEach(v => {
       const opt = document.createElement('option');
       opt.value = v.id;
       opt.textContent = v.name ?? `#${v.id}`;
@@ -1184,26 +1159,141 @@ export function openItemModal(item = null) {
     createOpt.value = '__create__';
     createOpt.textContent = 'Create new vendor…';
     vendorSelect.appendChild(createOpt);
-    if (selectedId) {
-      vendorSelect.value = String(selectedId);
-    } else if (item?.vendor_id) {
+    const nextSelectedId = selectedId != null ? String(selectedId) : selectedVendorId;
+    const hasOption = (value) => Array.from(vendorSelect.options).some((opt) => opt.value === String(value));
+    if (nextSelectedId && hasOption(nextSelectedId)) {
+      vendorSelect.value = nextSelectedId;
+      selectedVendorId = nextSelectedId;
+    } else if (!nextSelectedId && item?.vendor_id && hasOption(item.vendor_id)) {
       vendorSelect.value = String(item.vendor_id);
+      selectedVendorId = String(item.vendor_id);
+    } else {
+      vendorSelect.value = '';
+      selectedVendorId = '';
     }
+  };
+
+  const selectSavedVendor = async (saved) => {
+    if (!saved?.id || !saved.is_vendor) return;
+    selectedVendorId = String(saved.id);
+    let refreshed = await fetchVendors();
+    if (!Array.isArray(refreshed)) refreshed = [];
+    if (!refreshed.some((v) => String(v?.id) === selectedVendorId)) {
+      refreshed = [...refreshed, saved];
+    }
+    populateVendors(refreshed, selectedVendorId);
   };
 
   const onContactSaved = async (ev) => {
-    const saved = ev.detail;
-    if (!saved?.id || !saved.is_vendor) return;
-    const refreshed = await fetchVendors();
-    if (!Array.isArray(refreshed) || !refreshed.length) return;
-    populateVendors(refreshed, saved.id);
+    await selectSavedVendor(ev.detail);
   };
+
+  function openVendorCreateModal() {
+    const vendorOverlay = document.createElement('div');
+    vendorOverlay.className = 'modal-overlay';
+    const vendorCard = document.createElement('div');
+    vendorCard.className = 'modal-card inventory-modal-card inventory-modal-card--narrow';
+
+    const vendorTitle = document.createElement('div');
+    vendorTitle.className = 'modal-title';
+    vendorTitle.textContent = 'Add Vendor';
+
+    const vendorError = document.createElement('div');
+    vendorError.className = 'error-banner';
+    vendorError.hidden = true;
+
+    const vendorBody = document.createElement('div');
+    vendorBody.className = 'modal-body';
+    const nameRow = inputRow('Name', 'text', '', { required: 'true' });
+    const nameInput = nameRow.querySelector('input');
+    const contactRow = inputRow('Contact', 'text', '');
+    const contactInput = contactRow.querySelector('input');
+
+    const vendorActions = document.createElement('div');
+    vendorActions.className = 'modal-actions';
+    const saveVendorBtn = document.createElement('button');
+    saveVendorBtn.type = 'button';
+    saveVendorBtn.className = 'btn primary';
+    saveVendorBtn.textContent = 'Save Vendor';
+    const cancelVendorBtn = document.createElement('button');
+    cancelVendorBtn.type = 'button';
+    cancelVendorBtn.className = 'btn';
+    cancelVendorBtn.textContent = 'Cancel';
+    vendorActions.append(saveVendorBtn, cancelVendorBtn);
+
+    vendorBody.append(nameRow, contactRow, vendorActions);
+    vendorCard.append(vendorTitle, vendorError, vendorBody);
+    vendorOverlay.appendChild(vendorCard);
+    document.body.appendChild(vendorOverlay);
+    nameInput?.focus();
+
+    const closeVendorModal = () => vendorOverlay.remove();
+    cancelVendorBtn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      closeVendorModal();
+    });
+    vendorOverlay.addEventListener('click', (ev) => {
+      if (ev.target === vendorOverlay) ev.stopPropagation();
+    }, true);
+    vendorCard.addEventListener('click', (ev) => ev.stopPropagation());
+
+    const saveVendor = async () => {
+      const name = nameInput?.value?.trim() || '';
+      if (!name) {
+        vendorError.textContent = 'Vendor name is required.';
+        vendorError.hidden = false;
+        markInvalid(nameInput);
+        return;
+      }
+      try {
+        vendorError.hidden = true;
+        saveVendorBtn.disabled = true;
+        saveVendorBtn.textContent = 'Saving...';
+        await ensureToken();
+        const saved = await apiPost('/app/contacts', {
+          name,
+          contact: contactInput?.value?.trim() || null,
+          is_vendor: true,
+          is_org: true,
+        });
+        closeVendorModal();
+        await selectSavedVendor(saved);
+      } catch (err) {
+        vendorError.textContent = serverErrorMessage(err) || 'Save vendor failed.';
+        vendorError.hidden = false;
+        saveVendorBtn.disabled = false;
+        saveVendorBtn.textContent = 'Save Vendor';
+      }
+    };
+
+    saveVendorBtn.addEventListener('click', (ev) => {
+      ev.preventDefault();
+      void saveVendor();
+    });
+    vendorOverlay.addEventListener('keydown', (ev) => {
+      if (ev.key === 'Enter') {
+        ev.preventDefault();
+        void saveVendor();
+      }
+      if (ev.key === 'Escape') {
+        ev.preventDefault();
+        ev.stopPropagation();
+      }
+    });
+  }
+
+  addVendorBtn.addEventListener('click', (ev) => {
+    ev.preventDefault();
+    openVendorCreateModal();
+  });
 
   vendorSelect.addEventListener('change', () => {
     if (vendorSelect.value === '__create__') {
-      window.dispatchEvent(new CustomEvent('open-contacts-modal', { detail: { prefill: { is_vendor: true, is_org: true } } }));
-      vendorSelect.value = '';
+      vendorSelect.value = selectedVendorId || '';
+      openVendorCreateModal();
+      return;
     }
+    selectedVendorId = vendorSelect.value;
   });
 
   function currentDimension() {
@@ -1301,10 +1391,6 @@ export function openItemModal(item = null) {
   // Load vendors (async)
   (async () => {
     const vs = await fetchVendors();
-    if (!vs.length) {
-      vendorSelect.replaceWith(helpLinkToVendors());
-      return;
-    }
     populateVendors(vs);
     window.addEventListener('contacts:saved', onContactSaved);
   })();
@@ -1462,14 +1548,6 @@ export function openItemModal(item = null) {
     wrap.appendChild(input);
     row.append(label, wrap);
     return row;
-  }
-
-  function helpLinkToVendors() {
-    const a = document.createElement('a');
-    a.href = '#/contacts';
-    a.textContent = 'No vendors found. Go to Vendors.';
-    a.className = 'link';
-    return a;
   }
 
   let stockInOverlay = null;

--- a/core/ui/js/cards/manufacturing.js
+++ b/core/ui/js/cards/manufacturing.js
@@ -1,10 +1,11 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 // Manufacturing Runs & History Card
 
-import { ensureToken } from '../api.js';
+import { apiGetJson, ensureToken } from '../api.js';
 import { RecipesAPI } from '../api/recipes.js';
 import * as canonical from '../api/canonical.js';
 import { fromBaseQty, fmtQty, dimensionForUnit } from '../lib/units.js';
+import { formatOnHandDisplay } from '../lib/item-display.js';
 
 function el(tag, attrs = {}, children = []) {
   const node = document.createElement(tag);
@@ -23,6 +24,8 @@ function el(tag, attrs = {}, children = []) {
 let _state = {
   recipes: [],
   selectedRecipe: null,
+  items: [],
+  itemById: new Map(),
 };
 
 const recipeNameCache = (window._recipeNameCache = window._recipeNameCache || Object.create(null));
@@ -47,6 +50,33 @@ function scaleQuantityDecimal(value, factor) {
   const qty = decimalToNumber(value);
   if (!Number.isFinite(qty)) return '0';
   return toDecimalString(String(qty * factor));
+}
+
+async function refreshItemStockMap() {
+  const items = await apiGetJson('/app/items');
+  _state.items = Array.isArray(items) ? items : [];
+  _state.itemById = new Map(_state.items.map((item) => [String(item?.id), item]));
+  return _state.itemById;
+}
+
+function itemForStock(recipeItem) {
+  const id = recipeItem?.item_id ?? recipeItem?.item?.id;
+  if (id != null && _state.itemById?.has(String(id))) {
+    return _state.itemById.get(String(id));
+  }
+  return recipeItem?.item || null;
+}
+
+function outputItemForStock(recipe) {
+  const id = recipe?.output_item_id ?? recipe?.output_item?.id;
+  if (id != null && _state.itemById?.has(String(id))) {
+    return _state.itemById.get(String(id));
+  }
+  return recipe?.output_item || null;
+}
+
+function stockText(item) {
+  return formatOnHandDisplay(item, { fallback: 'Unknown', allowLegacyFallbacks: false });
 }
 
 function formatManufactureError(err) {
@@ -76,7 +106,7 @@ function _runConfirmText({ recipeName, outputQty, adhoc }) {
 
 export async function mountManufacturing() {
   await ensureToken();
-  _state = { recipes: [], selectedRecipe: null };
+  _state = { recipes: [], selectedRecipe: null, items: [], itemById: new Map() };
   const container = document.querySelector('[data-tab-panel="manufacturing"]');
   if (!container) return;
 
@@ -95,14 +125,17 @@ export async function mountManufacturing() {
 }
 
 export function unmountManufacturing() {
-  _state = { recipes: [], selectedRecipe: null };
+  _state = { recipes: [], selectedRecipe: null, items: [], itemById: new Map() };
   const container = document.querySelector('[data-tab-panel="manufacturing"]');
   if (container) container.innerHTML = '';
 }
 
 async function renderNewRunForm(parent) {
   try {
-    const list = await RecipesAPI.list();
+    const [list] = await Promise.all([
+      RecipesAPI.list(),
+      refreshItemStockMap().catch(() => new Map()),
+    ]);
     _state.recipes = (list || []).filter((r) => !r.archived);
   } catch {
     parent.append(el('div', { class: 'error' }, 'Failed to load recipes.'));
@@ -208,8 +241,8 @@ async function renderNewRunForm(parent) {
 
         (fullRecipe.items || []).forEach((ri) => {
           const row = el('tr', { class: 'mfg-projection-row' });
-          const item = ri.item || {};
-          const stock = item.stock_on_hand_display?.value ?? '—';
+          const item = itemForStock(ri);
+          const stock = stockText(item);
           const scaledChange = scaleQuantityDecimal(ri.quantity_decimal || '0', factor);
           const change = fmtHumanQty(`-${scaledChange}`, ri.uom || ri.item?.uom);
           row.append(
@@ -223,10 +256,11 @@ async function renderNewRunForm(parent) {
 
         if (fullRecipe.output_item_id) {
           const row = el('tr', { class: 'mfg-projection-row' });
+          const outputItem = outputItemForStock(fullRecipe);
           row.append(
             el('td', { text: fullRecipe.output_item?.name || `Item #${fullRecipe.output_item_id}` }),
             el('td', { class: 'mfg-output-cell', text: 'Output' }),
-            el('td', { class: 'mfg-col-right', text: '—' }),
+            el('td', { class: 'mfg-col-right', text: stockText(outputItem) }),
             el('td', { class: 'mfg-col-right mfg-output-cell', text: fmtHumanQty(toDecimalString(qtyInput.value || fullRecipe.quantity_decimal || '1'), fullRecipe.uom || fullRecipe.output_item?.uom) }),
           );
           tbody.append(row);
@@ -239,8 +273,8 @@ async function renderNewRunForm(parent) {
 
       (fullRecipe.items || []).forEach((ri) => {
         const row = el('tr', { class: 'mfg-projection-row' });
-        const item = ri.item || {};
-        const stock = item.stock_on_hand_display?.value ?? '—';
+        const item = itemForStock(ri);
+        const stock = stockText(item);
         const change = fmtHumanQty(`-${ri.quantity_decimal || '0'}`, ri.uom || ri.item?.uom);
         row.append(
           el('td', { text: ri.item?.name || `Item #${ri.item_id}` }),
@@ -306,6 +340,7 @@ async function renderNewRunForm(parent) {
       await canonical.manufactureRecipe(payload);
 
       setStatus('Run Complete!', 'success');
+      await refreshItemStockMap().catch(() => new Map());
       await updateProjection();
       await loadRecentRuns30d();
       runBtn.textContent = 'Run Production';

--- a/core/ui/js/lib/item-display.js
+++ b/core/ui/js/lib/item-display.js
@@ -1,0 +1,39 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export function quantityValueOnly(source) {
+  const toNumeric = (value) => {
+    if (value == null || typeof value === 'object') return null;
+    const match = String(value).match(/-?\d+(?:\.\d+)?/);
+    if (!match) return null;
+    const parsed = Number(match[0]);
+    return Number.isFinite(parsed) ? parsed : null;
+  };
+  if (source == null) return null;
+  if (typeof source !== 'object') return toNumeric(source);
+  return toNumeric(source.qty ?? source.quantity ?? source.value);
+}
+
+export function formatOnHandDisplay(item, { fallback = '—', allowLegacyFallbacks = true } = {}) {
+  const stockOnHandValue = quantityValueOnly(item?.stock_on_hand_display);
+  if (stockOnHandValue != null && stockOnHandValue !== '') {
+    return String(stockOnHandValue);
+  }
+  if (item?.quantity_decimal != null) {
+    return String(item.quantity_decimal);
+  }
+  const quantityDisplayValue = quantityValueOnly(item?.quantity_display);
+  if (quantityDisplayValue != null && quantityDisplayValue !== '') {
+    return String(quantityDisplayValue);
+  }
+  if (!allowLegacyFallbacks) {
+    return fallback;
+  }
+  const quantityValue = quantityValueOnly(item?.quantity);
+  if (quantityValue != null && quantityValue !== '') {
+    return String(quantityValue);
+  }
+  if (item?.qty != null && item.qty !== '') {
+    return String(item.qty);
+  }
+  return fallback;
+}

--- a/core/ui/js/router.js
+++ b/core/ui/js/router.js
@@ -3,24 +3,51 @@
 
 // core/ui/js/router.js
 const LEGACY_ROUTER_ENABLED = false;
+const HOME_ROUTE = '/home';
+const RESERVED_ROUTE_KEYS = new Set(['__proto__', 'constructor', 'prototype', 'toString']);
 
-const routes = {};
+// Legacy compatibility router only. shell/app.js is the canonical active router.
+const routes = Object.create(null);
+
+
+function normalizeRoute(path) {
+  if (typeof path !== 'string') return HOME_ROUTE;
+  const normalized = path.trim() || HOME_ROUTE;
+  if (RESERVED_ROUTE_KEYS.has(normalized)) return HOME_ROUTE;
+  return normalized;
+}
+
+
+function hasRoute(path) {
+  return Object.prototype.hasOwnProperty.call(routes, path);
+}
+
+
+function resolveRoute(path) {
+  const normalizedPath = normalizeRoute(path);
+  const handler = hasRoute(normalizedPath) ? routes[normalizedPath] : routes[HOME_ROUTE];
+  return typeof handler === 'function' ? handler : null;
+}
 
 export function registerRoute(path, render) {
-  routes[path] = render;
+  const normalizedPath = normalizeRoute(path);
+  if (typeof render !== 'function') return;
+  routes[normalizedPath] = render;
 }
 
 export function navigate(path) {
-  if (location.hash !== `#${path}`) location.hash = `#${path}`;
+  const normalizedPath = normalizeRoute(path);
+  if (location.hash !== `#${normalizedPath}`) location.hash = `#${normalizedPath}`;
   render();
 }
 
 function render() {
-  const path = location.hash.replace(/^#/, '') || '/home';
+  const path = normalizeRoute(location.hash.replace(/^#/, ''));
   const target = document.getElementById('app');
-  const fn = routes[path] || routes['/home'];
+  const handler = resolveRoute(path);
+  if (!target || typeof handler !== 'function') return;
   target.innerHTML = '';
-  fn(target);
+  handler(target);
 }
 
 function initLegacyRouter() {

--- a/core/utils/export.py
+++ b/core/utils/export.py
@@ -53,6 +53,7 @@ from core.config.paths import (
     EXPORTS_DIR,
 )
 from core.platform.winfile import robust_replace, wait_for_exclusive
+from core.utils.pathsafe import PathSafetyError, resolve_path_under_roots
 
 # Ensure required dirs exist (idempotent)
 for _p in (APP_DIR, DATA_DIR, JOURNAL_DIR, EXPORTS_DIR, BUS_ROOT):
@@ -117,6 +118,13 @@ def _safe_under(root: Path, target: Path) -> bool:
     return Path(common) == root_resolved
 
 
+def _resolve_export_path(path: str | Path) -> Path:
+    try:
+        return resolve_path_under_roots(path, [EXPORTS_DIR])
+    except PathSafetyError as exc:
+        raise PermissionError("path_out_of_roots") from exc
+
+
 def _retry_unlink(p: Path, attempts: int = 10, delay: float = 0.1):
     for _ in range(attempts):
         try:
@@ -146,7 +154,7 @@ def list_exports() -> list[dict[str, object]]:
 
 
 def stage_uploaded_backup(upload_name: str, data: bytes) -> Dict[str, object]:
-    safe_name = Path(upload_name or "upload.db.gcm").name
+    safe_name = Path((upload_name or "upload.db.gcm").replace("\\", "/")).name
     ts = time.strftime("%Y%m%d-%H%M%S", time.localtime())
     EXPORTS_DIR.mkdir(parents=True, exist_ok=True)
     target = EXPORTS_DIR / f"upload-{ts}-{safe_name}"
@@ -221,7 +229,7 @@ def _load_and_decrypt(path: Path, password: str) -> tuple[bytes, ContainerHeader
 
 def import_preview(path: str, password: str) -> Dict[str, object]:
     try:
-        plaintext, header = _load_and_decrypt(Path(path), password)
+        plaintext, header = _load_and_decrypt(_resolve_export_path(path), password)
     except (PermissionError, FileNotFoundError, ValueError) as exc:
         msg = str(exc)
         if msg not in {
@@ -287,7 +295,8 @@ def import_commit(
             pass
 
     try:
-        plaintext, header = _load_and_decrypt(Path(path), password)
+        resolved_source = _resolve_export_path(path)
+        plaintext, header = _load_and_decrypt(resolved_source, password)
     except (PermissionError, FileNotFoundError, ValueError) as exc:
         msg = str(exc)
         if msg not in {
@@ -357,7 +366,7 @@ def import_commit(
         audit_entry = {
             "ts": int(time.time()),
             "action": "import",
-            "src": str(Path(path).resolve()),
+            "src": str(resolved_source),
             "manifest": {"version": header.version},
         }
         try:

--- a/core/utils/pathsafe.py
+++ b/core/utils/pathsafe.py
@@ -1,0 +1,42 @@
+from __future__ import annotations
+
+import ntpath
+from pathlib import Path
+from typing import Iterable
+
+
+class PathSafetyError(ValueError):
+    def __init__(self, code: str):
+        super().__init__(code)
+        self.code = code
+
+
+def _clean_path_value(path_value: str | Path) -> str:
+    raw = str(path_value or "").strip()
+    if not raw:
+        raise PathSafetyError("path_empty")
+    if "\x00" in raw:
+        raise PathSafetyError("path_invalid")
+    if raw.startswith(("\\\\?\\", "\\\\.\\", "\\\\", "//")):
+        raise PathSafetyError("path_out_of_roots")
+    drive, tail = ntpath.splitdrive(raw)
+    if drive and not tail.startswith(("\\", "/")):
+        raise PathSafetyError("path_out_of_roots")
+    return raw
+
+
+def resolve_path_under_roots(path_value: str | Path, allowed_roots: Iterable[Path]) -> Path:
+    raw = _clean_path_value(path_value)
+    candidate_input = Path(raw).expanduser()
+
+    for root in allowed_roots:
+        resolved_root = Path(root).expanduser().resolve(strict=False)
+        candidate = candidate_input if candidate_input.is_absolute() else (resolved_root / candidate_input)
+        resolved_candidate = candidate.expanduser().resolve(strict=False)
+        try:
+            resolved_candidate.relative_to(resolved_root)
+        except ValueError:
+            continue
+        return resolved_candidate
+
+    raise PathSafetyError("path_out_of_roots")

--- a/core/version.py
+++ b/core/version.py
@@ -23,7 +23,7 @@
 VERSION = "1.1.0"
 
 # Internal working revision. Agents may bump this on meaningful repo changes.
-INTERNAL_VERSION = "1.1.0.5"
+INTERNAL_VERSION = "1.1.0.6"
 
 __all__ = ["VERSION", "INTERNAL_VERSION"]
 

--- a/core/version.py
+++ b/core/version.py
@@ -23,7 +23,7 @@
 VERSION = "1.1.0"
 
 # Internal working revision. Agents may bump this on meaningful repo changes.
-INTERNAL_VERSION = "1.1.0.6"
+INTERNAL_VERSION = "1.1.0.7"
 
 __all__ = ["VERSION", "INTERNAL_VERSION"]
 

--- a/docs/security/remediation_audit_log.md
+++ b/docs/security/remediation_audit_log.md
@@ -1,7 +1,7 @@
 # Bandit Remediation Audit Log
 
 Date: 2026-04-23
-Last documentation correction: 2026-04-24
+Last documentation correction: 2026-05-02
 
 ## Entries
 
@@ -11,6 +11,7 @@ Last documentation correction: 2026-04-24
 | `core/api/http.py` | B608 | NARROW SUPPRESSION (EXACT-LINE RETAINED) | Removed inline `# nosec B608` for stale-check, re-ran Bandit on file, observed B608 at the same query line, then restored suppression on that exact line only | Query values remain parameterized with DB-API placeholders; scanner still flags dynamic placeholder assembly. |
 | `core/ledger/health.py` | B608 | TRUE FIX | Replaced dynamic column interpolation with two static query variants (`qty` / `qty_stored`) | Removes string-formatted SQL while preserving existing runtime behavior and schema compatibility. |
 | `core/utils/export.py` | B608 | NARROW SUPPRESSION | Added inline `# nosec B608` on table-count query | Table identifier comes from fixed internal dictionary keys only. |
+| `core/runtime/sandbox.py`, `core/runtime/sandbox_runner.py`, `core/ui/js/router.js`, `core/ui/js/cards/admin.js`, `core/api/http.py`, `core/utils/export.py`, `core/utils/pathsafe.py` | CodeQL hardening pass | TRUE FIX | Fixed sandbox argv to BUS Core-owned runner args with stdin JSON payloads, removed legacy router dynamic dispatch, replaced admin preview `innerHTML` metadata rendering with text-safe DOM construction, and constrained import/local/plugin paths to explicit allowed roots | Hardening addresses the recorded command-construction, DOM-XSS, and path-injection boundary issues; GitHub CodeQL re-scan after push/PR remains the confirmation source. |
 | `core/reader/ids.py`, `core/reader/api.py`, `core/plans/commit.py`, `tests/test_reader_rid_security.py` | B324 | TRUE FIX + COMPATIBILITY HARDENING | Replaced active RID signature generation with hardened v2 generation (`local:v2:<sig32>:<payload>`), retained strict legacy read compatibility (`local:<sig10>:<payload>`), enforced strict fail-closed RID parsing/decoding/path checks, and tightened commit RID authority for present RID fields | Resolves integrity-relevant RID boundary weakness via real hardening without suppression/workarounds while preserving standing product compatibility for valid legacy values. |
 | `plugins/notion/plugin.py` | B310 | TRUE FIX + NARROW SUPPRESSION | Added strict URL allowlist check (`https://api.notion.com`) and inline `# nosec B310` at `urlopen` | Runtime path now enforces scheme/host policy before network open; scanner warning is retained as documented suppression due generic `urlopen` rule. |
 

--- a/tests/backup/test_export_path_security.py
+++ b/tests/backup/test_export_path_security.py
@@ -1,5 +1,4 @@
 import importlib
-from pathlib import Path
 
 import pytest
 

--- a/tests/backup/test_export_path_security.py
+++ b/tests/backup/test_export_path_security.py
@@ -1,0 +1,46 @@
+import importlib
+from pathlib import Path
+
+import pytest
+
+from tests.conftest import reset_bus_modules
+
+
+@pytest.fixture()
+def modules(tmp_path, monkeypatch):
+    monkeypatch.setenv("LOCALAPPDATA", str(tmp_path / "lad"))
+    monkeypatch.setenv("BUS_DB", str(tmp_path / "lad" / "app" / "app.db"))
+
+    reset_bus_modules(
+        [
+            "core.utils.export",
+            "core.utils.pathsafe",
+            "core.config.paths",
+            "core.backup.crypto",
+        ]
+    )
+
+    export = importlib.import_module("core.utils.export")
+    return importlib.reload(export)
+
+
+@pytest.mark.parametrize(
+    "dangerous_path",
+    [
+        "../escape.db.gcm",
+        "..\\escape.db.gcm",
+        "/etc/passwd",
+        r"C:\Windows\System32\drivers\etc\hosts",
+        r"\\server\share\file",
+        r"\\?\C:\Windows\bad",
+        "bad\x00name",
+    ],
+)
+def test_import_preview_and_commit_reject_paths_outside_exports(modules, dangerous_path: str):
+    export_module = modules
+
+    preview = export_module.import_preview(dangerous_path, "pw")
+    commit = export_module.import_commit(dangerous_path, "pw")
+
+    assert preview == {"ok": False, "error": "path_out_of_roots"}
+    assert commit == {"ok": False, "error": "path_out_of_roots"}

--- a/tests/test_admin_preview_security.py
+++ b/tests/test_admin_preview_security.py
@@ -1,0 +1,22 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_admin_preview_renders_dynamic_values_without_innerhtml() -> None:
+    admin_js = (REPO_ROOT / 'core' / 'ui' / 'js' / 'cards' / 'admin.js').read_text(encoding='utf-8')
+
+    assert 'previewBox.innerHTML' not in admin_js
+    assert 'renderPreview(previewBox, path, res.schema_version, counts);' in admin_js
+    assert "previewBox.replaceChildren(" in admin_js
+    assert "item.textContent = `${key}: ${value}`;" in admin_js
+    assert "strong.textContent = `${label}:`;" in admin_js
+
+
+def test_admin_preview_avoids_template_html_for_untrusted_fields() -> None:
+    admin_js = (REPO_ROOT / 'core' / 'ui' / 'js' / 'cards' / 'admin.js').read_text(encoding='utf-8')
+
+    assert '${path}</div>' not in admin_js
+    assert '${res.schema_version' not in admin_js
+    assert '<li>${k}: ${v}</li>' not in admin_js

--- a/tests/test_http_local_path_security.py
+++ b/tests/test_http_local_path_security.py
@@ -1,0 +1,82 @@
+import base64
+from pathlib import Path
+
+
+class _FakeLocalProvider:
+    def __init__(self, roots: list[str]):
+        self._roots = roots
+
+    def _settings(self):
+        return {"local_roots": self._roots}
+
+
+class _FakeCatalog:
+    def __init__(self, roots: list[str]):
+        self._providers = {"local_fs": _FakeLocalProvider(roots)}
+
+
+class _FakeBroker:
+    def __init__(self, roots: list[str]):
+        self._catalog = _FakeCatalog(roots)
+
+
+def _encode_local_id(path: str) -> str:
+    encoded = base64.urlsafe_b64encode(path.encode("utf-8")).decode("ascii").rstrip("=")
+    return f"local:{encoded}"
+
+
+def test_local_validate_path_rejects_outside_root(bus_client, monkeypatch, tmp_path: Path):
+    client = bus_client["client"]
+    api_http = bus_client["api_http"]
+    allowed_root = tmp_path / "allowed"
+    outside = tmp_path / "outside"
+    allowed_root.mkdir()
+    outside.mkdir()
+
+    monkeypatch.setattr(api_http, "_broker", lambda: _FakeBroker([str(allowed_root)]))
+
+    response = client.get("/local/validate_path", params={"path": str(outside)})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": False, "reason": "path_not_allowed"}
+
+
+def test_open_local_uses_resolved_safe_file_path(bus_client, monkeypatch, tmp_path: Path):
+    client = bus_client["client"]
+    api_http = bus_client["api_http"]
+    allowed_root = tmp_path / "allowed"
+    safe_file = allowed_root / "nested" / "file.txt"
+    safe_file.parent.mkdir(parents=True)
+    safe_file.write_text("ok", encoding="utf-8")
+    raw_path = str(allowed_root / "nested" / ".." / "nested" / "file.txt")
+    captured: dict[str, object] = {}
+
+    monkeypatch.setattr(api_http, "_broker", lambda: _FakeBroker([str(allowed_root)]))
+
+    def _fake_popen(args, *unused_args, **unused_kwargs):
+        captured["args"] = args
+        return object()
+
+    monkeypatch.setattr(api_http.subprocess, "Popen", _fake_popen)
+
+    response = client.post("/open/local", json={"id": _encode_local_id(raw_path)})
+
+    assert response.status_code == 200
+    assert response.json() == {"ok": True}
+    assert captured["args"] == ["explorer", "/select,", str(safe_file.resolve(strict=False))]
+
+
+def test_open_local_rejects_path_outside_root(bus_client, monkeypatch, tmp_path: Path):
+    client = bus_client["client"]
+    api_http = bus_client["api_http"]
+    allowed_root = tmp_path / "allowed"
+    outside_file = tmp_path / "outside.txt"
+    allowed_root.mkdir()
+    outside_file.write_text("bad", encoding="utf-8")
+
+    monkeypatch.setattr(api_http, "_broker", lambda: _FakeBroker([str(allowed_root)]))
+
+    response = client.post("/open/local", json={"id": _encode_local_id(str(outside_file))})
+
+    assert response.status_code == 403
+    assert response.json() == {"detail": "path_not_allowed"}

--- a/tests/test_path_safety.py
+++ b/tests/test_path_safety.py
@@ -1,0 +1,50 @@
+from pathlib import Path
+
+import pytest
+
+from core.utils.pathsafe import PathSafetyError, resolve_path_under_roots
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+@pytest.mark.parametrize(
+    ("raw_path", "expected_code"),
+    [
+        ("../escape.db.gcm", "path_out_of_roots"),
+        ("..\\escape.db.gcm", "path_out_of_roots"),
+        ("/etc/passwd", "path_out_of_roots"),
+        (r"C:\Windows\System32\drivers\etc\hosts", "path_out_of_roots"),
+        (r"\\server\share\file", "path_out_of_roots"),
+        (r"\\?\C:\Windows\bad", "path_out_of_roots"),
+        ("bad\x00name", "path_invalid"),
+    ],
+)
+def test_resolve_path_under_roots_rejects_dangerous_inputs(tmp_path: Path, raw_path: str, expected_code: str) -> None:
+    allowed_root = tmp_path / "exports"
+    allowed_root.mkdir(parents=True)
+
+    with pytest.raises(PathSafetyError, match=expected_code):
+        resolve_path_under_roots(raw_path, [allowed_root])
+
+
+def test_resolve_path_under_roots_accepts_valid_in_root_path(tmp_path: Path) -> None:
+    allowed_root = tmp_path / "exports"
+    nested_file = allowed_root / "nested" / "backup.db.gcm"
+    nested_file.parent.mkdir(parents=True)
+
+    resolved = resolve_path_under_roots("nested/backup.db.gcm", [allowed_root])
+
+    assert resolved == nested_file.resolve(strict=False)
+
+
+def test_path_sensitive_sinks_use_shared_resolved_path_helper() -> None:
+    http_source = (REPO_ROOT / "core" / "api" / "http.py").read_text(encoding="utf-8")
+    export_source = (REPO_ROOT / "core" / "utils" / "export.py").read_text(encoding="utf-8")
+
+    assert 'subprocess.Popen(["explorer", "/select,", path])' not in http_source
+    assert 'subprocess.Popen(["xdg-open", path])' not in http_source
+    assert 'os.startfile(path)' not in http_source
+    assert '_load_and_decrypt(Path(path), password)' not in export_source
+    assert 'resolve_path_under_roots' in http_source
+    assert 'resolve_path_under_roots' in export_source

--- a/tests/test_runtime_sandbox.py
+++ b/tests/test_runtime_sandbox.py
@@ -3,6 +3,7 @@ from __future__ import annotations
 import io
 import json
 import subprocess
+import sys
 
 import pytest
 
@@ -55,8 +56,7 @@ def test_run_transform_never_places_user_strings_in_subprocess_argv(
     stdin_payload = json.loads(captured["input"].decode("utf-8"))
     assert stdin_payload["plugin_id"] == plugin_id
     assert stdin_payload["fn"] == fn
-    assert stdin_payload["input"] == {"value": 1}
-    assert stdin_payload["limits"] == {"rows": 5}
+    assert stdin_payload["payload"] == {"input": {"value": 1}, "limits": {"rows": 5}}
 
 
 def test_sandbox_runner_executes_transform_from_stdin_request(monkeypatch: pytest.MonkeyPatch) -> None:
@@ -66,8 +66,7 @@ def test_sandbox_runner_executes_transform_from_stdin_request(monkeypatch: pytes
             {
                 "plugin_id": "trusted_plugin",
                 "fn": "normalize",
-                "input": {"value": 7},
-                "limits": {"rows": 1},
+                "payload": {"input": {"value": 7}, "limits": {"rows": 1}},
             }
         )
     )
@@ -88,6 +87,44 @@ def test_sandbox_runner_executes_transform_from_stdin_request(monkeypatch: pytes
             "limits": {"rows": 1},
         }
     }
+
+
+def test_sandbox_runner_rejects_malformed_stdin_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    stdin = io.StringIO("{not-json")
+    stdout = io.StringIO()
+    stderr = io.StringIO()
+
+    monkeypatch.setattr("sys.stdin", stdin)
+    monkeypatch.setattr("sys.stdout", stdout)
+    monkeypatch.setattr("sys.stderr", stderr)
+
+    exit_code = sandbox_runner.main([])
+
+    assert exit_code == 2
+    assert stdout.getvalue() == ""
+    assert stderr.getvalue() == "sandbox_invalid_request"
+
+
+@pytest.mark.parametrize(
+    ("requested", "expected"),
+    [
+        (0, 0.5),
+        (999, 30.0),
+    ],
+)
+def test_run_transform_clamps_timeout_bounds(monkeypatch: pytest.MonkeyPatch, requested: float, expected: float) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(*args, **kwargs):
+        captured["timeout"] = kwargs["timeout"]
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout=b'{"proposal": {}}', stderr=b"")
+
+    monkeypatch.setattr("core.runtime.sandbox.subprocess.run", _fake_run)
+
+    result = sandbox.run_transform("trusted_plugin", "normalize", {"input": {}, "limits": {}}, timeout=requested)
+
+    assert result == {"proposal": {}}
+    assert captured["timeout"] == expected
 
 
 def test_run_transform_rejects_non_numeric_timeout() -> None:

--- a/tests/test_runtime_sandbox.py
+++ b/tests/test_runtime_sandbox.py
@@ -1,0 +1,95 @@
+from __future__ import annotations
+
+import io
+import json
+import subprocess
+
+import pytest
+
+from core.runtime import sandbox, sandbox_runner
+
+
+class _FakePlugin:
+    def __init__(self) -> None:
+        self.calls: list[tuple[str, dict[str, object], dict[str, object]]] = []
+
+    def plan_transform(self, fn: str, input_data: dict[str, object], *, limits: dict[str, object]) -> dict[str, object]:
+        self.calls.append((fn, input_data, limits))
+        return {"fn": fn, "input": input_data, "limits": limits}
+
+
+@pytest.mark.parametrize(
+    ("plugin_id", "fn"),
+    [
+        ("calc.exe", "cmd /c whoami"),
+        ("powershell -NoProfile -Command Write-Host pwned", "python -c print(1)"),
+        (r"C:\Program Files\Bad App\tool.exe", "--extra-argv=--danger"),
+        ("cmd /c echo injected", "&& rm -rf /"),
+    ],
+)
+def test_run_transform_never_places_user_strings_in_subprocess_argv(
+    monkeypatch: pytest.MonkeyPatch,
+    plugin_id: str,
+    fn: str,
+) -> None:
+    captured: dict[str, object] = {}
+
+    def _fake_run(*args, **kwargs):
+        captured["command"] = args[0]
+        captured["input"] = kwargs["input"]
+        captured["timeout"] = kwargs["timeout"]
+        return subprocess.CompletedProcess(args=args[0], returncode=0, stdout=b'{"proposal": {"ok": true}}', stderr=b"")
+
+    monkeypatch.setattr("core.runtime.sandbox.subprocess.run", _fake_run)
+
+    result = sandbox.run_transform(plugin_id, fn, {"input": {"value": 1}, "limits": {"rows": 5}}, timeout=999)
+
+    assert result == {"proposal": {"ok": True}}
+    assert captured["command"] == [sandbox.sys.executable, "-m", "core.runtime.sandbox_runner"]
+    assert captured["timeout"] == 30.0
+
+    command_text = " ".join(captured["command"])
+    assert plugin_id not in command_text
+    assert fn not in command_text
+
+    stdin_payload = json.loads(captured["input"].decode("utf-8"))
+    assert stdin_payload["plugin_id"] == plugin_id
+    assert stdin_payload["fn"] == fn
+    assert stdin_payload["input"] == {"value": 1}
+    assert stdin_payload["limits"] == {"rows": 5}
+
+
+def test_sandbox_runner_executes_transform_from_stdin_request(monkeypatch: pytest.MonkeyPatch) -> None:
+    fake_plugin = _FakePlugin()
+    stdin = io.StringIO(
+        json.dumps(
+            {
+                "plugin_id": "trusted_plugin",
+                "fn": "normalize",
+                "input": {"value": 7},
+                "limits": {"rows": 1},
+            }
+        )
+    )
+    stdout = io.StringIO()
+
+    monkeypatch.setattr("core.runtime.sandbox_runner._load_plugin", lambda plugin_id: fake_plugin)
+    monkeypatch.setattr("sys.stdin", stdin)
+    monkeypatch.setattr("sys.stdout", stdout)
+
+    exit_code = sandbox_runner.main([])
+
+    assert exit_code == 0
+    assert fake_plugin.calls == [("normalize", {"value": 7}, {"rows": 1})]
+    assert json.loads(stdout.getvalue()) == {
+        "proposal": {
+            "fn": "normalize",
+            "input": {"value": 7},
+            "limits": {"rows": 1},
+        }
+    }
+
+
+def test_run_transform_rejects_non_numeric_timeout() -> None:
+    with pytest.raises(sandbox.SandboxError, match="sandbox_invalid_timeout"):
+        sandbox.run_transform("trusted_plugin", "normalize", {"input": {}, "limits": {}}, timeout=float("nan"))

--- a/tests/test_runtime_sandbox.py
+++ b/tests/test_runtime_sandbox.py
@@ -3,7 +3,6 @@ from __future__ import annotations
 import io
 import json
 import subprocess
-import sys
 
 import pytest
 

--- a/tests/test_ui_router_security.py
+++ b/tests/test_ui_router_security.py
@@ -1,0 +1,20 @@
+from pathlib import Path
+
+
+REPO_ROOT = Path(__file__).resolve().parents[1]
+
+
+def test_legacy_router_uses_allowlisted_route_resolution() -> None:
+    router_js = (REPO_ROOT / "core" / "ui" / "js" / "router.js").read_text(encoding="utf-8")
+
+    assert "const routes = Object.create(null);" in router_js
+    assert "Object.prototype.hasOwnProperty.call(routes, path)" in router_js
+    assert "const handler = resolveRoute(path);" in router_js
+    assert "typeof handler === 'function'" in router_js
+    assert "routes[path] || routes['/home']" not in router_js
+
+
+def test_shell_still_uses_app_js_as_canonical_router() -> None:
+    shell_html = (REPO_ROOT / "core" / "ui" / "shell.html").read_text(encoding="utf-8")
+
+    assert '<script type="module" src="/ui/app.js' in shell_html


### PR DESCRIPTION
This pull request implements a focused security hardening pass and several UI correctness fixes, with changes spanning the sandbox transform execution, path safety, admin UI rendering, and manufacturing/inventory workflows. The most critical updates are the hardening of subprocess boundaries (sandbox), strict path resolution for file operations and plugin assets, and the elimination of unsafe HTML rendering in admin previews. Versioning and documentation are updated to reflect these changes, and targeted regression tests have been added.

**Security and Trust Boundary Hardening**

- Sandbox transform subprocesses now use a fixed command (`sys.executable -m core.runtime.sandbox_runner`), passing all dynamic data (plugin ID, function, payload) via stdin JSON. Malformed or malicious input is strictly rejected, and the subprocess is constrained in terms of timeout and output size. This prevents user or plugin data from influencing command-line arguments or executable selection. [[1]](diffhunk://#diff-6388c9057d06652a0e696ce3ffda961438a9a0e0d70f68287cf1902ae17f6c6aR27-R90) [[2]](diffhunk://#diff-7cb9b8b8eb163fd8dda092ee3fccbbf2bf70612687cbef8e4376e9d14a9b4742L22) [[3]](diffhunk://#diff-7cb9b8b8eb163fd8dda092ee3fccbbf2bf70612687cbef8e4376e9d14a9b4742R45-R72) [[4]](diffhunk://#diff-2e61ef3f8656de79acc3baa37433d04f5022b6461f13dee0602193c98c0cea98R22-R24) [[5]](diffhunk://#diff-2e61ef3f8656de79acc3baa37433d04f5022b6461f13dee0602193c98c0cea98R115-R121) [[6]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R23) [[7]](diffhunk://#diff-ded4cd6d206a097754a81d77b0457fd00b0355f59770fdfef365383d0536b72fR85-R86)

- All user-influenced file system paths (import/export, local-open, local-validate, plugin UI assets) are now resolved through explicit allowed roots before any file system or OS-open operations, preventing path traversal and ensuring only safe, in-root paths are used. [[1]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2R127) [[2]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2L736-R739) [[3]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2R1447-R1470) [[4]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2L2156-R2180) [[5]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2L2174-R2203) [[6]](diffhunk://#diff-2e61ef3f8656de79acc3baa37433d04f5022b6461f13dee0602193c98c0cea98R22-R24) [[7]](diffhunk://#diff-2e61ef3f8656de79acc3baa37433d04f5022b6461f13dee0602193c98c0cea98R115-R121) [[8]](diffhunk://#diff-ded4cd6d206a097754a81d77b0457fd00b0355f59770fdfef365383d0536b72fR85-R86)

**UI Rendering and Workflow Fixes**

- Admin restore/import preview metadata is now rendered using DOM text nodes instead of `innerHTML`, eliminating the risk of markup injection and ensuring all previewed data is treated as plain text. [[1]](diffhunk://#diff-4c4f2a17b3dc8e92f2a4cdbb81a078930e937d8f3f5e462cb28ad4db0f5c08bfR31-R60) [[2]](diffhunk://#diff-4c4f2a17b3dc8e92f2a4cdbb81a078930e937d8f3f5e462cb28ad4db0f5c08bfL141-R171) [[3]](diffhunk://#diff-2e61ef3f8656de79acc3baa37433d04f5022b6461f13dee0602193c98c0cea98R22-R24) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R23)

- Manufacturing and Inventory UI now correctly display current on-hand inventory values and align rendering with shared item display helpers. Item-entry workflow improvements ensure that adding a vendor from the item form preserves current fields and selects the newly created vendor. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R23) [[2]](diffhunk://#diff-8d5ea661965d70d6980350c567d939b333af18a4e3f8d71c0d9d8192fbb5f3efR8)

**Documentation and Versioning**

- Updated `CHANGELOG.md`, `SOT.md`, and security governance docs to reflect all boundary changes and hardening measures. Internal version bumped to `1.1.0.7` for these security changes, and compliance status updated. [[1]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR49-R50) [[2]](diffhunk://#diff-628a05b67e753eddb9cde42988143f59fa4d7fed82b23a89465f59f0c2014e11L17-R19) [[3]](diffhunk://#diff-ded4cd6d206a097754a81d77b0457fd00b0355f59770fdfef365383d0536b72fR85-R86) [[4]](diffhunk://#diff-2e61ef3f8656de79acc3baa37433d04f5022b6461f13dee0602193c98c0cea98R22-R24)

**Testing**

- Added targeted regression tests for sandbox command construction, legacy route dispatch, admin preview rendering, and path traversal/outside-root rejection.

**References:** [[1]](diffhunk://#diff-2e61ef3f8656de79acc3baa37433d04f5022b6461f13dee0602193c98c0cea98R22-R24) [[2]](diffhunk://#diff-2e61ef3f8656de79acc3baa37433d04f5022b6461f13dee0602193c98c0cea98R115-R121) [[3]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR14-R23) [[4]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR49-R50) [[5]](diffhunk://#diff-06572a96a58dc510037d5efa622f9bec8519bc1beab13c9f251e97e657a9d4edR125-R131) [[6]](diffhunk://#diff-ded4cd6d206a097754a81d77b0457fd00b0355f59770fdfef365383d0536b72fR85-R86) [[7]](diffhunk://#diff-628a05b67e753eddb9cde42988143f59fa4d7fed82b23a89465f59f0c2014e11L17-R19) [[8]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2R127) [[9]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2L736-R739) [[10]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2R1447-R1470) [[11]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2L2156-R2180) [[12]](diffhunk://#diff-6ec869cbc40d5d06c5dff32a2f49e0ca1d5db4534cf3b995003b9fbef6f59eb2L2174-R2203) [[13]](diffhunk://#diff-6388c9057d06652a0e696ce3ffda961438a9a0e0d70f68287cf1902ae17f6c6aR27-R90) [[14]](diffhunk://#diff-7cb9b8b8eb163fd8dda092ee3fccbbf2bf70612687cbef8e4376e9d14a9b4742L22) [[15]](diffhunk://#diff-7cb9b8b8eb163fd8dda092ee3fccbbf2bf70612687cbef8e4376e9d14a9b4742R45-R72) [[16]](diffhunk://#diff-4c4f2a17b3dc8e92f2a4cdbb81a078930e937d8f3f5e462cb28ad4db0f5c08bfR31-R60) [[17]](diffhunk://#diff-4c4f2a17b3dc8e92f2a4cdbb81a078930e937d8f3f5e462cb28ad4db0f5c08bfL141-R171) [[18]](diffhunk://#diff-8d5ea661965d70d6980350c567d939b333af18a4e3f8d71c0d9d8192fbb5f3efR8)