### PR TITLE
BUS Core 1.3.0 combines the local Invoice Truth MVP with selectable UI theme variants.

### DIFF
--- a/.tools/gh/LICENSE
+++ b/.tools/gh/LICENSE
@@ -1,0 +1,21 @@
+MIT License
+
+Copyright (c) 2019 GitHub Inc.
+
+Permission is hereby granted, free of charge, to any person obtaining a copy
+of this software and associated documentation files (the "Software"), to deal
+in the Software without restriction, including without limitation the rights
+to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+copies of the Software, and to permit persons to whom the Software is
+furnished to do so, subject to the following conditions:
+
+The above copyright notice and this permission notice shall be included in all
+copies or substantial portions of the Software.
+
+THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+SOFTWARE.

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,21 @@
 
 ## [1.2.4] - 2026-06-17
 
+### Invoice Truth MVP Frontend UI
+
+- Added a dedicated `#/invoices` route, screen host, and sidebar navigation entry near Jobs and Finance.
+- Added the local invoice list/detail UI, manual draft invoice creation, draft line add/edit/delete, tax-rate and taxable-line controls, totals display, and issue/mark-paid/void actions.
+- Added a Jobs detail action that creates a draft invoice from a job and routes directly into the invoice editor.
+- Kept the scope UI-only for this pass: no Pro email/payment/accounting/customer-portal/recurring/reminder features were added.
+- Bumped `INTERNAL_VERSION` from `1.2.4.1` to `1.2.4.2` for the frontend Invoice Truth MVP implementation without changing public `VERSION`.
+
+### Invoice Truth MVP Print Slice
+
+- Added `GET /app/invoices/{invoice_id}/print` as a local HTML-first printable invoice route with escaped invoice, contact, job, line, and notes text.
+- Added a Print action in the Invoices UI that opens the printable invoice in a new tab for standard browser print or save-to-PDF flow.
+- Kept the scope minimal and local-first: no PDF dependency, email sending, payment links, customer portal, accounting sync, or other Pro features were added.
+- Bumped `INTERNAL_VERSION` from `1.2.4.2` to `1.2.4.3` for the printable invoice completion slice without changing public `VERSION`.
+
 ### Invoice Truth MVP Backend Phase 1
 
 - Added backend Invoice Truth MVP Phase 1: local invoice tables, additive startup bootstrap, invoice/job draft creation, draft-only invoice editing, issuing, idempotent mark-paid cash events, and focused invoice API/tests.

--- a/core/api/routes/invoices.py
+++ b/core/api/routes/invoices.py
@@ -4,6 +4,7 @@ from __future__ import annotations
 from datetime import datetime
 
 from fastapi import APIRouter, Depends, Query
+from fastapi.responses import HTMLResponse
 from pydantic import BaseModel
 from sqlalchemy.orm import Session
 
@@ -101,6 +102,17 @@ def get_invoice_detail(
     _state: AppState = Depends(get_state),
 ):
     return invoice_service.get_invoice_detail(db, invoice_id)
+
+
+@router.get("/{invoice_id}/print", response_class=HTMLResponse)
+def get_invoice_print(
+    invoice_id: int,
+    db: Session = Depends(get_session),
+    _permission=Depends(require_permission(PERMISSION_INVOICES_READ)),
+    _token: str = Depends(require_token_ctx),
+    _state: AppState = Depends(get_state),
+):
+    return HTMLResponse(invoice_service.render_invoice_print_html(db, invoice_id))
 
 
 @router.patch("/{invoice_id}")

--- a/core/services/invoices.py
+++ b/core/services/invoices.py
@@ -1,6 +1,7 @@
 # SPDX-License-Identifier: AGPL-3.0-or-later
 from __future__ import annotations
 
+from html import escape
 from datetime import datetime
 from decimal import Decimal, InvalidOperation, ROUND_HALF_UP
 from typing import Any
@@ -323,6 +324,130 @@ def delete_invoice_line(db: Session, invoice_id: int, line_id: int) -> dict[str,
 
 def get_invoice_detail(db: Session, invoice_id: int) -> dict[str, Any]:
     return _serialize_invoice(_get_invoice(db, invoice_id), include_lines=True)
+
+
+def _format_invoice_print_date(value: Any, fallback: str = "—") -> str:
+    if value is None:
+        return fallback
+    if isinstance(value, datetime):
+        return value.strftime("%Y-%m-%d")
+    text = str(value).strip()
+    if not text:
+        return fallback
+    try:
+        return datetime.fromisoformat(text.replace("Z", "+00:00")).strftime("%Y-%m-%d")
+    except ValueError:
+        return text
+
+
+def _format_invoice_money(cents: Any) -> str:
+    value = Decimal(int(cents or 0)) / Decimal("100")
+    return f"${value:,.2f}"
+
+
+def render_invoice_print_html(db: Session, invoice_id: int) -> str:
+    invoice = get_invoice_detail(db, invoice_id)
+    contact = _get_contact(db, int(invoice["contact_id"]))
+    job = _get_job(db, int(invoice["job_id"])) if invoice.get("job_id") is not None else None
+
+    lines_html = []
+    for line in invoice.get("lines", []):
+        taxable_label = "Yes" if line.get("taxable") else "No"
+        lines_html.append(
+            (
+                "<tr>"
+                f"<td>{escape(str(line.get('description') or ''))}</td>"
+                f"<td>{escape(str(line.get('line_type') or ''))}</td>"
+                f"<td>{escape(str(line.get('quantity_decimal') or '—'))}</td>"
+                f"<td>{escape(str(line.get('uom') or '—'))}</td>"
+                f"<td>{escape(_format_invoice_money(line.get('unit_price_cents')) if line.get('unit_price_cents') is not None else '—')}</td>"
+                f"<td>{escape(taxable_label)}</td>"
+                f"<td>{escape(_format_invoice_money(line.get('line_subtotal_cents')))}</td>"
+                "</tr>"
+            )
+        )
+    if not lines_html:
+        lines_html.append('<tr><td colspan="7">No lines</td></tr>')
+
+    notes_text = str(invoice.get("notes") or "").strip()
+    notes_html = escape(notes_text) if notes_text else "—"
+    contact_display = str(getattr(contact, "name", "") or f"Contact #{invoice['contact_id']}")
+    job_display = str(getattr(job, "title", "") or f"Job #{invoice['job_id']}") if job is not None else "—"
+
+    return (
+        "<!doctype html>"
+        "<html lang=\"en\">"
+        "<head>"
+        "<meta charset=\"utf-8\">"
+        f"<title>{escape(str(invoice.get('invoice_number') or f'Invoice #{invoice_id}'))}</title>"
+        "<meta name=\"viewport\" content=\"width=device-width, initial-scale=1\">"
+        "<style>"
+        "body{font-family:Arial,sans-serif;margin:32px;color:#111;background:#fff;}"
+        "h1,h2,h3{margin:0 0 8px;}"
+        ".page{max-width:960px;margin:0 auto;}"
+        ".header{display:flex;justify-content:space-between;gap:24px;align-items:flex-start;margin-bottom:24px;}"
+        ".muted{color:#555;font-size:14px;}"
+        ".meta{display:grid;grid-template-columns:repeat(2,minmax(0,1fr));gap:12px 24px;margin:20px 0;}"
+        ".meta-block{border:1px solid #d0d0d0;padding:12px;border-radius:8px;}"
+        ".label{display:block;font-size:12px;text-transform:uppercase;color:#666;margin-bottom:4px;}"
+        "table{width:100%;border-collapse:collapse;margin-top:18px;}"
+        "th,td{border:1px solid #d0d0d0;padding:10px;text-align:left;vertical-align:top;font-size:14px;}"
+        "th{background:#f4f4f4;}"
+        ".totals{margin-top:18px;margin-left:auto;width:min(320px,100%);}"
+        ".totals-row{display:flex;justify-content:space-between;border-bottom:1px solid #d0d0d0;padding:8px 0;gap:12px;}"
+        ".totals-row strong{font-size:16px;}"
+        ".notes{margin-top:24px;border:1px solid #d0d0d0;border-radius:8px;padding:12px;white-space:pre-wrap;}"
+        "@media print{body{margin:16px;}.page{max-width:none;}}"
+        "</style>"
+        "</head>"
+        "<body>"
+        "<div class=\"page\">"
+        "<div class=\"header\">"
+        "<div>"
+        "<h1>BUS Core</h1>"
+        "<div class=\"muted\">Printable local invoice</div>"
+        "</div>"
+        "<div>"
+        f"<h2>{escape(str(invoice.get('invoice_number') or f'Invoice #{invoice_id}'))}</h2>"
+        f"<div class=\"muted\">Status: {escape(str(invoice.get('status') or 'draft'))}</div>"
+        "</div>"
+        "</div>"
+        "<div class=\"meta\">"
+        "<div class=\"meta-block\">"
+        "<span class=\"label\">Customer / Contact</span>"
+        f"<div>{escape(contact_display)}</div>"
+        "</div>"
+        "<div class=\"meta-block\">"
+        "<span class=\"label\">Linked Job</span>"
+        f"<div>{escape(job_display)}</div>"
+        "</div>"
+        "<div class=\"meta-block\">"
+        "<span class=\"label\">Issue Date</span>"
+        f"<div>{escape(_format_invoice_print_date(invoice.get('issue_date')))}</div>"
+        "</div>"
+        "<div class=\"meta-block\">"
+        "<span class=\"label\">Due Date</span>"
+        f"<div>{escape(_format_invoice_print_date(invoice.get('due_date')))}</div>"
+        "</div>"
+        "</div>"
+        "<table>"
+        "<thead><tr><th>Description</th><th>Type</th><th>Quantity</th><th>UOM</th><th>Unit Price</th><th>Taxable</th><th>Subtotal</th></tr></thead>"
+        f"<tbody>{''.join(lines_html)}</tbody>"
+        "</table>"
+        "<div class=\"totals\">"
+        f"<div class=\"totals-row\"><span>Subtotal</span><span>{escape(_format_invoice_money(invoice.get('subtotal_cents')))}</span></div>"
+        f"<div class=\"totals-row\"><span>Tax Rate</span><span>{escape(str(invoice.get('tax_rate_percent') or '0'))}%</span></div>"
+        f"<div class=\"totals-row\"><span>Tax Total</span><span>{escape(_format_invoice_money(invoice.get('tax_cents')))}</span></div>"
+        f"<div class=\"totals-row\"><strong>Total</strong><strong>{escape(_format_invoice_money(invoice.get('total_cents')))}</strong></div>"
+        "</div>"
+        "<div class=\"notes\">"
+        "<span class=\"label\">Notes</span>"
+        f"{notes_html}"
+        "</div>"
+        "</div>"
+        "</body>"
+        "</html>"
+    )
 
 
 def update_invoice(db: Session, invoice_id: int, payload: dict[str, Any]) -> dict[str, Any]:

--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -34,6 +34,9 @@ import { mountFinance } from "./js/cards/finance.js";
 import { mountSecurity } from "./js/security.js";
 import { toMetricBase, DIM_DEFAULTS_IMPERIAL } from "./js/lib/units.js";
 import { bindSidebarUpdateControls, maybeRunStartupUpdateCheck } from "./js/update-check.js";
+import { initTheme } from "./js/theme.js";
+
+initTheme();
 
 const ROUTES = {
   '#/welcome': showWelcome,

--- a/core/ui/app.js
+++ b/core/ui/app.js
@@ -25,6 +25,7 @@ import { mountBackupExport } from "./js/cards/backup.js";
 import mountVendors from "./js/cards/vendors.js";
 import { mountHome } from "./js/cards/home.js";
 import { mountInventory, unmountInventory } from "./js/cards/inventory.js";
+import { mountInvoices, unmountInvoices } from "./js/cards/invoices.js";
 import { mountJobs, unmountJobs } from "./js/cards/jobs.js";
 import { mountManufacturing, unmountManufacturing } from "./js/cards/manufacturing.js";
 import { mountRecipes, unmountRecipes } from "./js/cards/recipes.js";
@@ -41,6 +42,7 @@ initTheme();
 const ROUTES = {
   '#/welcome': showWelcome,
   '#/jobs': showJobs,
+  '#/invoices': showInvoices,
   '#/inventory': showInventory,
   '#/manufacturing': showManufacturing,
   '#/recipes': showRecipes,
@@ -89,6 +91,7 @@ const ROUTE_PERMISSIONS = {
   contacts: ['contacts.read'],
   finance: ['finance.read'],
   inventory: ['inventory.read'],
+  invoices: ['invoices.read'],
   jobs: ['jobs.read'],
   logs: ['logs.read'],
   manufacturing: ['manufacturing.read'],
@@ -408,9 +411,10 @@ function clearCardHost() {
   const recipesHost = document.querySelector('[data-tab-panel="recipes"]');
   const logsHost = document.querySelector('[data-role="logs-root"]');
   const financeHost = document.querySelector('[data-role="finance-root"]');
+  const invoicesHost = document.querySelector('[data-role="invoices-root"]');
   const jobsHost = document.querySelector('[data-role="jobs-root"]');
   const welcomeHost = document.querySelector('[data-role="welcome-root"]');
-  [root, inventoryHost, contactsHost, settingsHost, securityHost, manufacturingHost, recipesHost, logsHost, financeHost, jobsHost, welcomeHost]
+  [root, inventoryHost, contactsHost, settingsHost, securityHost, manufacturingHost, recipesHost, logsHost, financeHost, invoicesHost, jobsHost, welcomeHost]
     .filter(Boolean)
     .forEach((n) => {
       n.innerHTML = '';
@@ -496,7 +500,7 @@ async function onRouteChange() {
   renderDemoBanner();
   window.BUS_ROUTE = { path: canonical, base: canonical, id: null };
 
-  const detailMatch = canonical.match(/^#\/(inventory|contacts|recipes|runs)\/([^/]+)$/);
+  const detailMatch = canonical.match(/^#\/(inventory|contacts|recipes|runs|invoices)\/([^/]+)$/);
   const baseHash = detailMatch ? `#/${detailMatch[1]}` : canonical;
   const detailId = detailMatch ? decodeURIComponent(detailMatch[2]) : null;
   const hash = canonical;
@@ -512,6 +516,7 @@ async function onRouteChange() {
   document.querySelector('[data-role="settings-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="security-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
   clearCardHost();
 
@@ -589,6 +594,7 @@ async function showContacts() {
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
   const contactsScreen = document.querySelector('[data-role="contacts-screen"]');
   contactsScreen?.classList.remove('hidden');
@@ -604,6 +610,7 @@ async function showInventory() {
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
   unmountJobs();
   unmountManufacturing();
@@ -621,6 +628,7 @@ async function showManufacturing() {
   document.querySelector('[data-role="inventory-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
   const screen = document.querySelector('[data-role="manufacturing-screen"]');
   screen?.classList.remove('hidden');
@@ -638,10 +646,12 @@ async function showSettings() {
   document.querySelector('[data-role="contacts-screen"]')?.classList.add('hidden');
   showScreen(null);
   document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="recipes-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
   const settingsScreen = document.querySelector('[data-role="settings-screen"]');
   settingsScreen?.classList.remove('hidden');
@@ -717,9 +727,31 @@ async function showFinance() {
   document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="recipes-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   const financeScreen = document.querySelector('[data-role="finance-screen"]');
   financeScreen?.classList.remove('hidden');
   mountFinance();
+}
+
+async function showInvoices() {
+  showScreen(null);
+  document.querySelector('[data-role="home-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="contacts-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="settings-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="inventory-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="recipes-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
+  unmountInventory();
+  unmountJobs();
+  unmountManufacturing();
+  unmountRecipes();
+  const invoicesScreen = document.querySelector('[data-role="invoices-screen"]');
+  invoicesScreen?.classList.remove('hidden');
+  await mountInvoices();
 }
 
 async function showHome() {
@@ -727,14 +759,17 @@ async function showHome() {
   mountHome();          // keep existing Home logic
   unmountInventory();   // ensure Inventory hides when returning Home
   unmountJobs();
+  unmountInvoices();
   document.querySelector('[data-role="inventory-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="contacts-screen"]')?.classList.add('hidden');
   unmountManufacturing();
   unmountRecipes();
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
 }
 
@@ -748,8 +783,10 @@ async function showJobs() {
   document.querySelector('[data-role="recipes-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
   unmountInventory();
+  unmountInvoices();
   unmountManufacturing();
   unmountRecipes();
   const jobsScreen = document.querySelector('[data-role="jobs-screen"]');
@@ -766,6 +803,7 @@ async function showRecipes() {
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="welcome-screen"]')?.classList.add('hidden');
   const recipesScreen = document.querySelector('[data-role="recipes-screen"]');
   recipesScreen?.classList.remove('hidden');
@@ -799,6 +837,7 @@ async function showNotFound(badHash) {
   document.querySelector('[data-role="inventory-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="recipes-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
@@ -817,6 +856,7 @@ async function showRuns() {
   document.querySelector('[data-role="inventory-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="recipes-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
@@ -835,6 +875,7 @@ async function showImport() {
   document.querySelector('[data-role="inventory-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="recipes-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');
@@ -858,6 +899,7 @@ async function showWelcome() {
   document.querySelector('[data-role="inventory-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="manufacturing-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="jobs-screen"]')?.classList.add('hidden');
+  document.querySelector('[data-role="invoices-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="recipes-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="logs-screen"]')?.classList.add('hidden');
   document.querySelector('[data-role="finance-screen"]')?.classList.add('hidden');

--- a/core/ui/css/app.css
+++ b/core/ui/css/app.css
@@ -15,6 +15,25 @@
   --accent-3: #e9b256;
   --accent-4: #31c98d;
   --danger: #f06a72;
+  --success: #31c98d;
+  --warning: #e9b256;
+  --table-header: #24314a;
+  --input-bg: #1c2029;
+  --button-bg: var(--accent);
+  --button-text: #ffffff;
+  --theme-shell-gradient-1: rgba(89, 123, 255, 0.2);
+  --theme-shell-gradient-2: rgba(85, 102, 226, 0.16);
+  --theme-shell-gradient-3: rgba(39, 66, 138, 0.2);
+  --theme-body-gradient: linear-gradient(180deg, #0b1222 0%, #090d18 55%, #080c16 100%);
+  --theme-sidebar-glow: rgba(80, 111, 210, 0.24);
+  --theme-sidebar-overlay: linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.005));
+  --theme-main-overlay: linear-gradient(180deg, rgba(13, 19, 36, 0.34), rgba(8, 12, 22, 0.16));
+  --theme-card-bg: linear-gradient(180deg, rgba(30, 42, 69, 0.72), rgba(21, 30, 49, 0.68)), var(--surface);
+  --theme-card-border: rgba(102, 127, 176, 0.24);
+  --theme-card-shadow: 0 10px 26px rgba(7, 14, 28, 0.28), inset 0 0 0 1px rgba(143, 170, 222, 0.06);
+  --theme-row-hover: rgba(56, 94, 156, 0.18);
+  --theme-panel-bg: rgba(24, 33, 49, 0.7);
+  --theme-panel-border: rgba(95, 121, 165, 0.28);
   --badge-bg: rgba(109, 95, 255, 0.2);
 
   /* Safe aliases for currently referenced legacy tokens. */
@@ -36,6 +55,126 @@
   font-family: 'Inter', 'Segoe UI', system-ui, -apple-system, sans-serif;
 }
 
+:root[data-bus-theme="clean-light"] {
+  color-scheme: light;
+  --bg: #eef2f7;
+  --surface: #ffffff;
+  --sidebar: #e3eaf4;
+  --border: #b8c4d3;
+  --text: #162033;
+  --fg: var(--text);
+  --muted: #5d6a7b;
+  --accent: #246bcb;
+  --accent-2: #1d5fb8;
+  --accent-3: #a45f00;
+  --accent-4: #177245;
+  --danger: #b42331;
+  --success: #177245;
+  --warning: #a45f00;
+  --table-header: #dce5f0;
+  --input-bg: #f8fafc;
+  --button-bg: #246bcb;
+  --button-text: #ffffff;
+  --badge-bg: rgba(36, 107, 203, 0.14);
+  --theme-shell-gradient-1: rgba(36, 107, 203, 0.12);
+  --theme-shell-gradient-2: rgba(20, 114, 96, 0.08);
+  --theme-shell-gradient-3: rgba(96, 125, 159, 0.12);
+  --theme-body-gradient: linear-gradient(180deg, #f7f9fc 0%, #eef2f7 58%, #e7edf5 100%);
+  --theme-sidebar-glow: rgba(36, 107, 203, 0.13);
+  --theme-sidebar-overlay: linear-gradient(180deg, rgba(255, 255, 255, 0.72), rgba(255, 255, 255, 0.28));
+  --theme-main-overlay: linear-gradient(180deg, rgba(255, 255, 255, 0.52), rgba(231, 237, 245, 0.28));
+  --theme-card-bg: linear-gradient(180deg, rgba(255, 255, 255, 0.95), rgba(247, 249, 252, 0.94)), var(--surface);
+  --theme-card-border: rgba(91, 108, 131, 0.22);
+  --theme-card-shadow: 0 10px 26px rgba(36, 51, 74, 0.12), inset 0 0 0 1px rgba(255, 255, 255, 0.72);
+  --theme-row-hover: rgba(36, 107, 203, 0.1);
+  --theme-panel-bg: rgba(255, 255, 255, 0.82);
+  --theme-panel-border: rgba(105, 123, 145, 0.26);
+  --surface-2: #eef3f8;
+  --card-bg: var(--surface);
+  --border-color: var(--border);
+  --text-muted: var(--muted);
+}
+
+:root[data-bus-theme="workshop-slate"] {
+  color-scheme: dark;
+  --bg: #12161a;
+  --surface: #1d242b;
+  --sidebar: #171d22;
+  --border: #3f4b56;
+  --text: #e8ecef;
+  --fg: var(--text);
+  --muted: #a8b2bb;
+  --accent: #d99a32;
+  --accent-2: #f0b655;
+  --accent-3: #d99a32;
+  --accent-4: #63c084;
+  --danger: #f07167;
+  --success: #63c084;
+  --warning: #f0b655;
+  --table-header: #2d3741;
+  --input-bg: #232c34;
+  --button-bg: #b97925;
+  --button-text: #17110a;
+  --badge-bg: rgba(217, 154, 50, 0.18);
+  --theme-shell-gradient-1: rgba(217, 154, 50, 0.11);
+  --theme-shell-gradient-2: rgba(78, 95, 107, 0.22);
+  --theme-shell-gradient-3: rgba(30, 42, 50, 0.3);
+  --theme-body-gradient: linear-gradient(180deg, #171d22 0%, #12161a 58%, #0f1317 100%);
+  --theme-sidebar-glow: rgba(217, 154, 50, 0.13);
+  --theme-sidebar-overlay: linear-gradient(180deg, rgba(255, 255, 255, 0.035), rgba(255, 255, 255, 0.01));
+  --theme-main-overlay: linear-gradient(180deg, rgba(44, 55, 65, 0.36), rgba(18, 22, 26, 0.18));
+  --theme-card-bg: linear-gradient(180deg, rgba(38, 48, 57, 0.76), rgba(29, 36, 43, 0.72)), var(--surface);
+  --theme-card-border: rgba(139, 154, 166, 0.22);
+  --theme-card-shadow: 0 10px 26px rgba(8, 10, 12, 0.3), inset 0 0 0 1px rgba(217, 154, 50, 0.05);
+  --theme-row-hover: rgba(217, 154, 50, 0.13);
+  --theme-panel-bg: rgba(29, 36, 43, 0.78);
+  --theme-panel-border: rgba(139, 154, 166, 0.26);
+  --surface-2: #232c34;
+  --card-bg: var(--surface);
+  --border-color: var(--border);
+  --text-muted: var(--muted);
+}
+
+:root[data-bus-theme="high-contrast"] {
+  color-scheme: dark;
+  --bg: #000000;
+  --surface: #050505;
+  --sidebar: #000000;
+  --border: #ffffff;
+  --text: #ffffff;
+  --fg: var(--text);
+  --muted: #d7d7d7;
+  --accent: #ffff00;
+  --accent-2: #00ffff;
+  --accent-3: #ffff00;
+  --accent-4: #00ff66;
+  --danger: #ff4d4d;
+  --success: #00ff66;
+  --warning: #ffff00;
+  --table-header: #1a1a1a;
+  --input-bg: #000000;
+  --button-bg: #ffff00;
+  --button-text: #000000;
+  --badge-bg: rgba(255, 255, 0, 0.22);
+  --theme-shell-gradient-1: transparent;
+  --theme-shell-gradient-2: transparent;
+  --theme-shell-gradient-3: transparent;
+  --theme-body-gradient: linear-gradient(180deg, #000000 0%, #000000 100%);
+  --theme-sidebar-glow: transparent;
+  --theme-sidebar-overlay: linear-gradient(180deg, transparent, transparent);
+  --theme-main-overlay: linear-gradient(180deg, transparent, transparent);
+  --theme-card-bg: var(--surface);
+  --theme-card-border: #ffffff;
+  --theme-card-shadow: none;
+  --theme-row-hover: rgba(255, 255, 0, 0.16);
+  --theme-panel-bg: #050505;
+  --theme-panel-border: #ffffff;
+  --surface-2: #111111;
+  --card-bg: var(--surface);
+  --border-color: var(--border);
+  --text-muted: var(--muted);
+}
+
 /* 2. Base */
 /* 3. Shell layout */
 html {
@@ -52,10 +191,10 @@ body {
   overflow: hidden;
   font: 14px/1.5 system-ui, Segoe UI, Arial;
   background:
-    radial-gradient(1280px 760px at 16% -14%, rgba(89, 123, 255, 0.2), transparent 58%),
-    radial-gradient(980px 680px at 90% 8%, rgba(85, 102, 226, 0.16), transparent 64%),
-    radial-gradient(760px 520px at 52% 115%, rgba(39, 66, 138, 0.2), transparent 72%),
-    linear-gradient(180deg, #0b1222 0%, #090d18 55%, #080c16 100%);
+    radial-gradient(1280px 760px at 16% -14%, var(--theme-shell-gradient-1), transparent 58%),
+    radial-gradient(980px 680px at 90% 8%, var(--theme-shell-gradient-2), transparent 64%),
+    radial-gradient(760px 520px at 52% 115%, var(--theme-shell-gradient-3), transparent 72%),
+    var(--theme-body-gradient);
   color: var(--fg);
 }
 * { box-sizing: border-box; }
@@ -69,11 +208,11 @@ body {
   overflow-x: hidden;
   overflow-y: auto;
   background:
-    radial-gradient(720px 520px at 10% -10%, rgba(80, 111, 210, 0.24), transparent 60%),
-    linear-gradient(180deg, rgba(255, 255, 255, 0.03), rgba(255, 255, 255, 0.005)),
+    radial-gradient(720px 520px at 10% -10%, var(--theme-sidebar-glow), transparent 60%),
+    var(--theme-sidebar-overlay),
     var(--sidebar);
   padding: 14px 10px;
-  border-right: 1px solid rgba(117, 145, 203, 0.28);
+  border-right: 1px solid var(--border);
   box-shadow: inset -1px 0 0 rgba(255, 255, 255, 0.04), 10px 0 34px rgba(8, 15, 31, 0.34);
   display: flex;
   flex-direction: column;
@@ -87,30 +226,28 @@ body {
   padding: 22px 24px;
   overflow-x: hidden;
   overflow-y: auto;
-  background: linear-gradient(180deg, rgba(13, 19, 36, 0.34), rgba(8, 12, 22, 0.16));
+  background: var(--theme-main-overlay);
 }
 h1, h2, h3, h4, h5, h6 {
   font-family: 'JetBrains Mono', Consolas, monospace;
-  color: #edf3ff;
+  color: var(--text);
 }
 
 a { color: var(--accent-2); }
 
 /* 6. Cards */
 .card {
-  background:
-    linear-gradient(180deg, rgba(30, 42, 69, 0.72), rgba(21, 30, 49, 0.68)),
-    #151d31;
+  background: var(--theme-card-bg);
   padding: 16px;
   border-radius: 10px;
   margin-bottom: 16px;
-  border: 1px solid rgba(102, 127, 176, 0.24);
-  box-shadow: 0 10px 26px rgba(7, 14, 28, 0.28), inset 0 0 0 1px rgba(143, 170, 222, 0.06);
+  border: 1px solid var(--theme-card-border);
+  box-shadow: var(--theme-card-shadow);
 }
 
 .card h2 {
   margin: 0 0 8px;
-  color: #d9e6ff;
+  color: var(--text);
 }
 .eula-container {
   max-width: 640px;
@@ -234,9 +371,9 @@ a { color: var(--accent-2); }
   padding: 8px 10px;
   margin-bottom: 16px;
   border-radius: 8px;
-  background: #1f2736;
-  color: #dce7fb;
-  border: 1px solid #334056;
+  background: var(--input-bg);
+  color: var(--text);
+  border: 1px solid var(--border);
 }
 
 .settings-stack {
@@ -262,7 +399,7 @@ a { color: var(--accent-2); }
 
 .settings-check {
   transform: scale(1.05);
-  accent-color: #4d8eff;
+  accent-color: var(--accent);
 }
 
 .settings-subtext {
@@ -276,9 +413,9 @@ a { color: var(--accent-2); }
   width: 100%;
   padding: 8px 10px;
   border-radius: 8px;
-  background: #1f2736;
-  color: #b2bfd8;
-  border: 1px solid #334056;
+  background: var(--input-bg);
+  color: var(--muted);
+  border: 1px solid var(--border);
   font-size: 0.8rem;
 }
 
@@ -342,7 +479,7 @@ a { color: var(--accent-2); }
 .settings-save-feedback {
   opacity: 0;
   transition: opacity 0.3s;
-  color: #79d48b;
+  color: var(--success);
   font-weight: 500;
   font-size: 0.78rem;
 }
@@ -527,8 +664,8 @@ textarea {
 }
 
 button {
-  background: var(--accent);
-  color: #fff;
+  background: var(--button-bg);
+  color: var(--button-text);
   border: none;
   padding: 8px 12px;
   border-radius: 6px;
@@ -538,7 +675,7 @@ button {
 button:hover { opacity: .9; }
 
 button.danger { background: var(--danger); }
-button.primary { background: var(--accent); }
+button.primary { background: var(--button-bg); }
 
 .btn {
   display: inline-flex;
@@ -549,16 +686,17 @@ button.primary { background: var(--accent); }
   padding: 8px 12px;
   border: 0;
   border-radius: 8px;
-  background: var(--accent);
-  color: #fff;
+  background: var(--button-bg);
+  color: var(--button-text);
   text-decoration: none;
   cursor: pointer;
 }
 
 .btn-secondary,
 .btn.secondary {
-  background: #2b364e;
-  color: #dce7fb;
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
 }
 
 .btn-icon {
@@ -576,7 +714,7 @@ button.primary { background: var(--accent); }
 input,
 select,
 textarea {
-  background: #1c2029;
+  background: var(--input-bg);
   border: 1px solid var(--border);
   color: var(--text);
   padding: 8px 10px;
@@ -599,7 +737,9 @@ table td {
   border-bottom: 1px solid var(--border);
 }
 
-table tr:hover { background: #1e2530; }
+table th { background: var(--table-header); }
+
+table tr:hover { background: var(--theme-row-hover); }
 
 .table-clickable tbody tr[data-role="item-row"] { cursor: pointer; }
 .row-details td {
@@ -4073,5 +4213,313 @@ hr.thin {
 .subtable td {
   text-align: center;
   padding: 6px 8px;
+}
+
+/* Theme spike: late variable authority for major route/card patterns. */
+#sidebar h1 {
+  margin: 0 0 16px 16px;
+  font-size: 14px;
+  color: var(--muted);
+}
+
+.tab {
+  padding: 10px 16px;
+  cursor: pointer;
+  border-left: 4px solid transparent;
+}
+
+.tab.active {
+  background: var(--table-header);
+  border-left-color: var(--accent);
+  font-weight: 600;
+}
+
+.tab:hover:not(.active) {
+  background: var(--theme-row-hover);
+}
+
+.tabs {
+  display: flex;
+  gap: 8px;
+  margin-bottom: 16px;
+}
+
+.tabs button {
+  background: var(--surface-2);
+  color: var(--text);
+  border: 1px solid var(--border);
+  padding: 8px 14px;
+  border-radius: 10px;
+  cursor: pointer;
+}
+
+.tabs button.active {
+  background: var(--button-bg);
+  border-color: var(--accent);
+  color: var(--button-text);
+}
+
+.tab-panel {
+  display: flex;
+  flex-direction: column;
+  gap: 16px;
+}
+
+.legacy-contacts-head {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 12px;
+  margin-bottom: 12px;
+}
+
+.legacy-contacts-title {
+  margin: 0;
+}
+
+.screen-title {
+  margin: 0;
+}
+
+.legacy-contacts-table {
+  width: 100%;
+  border-collapse: separate;
+  border-spacing: 0;
+  background: var(--surface);
+  border-radius: 10px;
+  overflow: hidden;
+}
+
+.legacy-contacts-table th {
+  text-align: left;
+  padding: 10px;
+  background: var(--table-header);
+}
+
+.drawer-title {
+  margin: 0;
+  font-size: 18px;
+  color: var(--text);
+}
+
+.drawer-close {
+  background: transparent;
+  border: none;
+  color: var(--muted);
+  font-size: 24px;
+  cursor: pointer;
+  line-height: 1;
+}
+
+#sidebar .sidebar-nav > li > a,
+#sidebar .nav > li > a,
+.nav-section,
+.settings-label,
+.settings-check-row,
+.settings-subtext,
+.settings-help-text,
+.settings-feedback-muted,
+.admin-muted,
+.finance-field,
+.contacts-field-label,
+.recipes-row-label,
+.mfg-label,
+.kv .k {
+  color: var(--muted);
+}
+
+#sidebar .sidebar-nav > li > a:hover,
+#sidebar .sidebar-nav > li > a.active,
+#sidebar .nav > li > a:hover,
+#sidebar .nav > li > a.active {
+  background: var(--theme-row-hover);
+  color: var(--text);
+  border-color: var(--accent);
+}
+
+.settings-shell,
+.manufacturing-shell,
+.recipes-shell,
+.finance-shell,
+.logs-shell,
+.contacts-shell {
+  background: var(--theme-card-bg);
+  border-color: var(--theme-card-border);
+  box-shadow: var(--theme-card-shadow);
+}
+
+.settings-card,
+.settings-operational-section .settings-card,
+.settings-admin-host,
+.settings-admin-host .admin-block,
+.finance-card,
+.logs-card,
+.contacts-table,
+.contacts-expanded,
+.contacts-modal-box,
+.recipes-list-panel,
+.recipes-editor-panel,
+.recipes-items-box,
+.mfg-projection-wrap,
+.mfg-recent-panel,
+.inventory-table-wrap,
+.metric-card,
+.status-box,
+.row-details td,
+.drawer-panel,
+.drawer-body .kv,
+.drawer-body .list li,
+.modal-content,
+.modal-card,
+.inventory-modal-card {
+  background: var(--theme-panel-bg);
+  border-color: var(--theme-panel-border);
+  color: var(--text);
+}
+
+.settings-page-title,
+.settings-section-title,
+.settings-card h3,
+.settings-admin-host .admin-title,
+.contacts-title,
+.contacts-name-text,
+.contacts-expanded-name,
+.recipes-list-title,
+.recipes-items-title,
+.finance-summary-value,
+.logs-title,
+.recipe-row-name,
+.inventory-shell .inventory-table td,
+.finance-td,
+.logs-col,
+.mfg-output-cell,
+.drawer-body .kv .v {
+  color: var(--text);
+}
+
+.settings-page-kicker,
+.settings-subtext,
+.settings-help-text,
+.contacts-subtitle,
+.contacts-meta-line,
+.contacts-contact-col,
+.contacts-empty,
+.recipes-empty,
+.recipes-status,
+.finance-summary-name,
+.finance-loading,
+.finance-empty,
+.logs-empty,
+.mfg-empty-msg,
+.mfg-status-msg,
+.mfg-muted-cell,
+.welcome-body,
+.welcome-step,
+.eula-loading {
+  color: var(--muted);
+}
+
+.settings-select,
+.settings-input-readonly,
+.settings-admin-host :is(input, select, textarea),
+.contacts-search-input,
+.contacts-input,
+.recipes-filter-input,
+.recipes-input,
+.recipes-textarea,
+.mfg-select,
+.finance-input,
+input,
+select,
+textarea {
+  background: var(--input-bg);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.contacts-table-head,
+.finance-table th,
+.logs-head,
+.inventory-shell .inventory-table thead th,
+.recipes-items-thead,
+.mfg-projection-head,
+table th {
+  background: var(--table-header);
+  color: var(--text);
+  border-color: var(--border);
+}
+
+.contacts-row,
+.finance-td,
+.logs-row,
+.recipe-row,
+.recipes-item-row,
+.mfg-projection-row,
+.inventory-shell .inventory-table td,
+table td {
+  border-color: var(--border);
+}
+
+.contacts-row:hover,
+.recipe-row:hover,
+.inventory-shell .inventory-table tbody tr:hover,
+table tr:hover {
+  background: var(--theme-row-hover);
+}
+
+.recipe-row,
+.contacts-chip,
+.contacts-btn,
+.btn-secondary,
+.btn.secondary {
+  background: var(--surface-2);
+  border-color: var(--border);
+  color: var(--text);
+}
+
+.recipe-row.active,
+.contacts-filter-btn.active {
+  background: var(--theme-row-hover);
+  border-color: var(--accent);
+}
+
+.settings-btn-save,
+.settings-btn-download,
+.finance-refresh-btn,
+.inventory-shell #add-item-btn,
+.btn.primary,
+button.primary {
+  background: var(--button-bg);
+  color: var(--button-text);
+}
+
+.settings-btn-check,
+.badge-note.ok,
+.contacts-toast--ok {
+  background: color-mix(in srgb, var(--success) 24%, var(--surface));
+  color: var(--text);
+}
+
+.finance-error,
+.recipes-status[data-tone="error"],
+.mfg-status-msg[data-tone="error"] {
+  color: var(--danger);
+}
+
+.recipes-status[data-tone="success"],
+.mfg-status-msg[data-tone="success"] {
+  color: var(--success);
+}
+
+:root[data-bus-theme="high-contrast"] button,
+:root[data-bus-theme="high-contrast"] .btn,
+:root[data-bus-theme="high-contrast"] input,
+:root[data-bus-theme="high-contrast"] select,
+:root[data-bus-theme="high-contrast"] textarea,
+:root[data-bus-theme="high-contrast"] .card,
+:root[data-bus-theme="high-contrast"] table,
+:root[data-bus-theme="high-contrast"] .settings-shell,
+:root[data-bus-theme="high-contrast"] .settings-card {
+  border: 1px solid var(--border);
 }
 

--- a/core/ui/css/app.css
+++ b/core/ui/css/app.css
@@ -2871,6 +2871,370 @@ hr.thin {
   }
 }
 
+/* Invoices route */
+.invoices-shell {
+  max-width: 1240px;
+  margin: 0 auto;
+  padding: clamp(16px, 2vw, 24px);
+}
+
+.invoices-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 16px;
+  margin-bottom: 14px;
+  border: 1px solid rgba(101, 129, 176, 0.26);
+  background:
+    linear-gradient(135deg, rgba(34, 52, 78, 0.88), rgba(16, 26, 40, 0.92)),
+    rgba(17, 24, 38, 0.86);
+}
+
+.invoices-heading h1,
+.invoices-detail-head h2,
+.invoices-section-head h3,
+.invoices-form-subhead h4 {
+  margin: 0;
+  color: #eef5ff;
+}
+
+.invoices-heading p,
+.invoices-detail-head p,
+.invoices-section-head p,
+.invoices-form-subhead p,
+.invoices-muted,
+.invoices-linked-job {
+  margin: 4px 0 0;
+  color: #9fb1cf;
+  font-size: 0.82rem;
+}
+
+.invoices-layout {
+  display: grid;
+  grid-template-columns: minmax(260px, 360px) minmax(0, 1fr);
+  gap: 14px;
+  align-items: start;
+}
+
+.invoices-list-panel,
+.invoices-detail-panel {
+  border: 1px solid rgba(101, 129, 176, 0.24);
+  background: rgba(17, 24, 38, 0.78);
+}
+
+.invoices-list-panel {
+  position: sticky;
+  top: 12px;
+}
+
+.invoices-filters,
+.invoices-form-grid,
+.invoices-line-form-grid,
+.invoices-summary-grid {
+  display: grid;
+  gap: 10px;
+}
+
+.invoices-filters {
+  grid-template-columns: minmax(0, 1fr) minmax(120px, 150px);
+  margin-bottom: 10px;
+}
+
+.invoices-form-grid {
+  grid-template-columns: repeat(2, minmax(0, 1fr));
+}
+
+.invoices-line-form-grid {
+  grid-template-columns: repeat(4, minmax(0, 1fr));
+}
+
+.invoices-summary-grid {
+  grid-template-columns: repeat(3, minmax(0, 1fr));
+  margin-top: 18px;
+}
+
+.invoices-input {
+  width: 100%;
+  min-height: 38px;
+  border: 1px solid rgba(116, 142, 181, 0.34);
+  border-radius: 8px;
+  background: rgba(8, 14, 24, 0.72);
+  color: #e5efff;
+  padding: 8px 10px;
+  font: inherit;
+}
+
+.invoices-textarea {
+  resize: vertical;
+}
+
+.invoices-list-count,
+.invoices-label,
+.invoices-readonly-note {
+  color: #9fb1cf;
+  font-size: 0.76rem;
+}
+
+.invoices-list,
+.invoices-lines-list {
+  display: grid;
+  gap: 8px;
+  margin-top: 8px;
+}
+
+.invoices-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto;
+  gap: 5px 8px;
+  width: 100%;
+  padding: 11px;
+  border: 1px solid rgba(101, 129, 176, 0.2);
+  border-radius: 9px;
+  background: rgba(11, 19, 32, 0.64);
+  color: #dce8fb;
+  text-align: left;
+  cursor: pointer;
+}
+
+.invoices-row:hover,
+.invoices-row.active {
+  border-color: rgba(106, 168, 255, 0.48);
+  background: rgba(31, 54, 86, 0.44);
+}
+
+.invoices-row-number {
+  overflow: hidden;
+  color: #f0f6ff;
+  font-weight: 700;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.invoices-row-meta,
+.invoices-row-total {
+  color: #9fb1cf;
+  font-size: 0.75rem;
+}
+
+.invoices-row-total {
+  color: #dff6ea;
+  font-weight: 700;
+}
+
+.invoices-badge {
+  align-self: start;
+  justify-self: end;
+  padding: 3px 7px;
+  border: 1px solid rgba(101, 129, 176, 0.28);
+  border-radius: 999px;
+  color: #dce8fb;
+  font-size: 0.7rem;
+  text-transform: uppercase;
+}
+
+.invoices-badge--issued {
+  border-color: rgba(255, 203, 120, 0.42);
+  color: #ffd68a;
+}
+
+.invoices-badge--paid {
+  border-color: rgba(86, 187, 130, 0.42);
+  color: #8ee6ad;
+}
+
+.invoices-badge--void {
+  border-color: rgba(255, 120, 96, 0.42);
+  color: #ffb5a4;
+}
+
+.invoices-empty,
+.invoices-loading,
+.invoices-load-error {
+  padding: 18px;
+  border: 1px dashed rgba(101, 129, 176, 0.34);
+  border-radius: 10px;
+  color: #9fb1cf;
+  background: rgba(8, 14, 24, 0.38);
+}
+
+.invoices-empty p {
+  margin: 6px 0 0;
+}
+
+.invoices-empty--compact {
+  padding: 11px;
+}
+
+.invoices-form,
+.invoices-section,
+.invoices-line-form {
+  display: grid;
+  gap: 12px;
+}
+
+.invoices-section {
+  margin-top: 18px;
+  padding-top: 18px;
+  border-top: 1px solid rgba(101, 129, 176, 0.18);
+}
+
+.invoices-detail-head,
+.invoices-section-head,
+.invoices-form-subhead {
+  display: flex;
+  align-items: start;
+  justify-content: space-between;
+  gap: 12px;
+}
+
+.invoices-field {
+  display: grid;
+  gap: 5px;
+}
+
+.invoices-contact-control {
+  display: flex;
+  gap: 8px;
+  align-items: center;
+  min-width: 0;
+}
+
+.invoices-contact-control .invoices-input {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+.invoices-action-row,
+.invoices-line-actions {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 8px;
+  align-items: center;
+}
+
+.invoices-summary-tile {
+  display: grid;
+  gap: 6px;
+  padding: 12px;
+  border: 1px solid rgba(101, 129, 176, 0.18);
+  border-radius: 10px;
+  background: rgba(10, 18, 30, 0.56);
+}
+
+.invoices-summary-name {
+  color: #9fb1cf;
+  font-size: 0.75rem;
+}
+
+.invoices-summary-value {
+  color: #edf5ff;
+  font-size: 1rem;
+}
+
+.invoices-line-row {
+  display: grid;
+  grid-template-columns: minmax(0, 1fr) auto auto;
+  gap: 12px;
+  align-items: center;
+  padding: 10px;
+  border: 1px solid rgba(101, 129, 176, 0.18);
+  border-radius: 9px;
+  background: rgba(10, 18, 30, 0.56);
+}
+
+.invoices-line-main,
+.invoices-line-value {
+  display: grid;
+  gap: 3px;
+}
+
+.invoices-line-main strong,
+.invoices-line-value strong {
+  color: #edf5ff;
+}
+
+.invoices-line-main span,
+.invoices-line-value span {
+  color: #9fb1cf;
+  font-size: 0.76rem;
+}
+
+.invoices-toggle {
+  display: inline-flex;
+  gap: 8px;
+  align-items: center;
+  min-height: 38px;
+}
+
+.invoices-error {
+  padding: 8px 10px;
+  border: 1px solid rgba(255, 120, 96, 0.38);
+  border-radius: 8px;
+  background: rgba(82, 25, 20, 0.32);
+  color: #ffb5a4;
+  font-size: 0.78rem;
+}
+
+.invoice-toast {
+  position: fixed;
+  right: 20px;
+  bottom: 20px;
+  z-index: 9999;
+  padding: 10px 12px;
+  border: 1px solid rgba(86, 187, 130, 0.4);
+  border-radius: 9px;
+  background: rgba(16, 39, 29, 0.94);
+  color: #dff9e9;
+  box-shadow: 0 12px 30px rgba(0, 0, 0, 0.28);
+  transition: opacity 0.22s ease, transform 0.22s ease;
+}
+
+.invoice-toast--error {
+  border-color: rgba(255, 120, 96, 0.42);
+  background: rgba(74, 24, 20, 0.94);
+  color: #ffd3ca;
+}
+
+.invoice-toast--hide {
+  opacity: 0;
+  transform: translateY(8px);
+}
+
+@media (max-width: 980px) {
+  .invoices-layout {
+    grid-template-columns: 1fr;
+  }
+
+  .invoices-list-panel {
+    position: static;
+  }
+}
+
+@media (max-width: 660px) {
+  .invoices-filters,
+  .invoices-form-grid,
+  .invoices-line-form-grid,
+  .invoices-summary-grid {
+    grid-template-columns: 1fr;
+  }
+
+  .invoices-header,
+  .invoices-detail-head,
+  .invoices-section-head,
+  .invoices-form-subhead,
+  .invoices-line-row {
+    align-items: stretch;
+    grid-template-columns: 1fr;
+  }
+
+  .invoices-header,
+  .invoices-detail-head,
+  .invoices-section-head,
+  .invoices-form-subhead {
+    flex-direction: column;
+  }
+}
+
 /* Inventory route */
 .inventory-shell {
   max-width: 1060px;

--- a/core/ui/js/cards/invoices.js
+++ b/core/ui/js/cards/invoices.js
@@ -1,0 +1,880 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+import { apiDelete, apiGet, apiPatch, apiPost, ensureToken } from '../api.js';
+
+const INVOICE_STATUSES = ['draft', 'issued', 'paid', 'void'];
+const LINE_TYPES = ['product', 'service', 'fee', 'note'];
+const UOM_OPTIONS = ['ea', 'hr', 'day', 'kg', 'g', 'lb', 'm', 'cm', 'mm', 'm2', 'cm2', 'l', 'ml'];
+const INVOICE_ERROR_MESSAGES = {
+  invoice_contact_required: 'Choose a contact before saving the invoice.',
+  invoice_issue_requires_line: 'Add at least one line before issuing the invoice.',
+  invoice_payment_requires_issue: 'Issue the invoice before marking it paid.',
+  invoice_void_cannot_be_paid: 'Void invoices cannot be marked paid.',
+  invoice_paid_cannot_be_void: 'Paid invoices cannot be voided.',
+  invoice_edit_forbidden_after_paid: 'Paid invoices are read-only financially.',
+  invoice_edit_forbidden_after_void: 'Void invoices are read-only financially.',
+  invoice_edit_forbidden_after_issue: 'Issued invoices are read-only until paid or voided.',
+  quantity_decimal_required: 'Enter a quantity or leave it blank.',
+  quantity_decimal_invalid: 'Enter a valid quantity.',
+  uom_required: 'Choose a unit when quantity is set.',
+  uom_requires_quantity_decimal: 'Clear the unit or enter a quantity.',
+  unit_price_cents_invalid: 'Enter a valid non-negative unit price.',
+  invalid_invoice_line_type: 'Choose a valid invoice line type.',
+  tax_rate_percent_invalid: 'Enter a valid tax percent.',
+};
+
+let state = newState();
+
+function newState() {
+  return {
+    invoices: [],
+    selectedId: null,
+    selectedInvoice: null,
+    contacts: [],
+    jobs: [],
+    search: '',
+    status: '',
+    lineEditId: null,
+    busy: false,
+  };
+}
+
+function host() {
+  return document.querySelector('[data-role="invoices-root"]');
+}
+
+function el(tag, attrs = {}, children = []) {
+  const node = document.createElement(tag);
+  Object.entries(attrs).forEach(([key, value]) => {
+    if (value === null || value === undefined) return;
+    if (key === 'class') node.className = value;
+    else if (key === 'text') node.textContent = value;
+    else if (key === 'checked') node.checked = !!value;
+    else if (key === 'disabled') node.disabled = !!value;
+    else node.setAttribute(key, value);
+  });
+  for (const child of Array.isArray(children) ? children : [children]) {
+    if (child === null || child === undefined) continue;
+    node.append(child);
+  }
+  return node;
+}
+
+function safeError(error, fallback = 'Request failed.') {
+  const detail = error?.payload?.detail ?? error?.data?.detail ?? error?.detail;
+  const code = detail?.error || error?.payload?.error || error?.data?.error || error?.error;
+  if (error?.status === 401) return 'Sign in again to view invoices.';
+  if (error?.status === 403) {
+    if (code === 'writes_disabled') return 'Writes are disabled. Turn writes back on to save invoice changes.';
+    return 'Your account does not have permission for that invoice action.';
+  }
+  if (typeof detail === 'string') return INVOICE_ERROR_MESSAGES[detail] || detail.replaceAll('_', ' ');
+  if (typeof code === 'string') return INVOICE_ERROR_MESSAGES[code] || code.replaceAll('_', ' ');
+  if (typeof error?.message === 'string' && error.message && !error.message.includes('[object Object]')) {
+    return error.message;
+  }
+  return fallback;
+}
+
+function toast(message, tone = 'ok') {
+  const note = document.createElement('div');
+  note.textContent = message;
+  note.className = `invoice-toast invoice-toast--${tone === 'error' ? 'error' : 'ok'}`;
+  document.body.appendChild(note);
+  setTimeout(() => {
+    note.classList.add('invoice-toast--hide');
+    setTimeout(() => note.remove(), 280);
+  }, 2400);
+}
+
+function moneyFromCents(cents) {
+  const value = Number(cents || 0) / 100;
+  return value.toLocaleString(undefined, { style: 'currency', currency: 'USD' });
+}
+
+function centsFromMoney(value) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  const numeric = Number(raw);
+  if (!Number.isFinite(numeric)) return null;
+  return Math.round(numeric * 100);
+}
+
+function formatDate(value, fallback = 'No date') {
+  if (!value) return fallback;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return date.toLocaleDateString(undefined, { month: 'short', day: 'numeric', year: 'numeric' });
+}
+
+function formatDateTime(value, fallback = 'Unknown time') {
+  if (!value) return fallback;
+  const date = new Date(value);
+  if (Number.isNaN(date.getTime())) return fallback;
+  return date.toLocaleString(undefined, { dateStyle: 'medium', timeStyle: 'short' });
+}
+
+function parseOptionalInt(value) {
+  const raw = String(value ?? '').trim();
+  if (!raw) return null;
+  const numeric = Number(raw);
+  return Number.isInteger(numeric) && numeric > 0 ? numeric : null;
+}
+
+function selectOptions(values, selected, labeler = (value) => value) {
+  return values.map((value) => {
+    const option = el('option', { value: String(value), text: labeler(value) });
+    if (String(value) === String(selected ?? '')) option.selected = true;
+    return option;
+  });
+}
+
+function referenceOptions(entries, selected, placeholder, labeler = (entry) => entry.name || `#${entry.id}`) {
+  const options = [el('option', { value: '', text: placeholder })];
+  entries.forEach((entry) => {
+    const option = el('option', { value: String(entry.id), text: labeler(entry) });
+    if (String(entry.id) === String(selected ?? '')) option.selected = true;
+    options.push(option);
+  });
+  return options;
+}
+
+function contactName(id) {
+  if (id === null || id === undefined || id === '') return 'No contact';
+  const found = state.contacts.find((entry) => String(entry.id) === String(id));
+  return found?.name || `Contact #${id}`;
+}
+
+function jobName(id) {
+  if (id === null || id === undefined || id === '') return 'No job';
+  const found = state.jobs.find((entry) => String(entry.id) === String(id));
+  return found?.title || `Job #${id}`;
+}
+
+function filteredInvoices() {
+  const query = state.search.trim().toLowerCase();
+  return state.invoices.filter((invoice) => {
+    if (state.status && invoice.status !== state.status) return false;
+    if (!query) return true;
+    const haystack = [
+      invoice.invoice_number,
+      invoice.status,
+      contactName(invoice.contact_id),
+      jobName(invoice.job_id),
+    ].join(' ').toLowerCase();
+    return haystack.includes(query);
+  });
+}
+
+function isDraft(invoice) {
+  return invoice?.status === 'draft';
+}
+
+function isReadOnlyFinancial(invoice) {
+  return invoice?.status === 'paid' || invoice?.status === 'void';
+}
+
+function setInvoiceRoute(id = null) {
+  const nextHash = id ? `#/invoices/${encodeURIComponent(id)}` : '#/invoices';
+  if (window.location.hash !== nextHash) {
+    window.location.hash = nextHash;
+  }
+}
+
+async function loadContacts() {
+  const contacts = await apiGet('/app/contacts').catch(() => []);
+  state.contacts = Array.isArray(contacts) ? contacts : [];
+}
+
+async function loadJobs() {
+  const jobs = await apiGet('/app/jobs').catch(() => []);
+  state.jobs = Array.isArray(jobs) ? jobs : [];
+}
+
+async function loadInvoices({ keepSelection = true } = {}) {
+  state.invoices = await apiGet('/app/invoices');
+  if (!Array.isArray(state.invoices)) state.invoices = [];
+  const routeId = parseOptionalInt(window.BUS_ROUTE?.id);
+  const routeExists = routeId ? state.invoices.some((invoice) => String(invoice.id) === String(routeId)) : false;
+  if (routeExists) state.selectedId = routeId;
+  const stillExists = state.invoices.some((invoice) => String(invoice.id) === String(state.selectedId));
+  if (!keepSelection || !stillExists) {
+    state.selectedId = routeExists ? routeId : (state.invoices[0]?.id || null);
+  }
+  if (state.selectedId) {
+    await loadSelectedInvoice(state.selectedId, { rerender: false });
+  } else {
+    state.selectedInvoice = null;
+  }
+}
+
+async function loadSelectedInvoice(invoiceId, { rerender = true } = {}) {
+  state.selectedId = invoiceId;
+  state.selectedInvoice = await apiGet(`/app/invoices/${invoiceId}`);
+  if (rerender) render();
+}
+
+function lineQuantityLabel(line) {
+  const quantity = String(line?.quantity_decimal ?? '').trim();
+  const uom = String(line?.uom ?? '').trim();
+  if (!quantity && !uom) return 'No quantity';
+  if (!quantity) return uom;
+  if (!uom) return quantity;
+  return `${quantity} ${uom}`;
+}
+
+function render() {
+  const root = host();
+  if (!root) return;
+  root.className = 'invoices-shell';
+  root.replaceChildren(
+    el('section', { class: 'invoices-header card' }, [
+      el('div', { class: 'invoices-heading' }, [
+        el('h1', { text: 'Invoices' }),
+        el('p', { text: 'Create, issue, and mark paid local invoices without introducing any Pro workflows.' }),
+      ]),
+      el('button', { class: 'btn primary invoices-new-btn', type: 'button', text: 'New Invoice', 'data-action': 'new-invoice' }),
+    ]),
+    el('div', { class: 'invoices-layout' }, [
+      renderListPanel(),
+      renderDetailPanel(),
+    ]),
+  );
+  root.querySelector('[data-action="new-invoice"]')?.addEventListener('click', () => {
+    state.selectedId = null;
+    state.selectedInvoice = null;
+    state.lineEditId = null;
+    setInvoiceRoute(null);
+    render();
+  });
+}
+
+function renderListPanel() {
+  const rows = filteredInvoices();
+  const panel = el('section', { class: 'card invoices-list-panel' });
+  const search = el('input', {
+    class: 'invoices-input invoices-search',
+    type: 'search',
+    placeholder: 'Search invoice number, contact, or job...',
+    value: state.search,
+  });
+  const status = el('select', { class: 'invoices-input' }, [
+    el('option', { value: '', text: 'All statuses' }),
+    ...selectOptions(INVOICE_STATUSES, state.status),
+  ]);
+  const filters = el('div', { class: 'invoices-filters' }, [search, status]);
+  const count = el('div', { class: 'invoices-list-count', text: `${rows.length} invoice${rows.length === 1 ? '' : 's'}` });
+  const list = el('div', { class: 'invoices-list' });
+
+  if (!rows.length) {
+    list.append(
+      el('div', { class: 'invoices-empty' }, [
+        el('strong', { text: 'No invoices yet.' }),
+        el('p', { text: 'Create a draft invoice manually or from a job. Payment records one local finance revenue event.' }),
+      ]),
+    );
+  } else {
+    rows.forEach((invoice) => list.append(renderInvoiceRow(invoice)));
+  }
+
+  search.addEventListener('input', () => {
+    state.search = search.value;
+    render();
+  });
+  status.addEventListener('change', () => {
+    state.status = status.value;
+    render();
+  });
+
+  panel.append(filters, count, list);
+  return panel;
+}
+
+function renderInvoiceRow(invoice) {
+  const row = el('button', { class: 'invoices-row', type: 'button', 'data-invoice-id': invoice.id });
+  if (String(invoice.id) === String(state.selectedId)) row.classList.add('active');
+  row.append(
+    el('span', { class: 'invoices-row-number', text: invoice.invoice_number || `Invoice #${invoice.id}` }),
+    el('span', { class: `invoices-badge invoices-badge--${invoice.status || 'draft'}`, text: invoice.status || 'draft' }),
+    el('span', { class: 'invoices-row-meta', text: contactName(invoice.contact_id) }),
+    el('span', { class: 'invoices-row-meta', text: invoice.job_id ? jobName(invoice.job_id) : 'Manual invoice' }),
+    el('span', { class: 'invoices-row-meta', text: `Due ${formatDate(invoice.due_date, 'No due date')}` }),
+    el('span', { class: 'invoices-row-total', text: moneyFromCents(invoice.total_cents) }),
+  );
+  row.addEventListener('click', async () => {
+    try {
+      state.lineEditId = null;
+      setInvoiceRoute(invoice.id);
+      await loadSelectedInvoice(invoice.id);
+    } catch (error) {
+      toast(safeError(error, 'Failed to load invoice.'), 'error');
+    }
+  });
+  return row;
+}
+
+function renderDetailPanel() {
+  const panel = el('section', { class: 'card invoices-detail-panel' });
+  const invoice = state.selectedInvoice;
+  panel.append(renderInvoiceForm(invoice));
+  if (invoice) {
+    panel.append(renderInvoiceSummary(invoice), renderInvoiceActions(invoice), renderLinesSection(invoice));
+  }
+  return panel;
+}
+
+function renderInvoiceForm(invoice) {
+  const isNew = !invoice;
+  const form = el('form', { class: 'invoices-form', 'data-role': 'invoice-form' });
+  const readonly = !isNew && !isDraft(invoice);
+  const contactSelect = el('select', { class: 'invoices-input', name: 'contact_id', disabled: readonly }, referenceOptions(state.contacts, invoice?.contact_id, 'Choose contact'));
+  const jobSelect = el('select', { class: 'invoices-input', name: 'job_id', disabled: readonly }, referenceOptions(state.jobs, invoice?.job_id, 'No linked job', (entry) => entry.title || `Job #${entry.id}`));
+  const dueDate = el('input', {
+    class: 'invoices-input',
+    name: 'due_date',
+    type: 'date',
+    value: invoice?.due_date ? String(invoice.due_date).slice(0, 10) : '',
+    disabled: readonly,
+  });
+  const taxRate = el('input', {
+    class: 'invoices-input',
+    name: 'tax_rate_percent',
+    type: 'number',
+    min: '0',
+    step: '0.01',
+    value: invoice?.tax_rate_percent ?? '0',
+    disabled: readonly,
+  });
+  const notes = el('textarea', {
+    class: 'invoices-input invoices-textarea',
+    name: 'notes',
+    rows: '3',
+    placeholder: 'Notes',
+    disabled: readonly,
+  });
+  notes.value = invoice?.notes || '';
+
+  const contactTools = el('div', { class: 'invoices-contact-control' }, [
+    contactSelect,
+    el('button', {
+      class: 'btn secondary',
+      type: 'button',
+      text: '+ New Contact',
+      'data-action': 'invoice-new-contact',
+      disabled: readonly,
+    }),
+  ]);
+
+  const headChildren = [
+    el('div', {}, [
+      el('h2', { text: isNew ? 'New Invoice' : (invoice.invoice_number || `Invoice #${invoice.id}`) }),
+      el('p', {
+        text: isNew
+          ? 'Create a draft invoice linked to a contact and optionally a job.'
+          : `Status ${invoice.status}. Payment records one local finance sale event only.`,
+      }),
+    ]),
+  ];
+  if (!isNew && invoice.job_id) {
+    headChildren.push(el('span', { class: 'invoices-linked-job', text: `Linked to ${jobName(invoice.job_id)}` }));
+  }
+
+  const grid = el('div', { class: 'invoices-form-grid' }, [
+    field('Contact', contactTools),
+    field('Linked job', jobSelect),
+    field('Due date', dueDate),
+    field('Tax rate %', taxRate),
+  ]);
+  const error = el('div', { class: 'invoices-error hidden', 'data-role': 'invoice-form-error' });
+  const actions = el('div', { class: 'invoices-action-row' }, [
+    el('button', { class: 'btn primary', type: 'submit', text: isNew ? 'Create Invoice' : 'Save Invoice', disabled: readonly }),
+    ...(!isNew
+      ? [el('span', { class: 'invoices-muted', text: `Updated ${formatDateTime(invoice.updated_at)}` })]
+      : []),
+  ]);
+
+  form.append(el('div', { class: 'invoices-detail-head' }, headChildren), grid, field('Notes', notes), error, actions);
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    await saveInvoice(form, invoice);
+  });
+  form.querySelector('[data-action="invoice-new-contact"]')?.addEventListener('click', () => {
+    openInvoiceContactModal({ form, contactSelect, existingInvoice: invoice });
+  });
+  return form;
+}
+
+function field(label, control) {
+  return el('label', { class: 'invoices-field' }, [
+    el('span', { class: 'invoices-label', text: label }),
+    control,
+  ]);
+}
+
+function showFormError(form, message) {
+  const banner = form.querySelector('[data-role$="error"], [data-role="invoice-form-error"]');
+  if (!banner) return;
+  banner.textContent = message;
+  banner.classList.remove('hidden');
+}
+
+function hideFormError(form) {
+  const banner = form.querySelector('[data-role$="error"], [data-role="invoice-form-error"]');
+  if (!banner) return;
+  banner.textContent = '';
+  banner.classList.add('hidden');
+}
+
+async function saveInvoice(form, existingInvoice) {
+  hideFormError(form);
+  const data = new FormData(form);
+  const contactId = parseOptionalInt(data.get('contact_id'));
+  if (!contactId) {
+    showFormError(form, INVOICE_ERROR_MESSAGES.invoice_contact_required);
+    return;
+  }
+  const payload = {
+    contact_id: contactId,
+    job_id: parseOptionalInt(data.get('job_id')),
+    due_date: data.get('due_date') ? `${data.get('due_date')}T00:00:00` : null,
+    tax_rate_percent: String(data.get('tax_rate_percent') || '0').trim() || '0',
+    notes: String(data.get('notes') || '').trim() || null,
+  };
+  try {
+    let saved;
+    if (existingInvoice?.id) {
+      saved = await apiPatch(`/app/invoices/${existingInvoice.id}`, payload);
+      toast('Invoice saved.');
+    } else {
+      saved = await apiPost('/app/invoices', payload);
+      toast('Invoice created.');
+    }
+    state.selectedId = saved.id;
+    state.selectedInvoice = saved;
+    setInvoiceRoute(saved.id);
+    await loadInvoices({ keepSelection: true });
+    render();
+  } catch (error) {
+    showFormError(form, safeError(error, 'Unable to save invoice.'));
+  }
+}
+
+function renderInvoiceSummary(invoice) {
+  return el('section', { class: 'invoices-summary-grid' }, [
+    metricTile('Subtotal', moneyFromCents(invoice.subtotal_cents)),
+    metricTile('Tax', moneyFromCents(invoice.tax_cents)),
+    metricTile('Total', moneyFromCents(invoice.total_cents)),
+    metricTile('Issue date', formatDate(invoice.issue_date, 'Not issued')),
+    metricTile('Paid at', formatDate(invoice.paid_at, 'Not paid')),
+    metricTile('Cash event', invoice.paid_cash_event_id ? `#${invoice.paid_cash_event_id}` : 'Not recorded'),
+  ]);
+}
+
+function metricTile(label, value) {
+  return el('div', { class: 'invoices-summary-tile' }, [
+    el('span', { class: 'invoices-summary-name', text: label }),
+    el('strong', { class: 'invoices-summary-value', text: value }),
+  ]);
+}
+
+function renderInvoiceActions(invoice) {
+  const section = el('section', { class: 'invoices-section invoices-actions-section' }, [
+    el('div', { class: 'invoices-section-head' }, [
+      el('h3', { text: 'Invoice actions' }),
+      el('p', { text: 'Print opens a local printable invoice page. Mark Paid creates one local finance revenue event and does not touch stock or manufacturing.' }),
+    ]),
+  ]);
+  const row = el('div', { class: 'invoices-action-row' });
+  const printBtn = el('button', { class: 'btn secondary', type: 'button', text: 'Print' });
+  printBtn.addEventListener('click', () => openInvoicePrint(invoice));
+
+  if (invoice.status === 'draft') {
+    const issueBtn = el('button', { class: 'btn primary', type: 'button', text: 'Issue Invoice' });
+    const voidBtn = el('button', { class: 'btn secondary', type: 'button', text: 'Void Invoice' });
+    issueBtn.addEventListener('click', () => issueInvoice(invoice));
+    voidBtn.addEventListener('click', () => voidInvoice(invoice));
+    row.append(printBtn, issueBtn, voidBtn);
+  } else if (invoice.status === 'issued') {
+    const paidBtn = el('button', { class: 'btn primary', type: 'button', text: 'Mark Paid' });
+    const voidBtn = el('button', { class: 'btn secondary', type: 'button', text: 'Void Invoice' });
+    paidBtn.addEventListener('click', () => markInvoicePaid(invoice));
+    voidBtn.addEventListener('click', () => voidInvoice(invoice));
+    row.append(printBtn, paidBtn, voidBtn);
+  } else if (invoice.status === 'paid') {
+    row.append(printBtn, el('span', { class: 'invoices-readonly-note', text: 'Paid invoices are read-only financially.' }));
+  } else if (invoice.status === 'void') {
+    row.append(printBtn, el('span', { class: 'invoices-readonly-note', text: 'Void invoices are read-only financially.' }));
+  }
+
+  section.append(row);
+  return section;
+}
+
+function openInvoicePrint(invoice) {
+  if (!invoice?.id) return;
+  window.open(`/app/invoices/${encodeURIComponent(invoice.id)}/print`, '_blank', 'noopener');
+}
+
+async function issueInvoice(invoice) {
+  try {
+    await apiPost(`/app/invoices/${invoice.id}/issue`, {});
+    await loadInvoices({ keepSelection: true });
+    render();
+    toast('Invoice issued.');
+  } catch (error) {
+    toast(safeError(error, 'Unable to issue invoice.'), 'error');
+  }
+}
+
+async function markInvoicePaid(invoice) {
+  const confirmed = window.confirm('Mark this invoice paid? BUS Core will record one local finance revenue event.');
+  if (!confirmed) return;
+  try {
+    await apiPost(`/app/invoices/${invoice.id}/mark-paid`, {});
+    await loadInvoices({ keepSelection: true });
+    render();
+    toast('Invoice marked paid.');
+  } catch (error) {
+    toast(safeError(error, 'Unable to mark invoice paid.'), 'error');
+  }
+}
+
+async function voidInvoice(invoice) {
+  const confirmed = window.confirm('Void this invoice? This keeps the invoice but prevents payment.');
+  if (!confirmed) return;
+  try {
+    await apiPost(`/app/invoices/${invoice.id}/void`, {});
+    await loadInvoices({ keepSelection: true });
+    render();
+    toast('Invoice voided.');
+  } catch (error) {
+    toast(safeError(error, 'Unable to void invoice.'), 'error');
+  }
+}
+
+function renderLinesSection(invoice) {
+  const section = el('section', { class: 'invoices-section' }, [
+    el('div', { class: 'invoices-section-head' }, [
+      el('h3', { text: 'Lines' }),
+      el('p', { text: 'Invoice lines are billing records only. They do not control stock movement.' }),
+    ]),
+  ]);
+  const list = el('div', { class: 'invoices-lines-list' });
+  const lines = Array.isArray(invoice.lines) ? invoice.lines : [];
+  if (!lines.length) {
+    list.append(el('div', { class: 'invoices-empty invoices-empty--compact', text: 'No lines yet.' }));
+  } else {
+    lines.forEach((line) => list.append(renderLineRow(invoice, line)));
+  }
+  section.append(list);
+  if (isDraft(invoice)) {
+    section.append(renderLineForm(invoice));
+  }
+  return section;
+}
+
+function renderLineRow(invoice, line) {
+  const row = el('div', { class: 'invoices-line-row' });
+  row.append(
+    el('div', { class: 'invoices-line-main' }, [
+      el('strong', { text: line.description || 'Line' }),
+      el('span', { text: `${line.line_type || 'line'} | ${lineQuantityLabel(line)}` }),
+      el('span', { text: `${line.taxable ? 'Taxable' : 'Non-taxable'}${line.job_line_id ? ` | Job line #${line.job_line_id}` : ''}` }),
+    ]),
+    el('div', { class: 'invoices-line-value' }, [
+      el('strong', { text: moneyFromCents(line.line_subtotal_cents) }),
+      el('span', { text: line.unit_price_cents == null ? 'No unit price' : `${moneyFromCents(line.unit_price_cents)} each` }),
+    ]),
+  );
+  if (isDraft(invoice)) {
+    const actions = el('div', { class: 'invoices-line-actions' }, [
+      el('button', { type: 'button', class: 'btn small', text: 'Edit' }),
+      el('button', { type: 'button', class: 'btn small danger', text: 'Delete' }),
+    ]);
+    actions.children[0].addEventListener('click', () => {
+      state.lineEditId = line.id;
+      render();
+    });
+    actions.children[1].addEventListener('click', async () => {
+      if (!window.confirm('Delete this invoice line?')) return;
+      try {
+        await apiDelete(`/app/invoices/${invoice.id}/lines/${line.id}`);
+        state.lineEditId = null;
+        await loadSelectedInvoice(invoice.id, { rerender: false });
+        await loadInvoices({ keepSelection: true });
+        render();
+        toast('Line deleted.');
+      } catch (error) {
+        toast(safeError(error, 'Unable to delete line.'), 'error');
+      }
+    });
+    row.append(actions);
+  }
+  return row;
+}
+
+function renderLineForm(invoice) {
+  const editing = (invoice.lines || []).find((line) => String(line.id) === String(state.lineEditId));
+  const form = el('form', { class: 'invoices-line-form', 'data-role': 'invoice-line-form' });
+  const lineType = el('select', { class: 'invoices-input', name: 'line_type' }, selectOptions(LINE_TYPES, editing?.line_type || 'service'));
+  const description = el('input', {
+    class: 'invoices-input',
+    name: 'description',
+    required: 'true',
+    value: editing?.description || '',
+    placeholder: 'Description',
+  });
+  const quantity = el('input', {
+    class: 'invoices-input',
+    name: 'quantity_decimal',
+    type: 'number',
+    min: '0',
+    step: '0.001',
+    value: editing?.quantity_decimal || '',
+    placeholder: 'Optional quantity',
+  });
+  const uom = el('select', { class: 'invoices-input', name: 'uom' }, [
+    el('option', { value: '', text: 'No unit' }),
+    ...selectOptions(UOM_OPTIONS, editing?.uom || ''),
+  ]);
+  const unitPrice = el('input', {
+    class: 'invoices-input',
+    name: 'unit_price',
+    type: 'number',
+    min: '0',
+    step: '0.01',
+    value: editing?.unit_price_cents != null ? String(Number(editing.unit_price_cents) / 100) : '',
+    placeholder: 'Unit price',
+  });
+  const taxable = el('input', {
+    type: 'checkbox',
+    name: 'taxable',
+    checked: editing?.taxable ?? true,
+  });
+  const sortOrder = el('input', {
+    class: 'invoices-input',
+    name: 'sort_order',
+    type: 'number',
+    step: '1',
+    value: String(editing?.sort_order ?? 0),
+  });
+  const error = el('div', { class: 'invoices-error hidden', 'data-role': 'line-form-error' });
+
+  const syncLineControls = () => {
+    const note = lineType.value === 'note';
+    quantity.disabled = note;
+    uom.disabled = note;
+    unitPrice.disabled = note;
+    taxable.disabled = note;
+    if (note) {
+      quantity.value = '';
+      uom.value = '';
+      unitPrice.value = '';
+      taxable.checked = false;
+    }
+  };
+  lineType.addEventListener('change', syncLineControls);
+  syncLineControls();
+
+  form.append(
+    el('div', { class: 'invoices-form-subhead' }, [
+      el('h4', { text: editing ? 'Edit line' : 'Add line' }),
+      el('p', { text: 'Tax applies only to lines marked taxable. Money stays in integer cents in the backend.' }),
+    ]),
+    el('div', { class: 'invoices-line-form-grid' }, [
+      field('Type', lineType),
+      field('Description', description),
+      field('Quantity', quantity),
+      field('UOM', uom),
+      field('Unit price', unitPrice),
+      field('Sort order', sortOrder),
+      field('Taxable', el('label', { class: 'invoices-toggle' }, [taxable, el('span', { text: 'Apply invoice tax' })])),
+    ]),
+    error,
+    el('div', { class: 'invoices-action-row' }, [
+      el('button', { class: 'btn primary', type: 'submit', text: editing ? 'Save Line' : 'Add Line' }),
+      ...(editing ? [el('button', { class: 'btn secondary', type: 'button', text: 'Cancel', 'data-action': 'cancel-line-edit' })] : []),
+    ]),
+  );
+
+  form.querySelector('[data-action="cancel-line-edit"]')?.addEventListener('click', () => {
+    state.lineEditId = null;
+    render();
+  });
+  form.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    await saveLine(invoice, form, editing);
+  });
+  return form;
+}
+
+async function saveLine(invoice, form, editing) {
+  hideFormError(form);
+  const data = new FormData(form);
+  const description = String(data.get('description') || '').trim();
+  if (!description) {
+    showFormError(form, 'Description is required.');
+    return;
+  }
+  const quantity = String(data.get('quantity_decimal') || '').trim();
+  const unitPriceCents = centsFromMoney(data.get('unit_price'));
+  const payload = {
+    line_type: String(data.get('line_type') || 'service'),
+    description,
+    quantity_decimal: quantity || null,
+    uom: String(data.get('uom') || '').trim() || null,
+    unit_price_cents: unitPriceCents,
+    taxable: data.get('taxable') === 'on',
+    sort_order: Number(data.get('sort_order') || 0),
+  };
+  if (payload.line_type === 'note') {
+    payload.quantity_decimal = null;
+    payload.uom = null;
+    payload.unit_price_cents = null;
+    payload.taxable = false;
+  }
+  try {
+    if (editing?.id) {
+      await apiPatch(`/app/invoices/${invoice.id}/lines/${editing.id}`, payload);
+      toast('Line saved.');
+    } else {
+      await apiPost(`/app/invoices/${invoice.id}/lines`, payload);
+      toast('Line added.');
+    }
+    state.lineEditId = null;
+    await loadSelectedInvoice(invoice.id, { rerender: false });
+    await loadInvoices({ keepSelection: true });
+    render();
+  } catch (error) {
+    showFormError(form, safeError(error, 'Unable to save line.'));
+  }
+}
+
+function openInvoiceContactModal({ form, contactSelect, existingInvoice }) {
+  const overlay = el('div', { class: 'contacts-modal', role: 'dialog', 'aria-modal': 'true' });
+  const box = el('div', { class: 'contacts-modal-box' });
+  const name = el('input', {
+    class: 'invoices-input',
+    name: 'contact_name',
+    required: 'true',
+    placeholder: 'Name',
+    autocomplete: 'name',
+  });
+  const contactInfo = el('input', {
+    class: 'invoices-input',
+    name: 'contact_info',
+    placeholder: 'Email, phone, or preferred contact info',
+    autocomplete: 'email',
+  });
+  const error = el('div', { class: 'invoices-error hidden', 'data-role': 'invoice-contact-error' });
+  const save = el('button', { class: 'btn primary', type: 'submit', text: 'Create Contact' });
+  const cancel = el('button', { class: 'btn secondary', type: 'button', text: 'Cancel' });
+  const modalForm = el('form', { class: 'contacts-modal-form' }, [
+    field('Name', name),
+    field('Contact info', contactInfo),
+    error,
+    el('div', { class: 'contacts-modal-actions' }, [cancel, save]),
+  ]);
+
+  box.append(
+    el('div', { class: 'contacts-modal-title-row' }, [
+      el('div', { class: 'contacts-modal-title', text: 'New Contact' }),
+      el('button', { class: 'btn ghost', type: 'button', text: 'Close', 'data-action': 'close-contact-modal' }),
+    ]),
+    el('p', { class: 'contacts-modal-body', text: 'Create a contact and keep working in invoices.' }),
+    modalForm,
+  );
+  overlay.append(box);
+  document.body.append(overlay);
+
+  const close = () => overlay.remove();
+  cancel.addEventListener('click', close);
+  overlay.querySelector('[data-action="close-contact-modal"]')?.addEventListener('click', close);
+  overlay.addEventListener('click', (event) => {
+    if (event.target === overlay) close();
+  });
+
+  modalForm.addEventListener('submit', async (event) => {
+    event.preventDefault();
+    hideFormError(modalForm);
+    const contactNameValue = name.value.trim();
+    const contactValue = contactInfo.value.trim();
+    if (!contactNameValue) {
+      showFormError(modalForm, 'Contact name is required.');
+      name.focus();
+      return;
+    }
+    save.disabled = true;
+    try {
+      const created = await apiPost('/app/contacts', {
+        name: contactNameValue,
+        contact: contactValue || null,
+        is_vendor: false,
+      });
+      await loadContacts();
+      const createdId = created?.id;
+      contactSelect.replaceChildren(...referenceOptions(state.contacts, createdId, 'Choose contact'));
+
+      if (existingInvoice?.id && createdId) {
+        try {
+          await apiPatch(`/app/invoices/${existingInvoice.id}`, { contact_id: createdId });
+        } catch (linkError) {
+          close();
+          showFormError(
+            form,
+            `Contact "${contactNameValue}" was created, but it could not be linked to this invoice. Save Invoice to try linking it again. ${safeError(linkError, 'Unable to link contact.')}`,
+          );
+          toast('Contact created, but not linked.', 'error');
+          return;
+        }
+        close();
+        toast('Contact created and linked.');
+        await loadInvoices({ keepSelection: true });
+        render();
+        return;
+      }
+
+      close();
+      toast('Contact created and selected.');
+    } catch (submitError) {
+      showFormError(modalForm, safeError(submitError, 'Unable to create contact.'));
+      save.disabled = false;
+    }
+  });
+
+  name.focus();
+}
+
+async function initialRender(root) {
+  root.className = 'invoices-shell';
+  root.replaceChildren(el('div', { class: 'card invoices-loading', text: 'Loading invoices...' }));
+  try {
+    await ensureToken();
+    await Promise.all([loadContacts(), loadJobs()]);
+    await loadInvoices({ keepSelection: true });
+    render();
+  } catch (error) {
+    root.replaceChildren(
+      el('div', { class: 'card invoices-load-error' }, [
+        el('h2', { text: 'Invoices unavailable' }),
+        el('p', { text: safeError(error, 'Unable to load invoices.') }),
+      ]),
+    );
+  }
+}
+
+export async function mountInvoices() {
+  const root = host();
+  if (!root) return;
+  state = newState();
+  const routeId = parseOptionalInt(window.BUS_ROUTE?.id);
+  if (routeId) state.selectedId = routeId;
+  await initialRender(root);
+}
+
+export function unmountInvoices() {
+  const root = host();
+  if (root) root.replaceChildren();
+  state = newState();
+}
+
+export default mountInvoices;

--- a/core/ui/js/cards/jobs.js
+++ b/core/ui/js/cards/jobs.js
@@ -399,6 +399,17 @@ function renderJobForm(job) {
       el('p', { text: isNew ? 'Create a draft demand record. It will not change stock or finance.' : 'Edit job context. Status changes are handled separately below.' }),
     ]),
   ]);
+  if (!isNew) {
+    const invoiceBtn = el('button', {
+      class: 'btn secondary',
+      type: 'button',
+      text: 'Create Invoice',
+      'data-action': 'create-job-invoice',
+      disabled: !job?.contact_id,
+      title: job?.contact_id ? 'Create a draft invoice from this job.' : 'Add a contact before invoicing this job.',
+    });
+    head.append(invoiceBtn);
+  }
 
   const grid = el('div', { class: 'jobs-form-grid' }, [
     field('Title', title),
@@ -418,6 +429,18 @@ function renderJobForm(job) {
   form.addEventListener('submit', async (event) => {
     event.preventDefault();
     await saveJob(form, job);
+  });
+  form.querySelector('[data-action="create-job-invoice"]')?.addEventListener('click', async () => {
+    if (!job?.id) return;
+    try {
+      const invoice = await apiPost(`/app/jobs/${job.id}/invoice`, {});
+      toast('Draft invoice created from job.');
+      if (invoice?.id) {
+        window.location.hash = `#/invoices/${encodeURIComponent(invoice.id)}`;
+      }
+    } catch (error) {
+      showFormError(form, safeError(error, 'Unable to create invoice from job.'));
+    }
   });
   form.querySelector('[data-action="jobs-new-contact"]')?.addEventListener('click', () => {
     openJobContactModal({ form, contactSelect: contact, existingJob: job });

--- a/core/ui/js/cards/settings.js
+++ b/core/ui/js/cards/settings.js
@@ -1,6 +1,7 @@
 // SPDX-License-Identifier: AGPL-3.0-or-later
 import { apiGet, apiPost, ensureToken } from '../api.js';
 import { mountAdmin } from './admin.js';
+import { THEME_OPTIONS, applyTheme, getStoredThemeValue, normalizeTheme } from '../theme.js';
 
 export async function settingsCard(el) {
   el.innerHTML = '<div class="settings-loading">Loading settings...</div>';
@@ -45,10 +46,10 @@ export async function settingsCard(el) {
       <div class="settings-card settings-card--primary">
         <h3>System</h3>
         <label for="setting-theme" class="settings-label">Theme</label>
-        <select id="setting-theme" class="settings-select" disabled>
-          <option value="system">System (currently only mode)</option>
+        <select id="setting-theme" class="settings-select">
+          ${THEME_OPTIONS.map((theme) => `<option value="${theme.value}">${theme.label}</option>`).join('')}
         </select>
-        <p class="settings-subtext">Alternate themes are deferred. BUS Core uses system mode for now.</p>
+        <p class="settings-subtext">Theme selection is local to this browser and applies immediately.</p>
         <label class="settings-label">Launcher Behavior</label>
         <div class="settings-stack">
           <label class="settings-check-row">
@@ -148,7 +149,10 @@ export async function settingsCard(el) {
 
   // Populate
   const themeSelect = root.querySelector('#setting-theme');
-  themeSelect.value = 'system';
+  const configuredTheme = ui.theme || ui.style || ui.themeVariant;
+  const selectedTheme = normalizeTheme(getStoredThemeValue() || configuredTheme);
+  themeSelect.value = selectedTheme;
+  applyTheme(selectedTheme, { persist: false });
 
   root.querySelector('#setting-start-tray').checked = !!launcher.auto_start_in_tray;
   root.querySelector('#setting-backup-dir').value = backup.default_directory || '';
@@ -157,6 +161,10 @@ export async function settingsCard(el) {
   // Handlers
   const btnSave = root.querySelector('#btn-save');
   const feedback = root.querySelector('#save-feedback');
+
+  themeSelect?.addEventListener('change', () => {
+    applyTheme(themeSelect.value);
+  });
 
   btnSave.onclick = async () => {
     btnSave.disabled = true;
@@ -170,7 +178,7 @@ export async function settingsCard(el) {
 
     const payload = {
       ui: {
-        theme: 'system',
+        theme: ui.theme || 'system',
       },
       launcher: {
         auto_start_in_tray: root.querySelector('#setting-start-tray').checked,

--- a/core/ui/js/theme.js
+++ b/core/ui/js/theme.js
@@ -1,0 +1,70 @@
+// SPDX-License-Identifier: AGPL-3.0-or-later
+
+export const THEME_STORAGE_KEY = 'bus.ui.themeVariant';
+export const DEFAULT_THEME = 'forge-dark';
+
+export const THEME_OPTIONS = [
+  { value: 'forge-dark', label: 'BUS Core Default / Forge Dark' },
+  { value: 'clean-light', label: 'Clean Light' },
+  { value: 'workshop-slate', label: 'Workshop Slate' },
+  { value: 'high-contrast', label: 'High Contrast' },
+];
+
+const LEGACY_THEME_MAP = {
+  current: DEFAULT_THEME,
+  dark: DEFAULT_THEME,
+  default: DEFAULT_THEME,
+  forge: DEFAULT_THEME,
+  'forge-dark': DEFAULT_THEME,
+  system: DEFAULT_THEME,
+  light: 'clean-light',
+  'clean-light': 'clean-light',
+  slate: 'workshop-slate',
+  'workshop-slate': 'workshop-slate',
+  contrast: 'high-contrast',
+  'high-contrast': 'high-contrast',
+};
+
+const STORAGE_KEYS = [
+  THEME_STORAGE_KEY,
+  'bus.ui.theme',
+  'bus.ui.style',
+  'bus.theme',
+];
+
+export function normalizeTheme(value) {
+  const key = String(value || '').trim().toLowerCase();
+  return LEGACY_THEME_MAP[key] || DEFAULT_THEME;
+}
+
+export function getStoredTheme() {
+  return normalizeTheme(getStoredThemeValue());
+}
+
+export function getStoredThemeValue() {
+  try {
+    for (const key of STORAGE_KEYS) {
+      const value = localStorage.getItem(key);
+      if (value) return value;
+    }
+  } catch {
+    // Fall through to default.
+  }
+  return null;
+}
+
+export function applyTheme(value, options = {}) {
+  const theme = normalizeTheme(value);
+  document.documentElement.dataset.busTheme = theme;
+  if (options.persist !== false) {
+    try {
+      localStorage.setItem(THEME_STORAGE_KEY, theme);
+    } catch {}
+  }
+  document.dispatchEvent(new CustomEvent('bus:theme-change', { detail: { theme } }));
+  return theme;
+}
+
+export function initTheme() {
+  return applyTheme(getStoredTheme(), { persist: false });
+}

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -5,18 +5,37 @@
   <title>BUS Core</title>
   <meta name="viewport" content="width=device-width, initial-scale=1">
   <link rel="icon" type="image/svg+xml" href="favicon.svg?v=buscore-8">
+  <script>
+  (function(){
+    const fallback = 'forge-dark';
+    const map = {
+      current: fallback,
+      dark: fallback,
+      default: fallback,
+      system: fallback,
+      light: 'clean-light',
+      'clean-light': 'clean-light',
+      slate: 'workshop-slate',
+      'workshop-slate': 'workshop-slate',
+      contrast: 'high-contrast',
+      'high-contrast': 'high-contrast',
+      'forge-dark': fallback
+    };
+    const keys = ['bus.ui.themeVariant', 'bus.ui.theme', 'bus.ui.style', 'bus.theme'];
+    let theme = fallback;
+    try {
+      for (const key of keys) {
+        const value = localStorage.getItem(key);
+        if (value) {
+          theme = map[String(value).trim().toLowerCase()] || fallback;
+          break;
+        }
+      }
+    } catch {}
+    document.documentElement.dataset.busTheme = theme;
+  })();
+  </script>
   <link rel="stylesheet" href="/ui/css/app.css">
-  <style>
-    :root { --bg:#0e1118; --fg:#e6ecf7; --accent:#3b82f6; --sidebar:#111723; }
-    #sidebar h1{margin:0 0 16px 16px;font-size:14px;color:#aaa}
-    .tab{padding:10px 16px;cursor:pointer;border-left:4px solid transparent}
-    .tab.active{background:#333;border-left-color:var(--accent);font-weight:600}
-    .tab:hover:not(.active){background:#2a2a2a}
-    .tabs{display:flex;gap:8px;margin-bottom:16px}
-    .tabs button{background:#2b2f36;color:#e6e6e6;border:1px solid #363b44;padding:8px 14px;border-radius:10px;cursor:pointer}
-    .tabs button.active{background:var(--accent);border-color:var(--accent);color:#fff}
-    .tab-panel{display:flex;flex-direction:column;gap:16px}
-  </style>
   <script>
   (function(){
     const href = "favicon.svg?v=buscore-8";
@@ -109,16 +128,16 @@
       <!-- Contacts screen (hidden by default) -->
       <div data-role="contacts-screen" class="hidden">
         <div class="card" data-view="contacts">
-          <div style="display:flex;align-items:center;justify-content:space-between;gap:12px;margin-bottom:12px;">
-            <h2 style="margin:0;">Contacts</h2>
+          <div class="legacy-contacts-head">
+            <h2 class="legacy-contacts-title">Contacts</h2>
             <button type="button" data-action="open-contacts-modal">Add Contact</button>
           </div>
-          <table data-role="contacts-table" class="table" style="width:100%;border-collapse:separate;border-spacing:0;background:#111318;border-radius:10px;overflow:hidden">
+          <table data-role="contacts-table" class="table legacy-contacts-table">
             <thead>
               <tr>
-                <th style="text-align:left;padding:10px;background:#1a1f2b">Type</th>
-                <th style="text-align:left;padding:10px;background:#1a1f2b">Contact</th>
-                <th style="text-align:left;padding:10px;background:#1a1f2b">Actions</th>
+                <th>Type</th>
+                <th>Contact</th>
+                <th>Actions</th>
               </tr>
             </thead>
             <tbody><!-- rows rendered by vendors.js --></tbody>
@@ -142,7 +161,7 @@
 
       <div data-role="recipes-screen" class="hidden">
         <div class="screen-header">
-          <h1 style="margin:0;">Recipes</h1>
+          <h1 class="screen-title">Recipes</h1>
         </div>
         <div class="screen-body">
           <div data-tab-panel="recipes"></div>
@@ -243,8 +262,8 @@
     <div class="drawer-backdrop" data-action="close-contacts-drawer"></div>
     <div class="drawer-panel">
       <header class="drawer-header">
-        <h3 id="contact-drawer-title" style="margin:0;font-size:18px;color:#f8fafc">Contact</h3>
-        <button type="button" data-action="close-contacts-drawer" aria-label="Close" style="background:transparent;border:none;color:#9ca3af;font-size:24px;cursor:pointer;line-height:1">×</button>
+        <h3 id="contact-drawer-title" class="drawer-title">Contact</h3>
+        <button type="button" data-action="close-contacts-drawer" class="drawer-close" aria-label="Close">×</button>
       </header>
       <section class="drawer-body">
         <div class="kv"><span class="k">Type</span><span class="v" data-field="type"></span></div>

--- a/core/ui/shell.html
+++ b/core/ui/shell.html
@@ -63,8 +63,9 @@
       <li><a class="nav-link" href="#/inventory" data-role="nav-link" data-route="inventory">Inventory</a></li>
       <li><a class="nav-link" href="#/contacts" data-role="nav-link" data-route="contacts">Contacts</a></li>
       <li><a class="nav-link" href="#/recipes" data-role="nav-link" data-route="recipes">Recipes</a></li>
-      <li><a class="nav-link" href="#/finance" data-role="nav-link" data-route="finance">Finance</a></li>
       <li><a class="nav-link" href="#/jobs" data-role="nav-link" data-route="jobs">Jobs</a></li>
+      <li><a class="nav-link" href="#/invoices" data-role="nav-link" data-route="invoices">Invoices</a></li>
+      <li><a class="nav-link" href="#/finance" data-role="nav-link" data-route="finance">Finance</a></li>
 
       <li><div class="nav-section nav-section--system" role="heading" aria-level="2">System</div></li>
       <li><a class="nav-link" href="#/settings" id="nav-settings" data-role="nav-link" data-route="settings">Settings</a></li>
@@ -151,6 +152,10 @@
 
       <div data-role="jobs-screen" class="hidden">
         <div data-role="jobs-root"></div>
+      </div>
+
+      <div data-role="invoices-screen" class="hidden">
+        <div data-role="invoices-root"></div>
       </div>
 
       <div data-role="manufacturing-screen" class="hidden">

--- a/core/version.py
+++ b/core/version.py
@@ -23,7 +23,7 @@
 VERSION = "1.2.4"
 
 # Internal working revision. Agents may bump this on meaningful repo changes.
-INTERNAL_VERSION = "1.2.4.1"
+INTERNAL_VERSION = "1.2.4.3"
 
 __all__ = ["VERSION", "INTERNAL_VERSION"]
 

--- a/tests/api/test_invoices_api.py
+++ b/tests/api/test_invoices_api.py
@@ -179,3 +179,36 @@ def test_paid_invoice_cannot_be_financially_edited_and_void_invoice_cannot_be_pa
     pay_void = client.post(f"/app/invoices/{voidable['id']}/mark-paid", json={})
     assert pay_void.status_code == 400
     assert pay_void.json()["detail"] == "invoice_void_cannot_be_paid"
+
+
+def test_invoice_print_returns_html_and_escapes_unsafe_text(bus_client):
+    client = bus_client["client"]
+    contact_id = _create_contact(bus_client, name='<b>Danger Contact</b>')
+    invoice = _create_invoice(
+        client,
+        contact_id,
+        notes='<script>alert("x")</script>',
+        tax_rate_percent="13",
+    )
+    create_line = client.post(
+        f"/app/invoices/{invoice['id']}/lines",
+        json={
+            "line_type": "service",
+            "description": '<img src=x onerror=alert(1)>',
+            "quantity_decimal": "2",
+            "uom": "hr",
+            "unit_price_cents": 1500,
+            "taxable": True,
+        },
+    )
+    assert create_line.status_code == 200, create_line.text
+
+    response = client.get(f"/app/invoices/{invoice['id']}/print")
+    assert response.status_code == 200, response.text
+    assert response.headers["content-type"].startswith("text/html")
+    assert "INV-1001" in response.text
+    assert "$33.90" in response.text
+    assert "&lt;script&gt;alert(&quot;x&quot;)&lt;/script&gt;" in response.text
+    assert "&lt;img src=x onerror=alert(1)&gt;" in response.text
+    assert "<script>alert(\"x\")</script>" not in response.text
+    assert "<img src=x onerror=alert(1)>" not in response.text

--- a/tests/test_ui_router_security.py
+++ b/tests/test_ui_router_security.py
@@ -183,13 +183,30 @@ def test_jobs_phase2_ui_route_is_permissioned_and_mounted() -> None:
         "inventory",
         "contacts",
         "recipes",
-        "finance",
         "jobs",
+        "invoices",
+        "finance",
     ]
     assert 'data-role="jobs-screen"' in shell_html
     assert 'data-role="jobs-root"' in shell_html
     assert "export async function mountJobs()" in jobs_js
     assert "export function unmountJobs()" in jobs_js
+
+
+def test_invoices_phase1_ui_route_is_permissioned_and_mounted() -> None:
+    app_js = (REPO_ROOT / "core" / "ui" / "app.js").read_text(encoding="utf-8")
+    shell_html = (REPO_ROOT / "core" / "ui" / "shell.html").read_text(encoding="utf-8")
+    invoices_js = (REPO_ROOT / "core" / "ui" / "js" / "cards" / "invoices.js").read_text(encoding="utf-8")
+
+    assert 'import { mountInvoices, unmountInvoices } from "./js/cards/invoices.js";' in app_js
+    assert "'#/invoices': showInvoices" in app_js
+    assert "invoices: ['invoices.read']" in app_js
+    assert "async function showInvoices()" in app_js
+    assert 'href="#/invoices" data-role="nav-link" data-route="invoices"' in shell_html
+    assert 'data-role="invoices-screen"' in shell_html
+    assert 'data-role="invoices-root"' in shell_html
+    assert "export async function mountInvoices()" in invoices_js
+    assert "export function unmountInvoices()" in invoices_js
 
 
 def test_jobs_phase2_ui_uses_only_jobs_and_read_lookup_endpoints() -> None:
@@ -218,11 +235,42 @@ def test_jobs_phase2_ui_uses_only_jobs_and_read_lookup_endpoints() -> None:
     assert "apiPost(`/app/jobs/${job.id}/events`, { event_type: 'note', message: text })" in jobs_js
 
 
+def test_invoices_phase1_ui_uses_only_invoice_contact_and_job_endpoints() -> None:
+    invoices_js = (REPO_ROOT / "core" / "ui" / "js" / "cards" / "invoices.js").read_text(encoding="utf-8")
+
+    endpoints = sorted(set(re.findall(r"['`](/app/[^'`]+)", invoices_js)))
+    assert endpoints
+    allowed_prefixes = ("/app/invoices", "/app/contacts", "/app/jobs")
+    for endpoint in endpoints:
+        assert endpoint.startswith(allowed_prefixes), endpoint
+
+    forbidden_endpoint_terms = (
+        "/app/stock",
+        "/app/finance/export",
+        "/app/manufacturing",
+        "/app/purchase",
+        "/app/payments",
+        "/app/accounting",
+        "/app/portal",
+    )
+    for term in forbidden_endpoint_terms:
+        assert term not in invoices_js
+
+
+def test_invoices_phase1_ui_avoids_unsafe_dynamic_html_rendering() -> None:
+    invoices_js = (REPO_ROOT / "core" / "ui" / "js" / "cards" / "invoices.js").read_text(encoding="utf-8")
+
+    assert ".innerHTML" not in invoices_js
+    for forbidden in ("dangerouslySetInnerHTML", "insertAdjacentHTML"):
+        assert forbidden not in invoices_js
+
+
 def test_jobs_phase2_ui_preserves_backend_quantity_authority() -> None:
     jobs_js = (REPO_ROOT / "core" / "ui" / "js" / "cards" / "jobs.js").read_text(encoding="utf-8")
 
     assert "payload.quantity_decimal = quantity" in jobs_js
-    assert "payload.uom = String(data.get('uom') || '').trim();" in jobs_js
+    assert "const uom = normalizeJobUom(data.get('uom'));" in jobs_js
+    assert "payload.uom = uom;" in jobs_js
     assert "name: 'quantity_decimal'" in jobs_js
     assert "name: 'uom'" in jobs_js
     for forbidden in (


### PR DESCRIPTION
# BUS Core v1.3.0 Release Notes

Date: 2026-06-18
Tag: `v1.3.0`

## Summary

BUS Core 1.3.0 combines the local Invoice Truth MVP with selectable UI theme variants. This release keeps Core local-first: invoices, invoice lines, printable invoice HTML, and theme preference all stay inside the local app experience without adding cloud billing, payment processing, telemetry, CDN assets, or backend theme configuration.

## What's New

### Invoice Truth MVP

- Added Core-owned invoice tables and services for local invoice headers, lines, statuses, totals, and invoice numbers.
- Added canonical invoice API routes under `/app/invoices` for listing, creating drafts, editing draft headers and lines, issuing, marking paid, voiding, reading detail, and printing.
- Added a dedicated `#/invoices` UI with invoice list/detail editing, draft line controls, tax handling, totals, status badges, issue/paid/void actions, and print access.
- Added job-to-invoice flow so a job can create a local draft invoice and open it in the invoice editor.
- Added printable invoice HTML at `/app/invoices/{invoice_id}/print` for browser print or save-to-PDF workflows.
- Added invoice read/write permissions and route guard coverage for claimed mode.

### UI Theme Variants

- Added a UI-only theme manager using `localStorage["bus.ui.themeVariant"]`.
- Reused the existing Settings theme dropdown as the single selector.
- Added four visual variants:
  - BUS Core Default / Forge Dark
  - Clean Light
  - Workshop Slate
  - High Contrast
- Applied themes through `data-bus-theme` and CSS variables so visual authority stays in CSS.
- Preserved backward compatibility for legacy values: `dark`, `system`, `current`, and `default` map to Forge Dark; `light` maps to Clean Light.

### Release Hygiene

- Bumped public `VERSION` to `1.3.0`; `INTERNAL_VERSION` is `1.3.0.1` after the browser cache-busting release fix.
- Updated package metadata, Windows version metadata, SOT, API/UI contract docs, README, Home latest-update copy, changelog, and release notes.
- Removed accidentally tracked local GitHub CLI tooling from `.tools/` and ignored `.tools/` going forward.
- Added the Invoices sidebar icon mapping and icon asset.
- Added browser cache-busting for the native launcher, root/UI redirects, shell CSS/JS asset URLs, and `/ui/*` response headers so users do not need to manually hard reload after updating.

## Boundaries

- Invoice lines are billing records only and do not mutate inventory.
- Marking an invoice paid records one local invoice-linked sale `CashEvent`.
- This release does not add email sending, payment links, customer portals, accounting sync, recurring billing, reminders, or Pro automation.
- Theme state is browser presentation state only and is not backend config, auth, business, inventory, finance, or release-update authority.

## Upgrade Notes

- Release tag should be `v1.3.0` to match the strict SemVer authority in `core/version.py`.
- Startup schema materialization remains code-driven and additive; no separate migration runner is introduced.
- Existing local data remains in the operator's BUS Core AppData-backed SQLite database.

## Manual Test Checklist

- Start BUS Core and verify the Home card reports the 1.3.0 release update.
- Start BUS Core from the native launcher and confirm the opened URL includes `?v=buscore-1.3.0`.
- Reload `/ui/shell.html` normally and confirm the browser requests current `app.css?v=buscore-1.3.0` and `app.js?v=buscore-1.3.0`.
- Open Settings and confirm the existing theme dropdown contains Forge Dark, Clean Light, Workshop Slate, and High Contrast.
- Change the theme, reload the app, and confirm the selected theme persists.
- Open `#/invoices`, create a draft invoice, add/edit/delete a line, issue it, print it, mark it paid, and confirm void rules still behave as expected.
- From a job detail screen, create a draft invoice and verify it opens in the invoice editor.
- Confirm finance transaction visibility includes invoice-linked paid invoices.
- Confirm inventory quantities do not change when invoice lines are created or edited.
- Confirm claimed-mode users without invoice permission cannot use invoice read/write routes.

## Known Limitations

- Invoice print is browser-rendered HTML; Core still does not generate a server-side PDF.
- Invoice sending, online payments, customer portals, accounting sync, recurring billing, and reminders remain outside Core.
- Theme variants are a reversible UI spike and are intentionally local browser state.
